### PR TITLE
Fix a portability issue in svc_dg_recv().

### DIFF
--- a/src/pmap_clnt.c
+++ b/src/pmap_clnt.c
@@ -66,8 +66,13 @@ pmap_set(u_long program, u_long version, int protocol, int port)
     if (nconf == NULL) {
         return (FALSE);
     }
-    snprintf(buf, sizeof buf, "0.0.0.0.%d.%d",
+    if (strcmp(nconf->nc_protofmly, NC_INET) == 0) {
+       snprintf(buf, sizeof buf, "0.0.0.0.%d.%d",
+               (((u_int32_t)port) >> 8) & 0xff, port & 0xff);
+    } else if (strcmp(nconf->nc_protofmly, NC_INET6) == 0) {
+       snprintf(buf, sizeof buf, "::.%d.%d",
              (((u_int32_t)port) >> 8) & 0xff, port & 0xff);
+    }
     na = uaddr2taddr(nconf, buf);
     if (na == NULL) {
         freenetconfigent(nconf);

--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -245,14 +245,14 @@ again:
     mesgp->msg_iov = &iov;
     mesgp->msg_iovlen = 1;
     mesgp->msg_name = (struct sockaddr *)(void *) &ss;
-    sp->sa_family = 0xffff;
+    sp->sa_family = (sa_family_t)0xffff;
     mesgp->msg_namelen = sizeof (struct sockaddr_storage);
     mesgp->msg_control = su->su_cmsg;
     mesgp->msg_controllen = sizeof(su->su_cmsg);
 
     rlen = recvmsg(xprt->xp_fd, mesgp, 0);
 
-    if (sp->sa_family == 0xffff) {
+    if (sp->sa_family == (sa_family_t)0xffff) {
 	return FALSE;
     }
 


### PR DESCRIPTION
Size of 'sa_family_t' data type differs across platforms (2 bytes on Linux
x86_64 vs 1 byte on amd64 FreeBSD). Assigning a value to a variable of data type
sa_family_t thus requires an explicit cast to avoid the strict compile errors.

Signed-off-by: Sachin Bhamare sbhamare@panasas.com
