### PR TITLE
Re-organize CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,34 +1,178 @@
-# Ganesha CMake integration
+# New TI-RPC  Cmake
+
+# Current version as of Fedora 16.  Not tested with earlier.
+
+cmake_minimum_required(VERSION 2.6.3)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
+
+# Add maintainer mode for (mainly) strict builds
+
+include(${CMAKE_SOURCE_DIR}/cmake/maintainer_mode.cmake)
+
+project(NTIRPC C)
 
 # version numbers
 set(NTIRPC_MAJOR_VERSION 1)
 set(NTIRPC_MINOR_VERSION 3)
 set(NTIRPC_PATCHLEVEL 0)
-
+set(VERSION_COMMENT
+  "Full-duplex and bi-directional ONC RPC on TCP."
+)
 # version string used for packaging
 set(NTIRPC_VERSION
   "${NTIRPC_MAJOR_VERSION}.${NTIRPC_MINOR_VERSION}.${NTIRPC_PATCHLEVEL}")
 
-# subst files (need add_custom_command for dependency, fyi)
-configure_file(
-  "${PROJECT_SOURCE_DIR}/libntirpc/src/libntirpc.map.in.cmake"
-  "${PROJECT_BINARY_DIR}/libntirpc/src/libntirpc.map"
-)
+# Install destination, if built standalone
+if( CMAKE_SIZEOF_VOID_P EQUAL 8 )
+	set(LIB_INSTALL_DIR lib64 CACHE PATH
+		"Specify name of libdir inside install path")
+else( CMAKE_SIZEOF_VOID_P EQUAL 8 )
+	set(LIB_INSTALL_DIR lib CACHE PATH
+		"Specify name of libdir inside install path")
+endif( CMAKE_SIZEOF_VOID_P EQUAL 8 )
 
-if(TIRPC_EPOLL)
-  add_definitions(-DTIRPC_EPOLL)
-endif(TIRPC_EPOLL)
+include(GetGitRevisionDescription)
+get_git_head_revision(GIT_REFSPEC _GIT_HEAD_COMMIT)
+git_describe(_GIT_DESCRIBE)
 
-if(USE_NFS_RDMA)
-  add_definitions(-DUSE_RPC_RDMA)
-endif(USE_NFS_RDMA)
+# Build configure options
+
+option (USE_GSS "enable RPCSEC_GSS support" ON)
+
+option(TIRPC_EPOLL "platform supports EPOLL or emulation" ON)
+
+# MSPAC support -lwbclient link flag
+option(_MSPAC_SUPPORT "enable mspac Winbind support" OFF)
+
+# Choose a shortcut build config
+
+IF(BUILD_CONFIG)
+  INCLUDE(
+  ${CMAKE_SOURCE_DIR}/cmake/build_configurations/${BUILD_CONFIG}.cmake)
+ENDIF()
+
+# Build source locations and parameters
+
+set(ALLOCATOR "jemalloc" CACHE STRING
+  "specify the memory allocator to use: jemalloc|tcmalloc|libc")
+
+# Find packages and libs we need for building
+include(CheckIncludeFiles)
+include(TestBigEndian)
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  set(LINUX ON)
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  set(FREEBSD ON)
+endif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set(WINDOWS ON)
+  if(${CMAKE_CXX_COMPILER_ID} MATCHES "MSVC")
+    set(MSVC ON)
+  endif(${CMAKE_CXX_COMPILER_ID} MATCHES "MSVC")
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+
+check_include_files(stdbool.h HAVE_STDBOOL_H)
+check_include_files(strings.h HAVE_STRINGS_H)
+check_include_files(string.h HAVE_STRING_H)
+
+TEST_BIG_ENDIAN(BIGENDIAN)
+if(${BIGENDIAN})
+  set(WORDS_BIGENDIAN ON)
+else()
+  set(WORDS_BIGENDIAN OFF)
+endif(${BIGENDIAN})
+
+find_package(Threads REQUIRED)
+find_package(Krb5 REQUIRED gssapi)
+
+if(KRB5_FOUND)
+  set(HAVE_KRB5 ON)
+  set(KRB5_VERSION 194)  # hand code until we do krb5-config --version magic
+  set(_HAVE_GSSAPI ON)
+endif(KRB5_FOUND)
+
+set(SYSTEM_LIBRARIES ${SYSTEM_LIBRARIES})
+
+if(_MSPAC_SUPPORT)
+  find_package(WBclient REQUIRED)
+  set(SYSTEM_LIBRARIES ${WBclient_LIBRARIES} ${SYSTEM_LIBRARIES})
+endif(_MSPAC_SUPPORT)
+
+if (FREEBSD)
+   set(EXTRA_INCLUDE_DIR "/opt/ganesha/include")
+else()
+  # workaround bug in some include_directories when no extra includes
+  set(EXTRA_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/ntirpc/")
+endif(FREEBSD)
+
+add_definitions(-DHAVE_CONFIG_H)
+
+if (MSVC)
+   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif(MSVC)
 
 include_directories(
-  "${PROJECT_BINARY_DIR}/include"
-  "${PROJECT_SOURCE_DIR}/libntirpc/ntirpc/"
-  "${PROJECT_SOURCE_DIR}/include"
-  "${OS_INCLUDE_DIR}"
-  "${PROJECT_SOURCE_DIR}/libntirpc/src/"
+  "${PROJECT_BINARY_DIR}"
+  "${PROJECT_SOURCE_DIR}/ntirpc/"
+  "${EXTRA_INCLUDE_DIR}"
+)
+
+# Find misc system libs
+find_library(LIBRT rt)   # extended Pthreads functions
+find_library(LIBNSL nsl) # sockets
+
+set(SYSTEM_LIBRARIES
+  ${LIBTIRPC_LIBRARIES}
+  ${KRB5_LIBRARIES}
+  gssapi_krb5
+  ${SYSTEM_LIBRARIES}
+  ${LIBDL}
+  ${CMAKE_THREAD_LIBS_INIT}
+  ${LIBRT}
+)
+
+set(LIBNTIRPC_MAP "${PROJECT_BINARY_DIR}/src/libntirpc.map")
+# subst files (need add_custom_command for dependency, fyi)
+configure_file(
+  "${PROJECT_SOURCE_DIR}/src/libntirpc.map.in.cmake"
+  "${LIBNTIRPC_MAP}"
 )
 
 add_subdirectory(src)
+
+# display configuration vars
+
+message(STATUS)
+message(STATUS "-------------------------------------------------------")
+message(STATUS "TIRPC_EPOLL = ${TIRPC_EPOLL}")
+
+#force command line options to be stored in cache
+set(_MSPAC_SUPPORT ${_MSPAC_SUPPORT}
+  CACHE BOOL
+   "compile with MSPAC extensions"
+   FORCE)
+
+set(TIRPC_EPOLL ${TIRPC_EPOLL}
+  CACHE BOOL
+   "platform has EPOLL or emulation"
+   FORCE)
+
+# grist files
+configure_file(
+  "${PROJECT_SOURCE_DIR}/config-h.in.cmake"
+  "${PROJECT_BINARY_DIR}/config.h"
+)
+
+configure_file(
+  "${PROJECT_SOURCE_DIR}/libntirpc.pc.in.cmake"
+  "${PROJECT_BINARY_DIR}/libntirpc.pc"
+)
+
+########### install files ###############
+
+install(FILES  ${PROJECT_BINARY_DIR}/libntirpc.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)

--- a/ganesha/CMakeLists.txt
+++ b/ganesha/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Ganesha CMake integration
+
+# version numbers
+set(NTIRPC_MAJOR_VERSION 1)
+set(NTIRPC_MINOR_VERSION 3)
+set(NTIRPC_PATCHLEVEL 0)
+
+# version string used for packaging
+set(NTIRPC_VERSION
+  "${NTIRPC_MAJOR_VERSION}.${NTIRPC_MINOR_VERSION}.${NTIRPC_PATCHLEVEL}")
+
+# LIB_INSTALL_DIR set by Ganesha
+
+set(LIBNTIRPC_MAP "${PROJECT_BINARY_DIR}/libntirpc/src/libntirpc.map")
+# subst files (need add_custom_command for dependency, fyi)
+configure_file(
+  "${PROJECT_SOURCE_DIR}/libntirpc/src/libntirpc.map.in.cmake"
+  "${LIBNTIRPC_MAP}"
+)
+
+if(TIRPC_EPOLL)
+  add_definitions(-DTIRPC_EPOLL)
+endif(TIRPC_EPOLL)
+
+if(USE_NFS_RDMA)
+  add_definitions(-DUSE_RPC_RDMA)
+endif(USE_NFS_RDMA)
+
+include_directories(
+  "${PROJECT_BINARY_DIR}/include"
+  "${PROJECT_SOURCE_DIR}/libntirpc/ntirpc/"
+  "${PROJECT_SOURCE_DIR}/include"
+  "${OS_INCLUDE_DIR}"
+  "${PROJECT_SOURCE_DIR}/libntirpc/src/"
+)
+
+add_subdirectory(../src ${PROJECT_BINARY_DIR}/src/libntirpc/src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,14 +126,12 @@ target_link_libraries(ntirpc ${CMAKE_THREAD_LIBS_INIT})
 
 # set library version and symbol namespace(s) from gen'd map file
 set_target_properties(ntirpc PROPERTIES LINK_FLAGS
-  "-Wl,--version-script=${PROJECT_BINARY_DIR}/libntirpc/src/libntirpc.map"
+  "-Wl,--version-script=${LIBNTIRPC_MAP}"
+  VERSION ${NTIRPC_VERSION}
+  SOVERSION "${NTIRPC_MAJOR_VERSION}.${NTIRPC_MINOR_VERSION}"
   )
 
-if (NTIRPC_STANALONE)
-install(TARGETS ntirpc DESTINATION lib)
-else(NTIRPC_STANDALONE)
-install(TARGETS ntirpc DESTINATION ${FSAL_DESTINATION})
-endif(NTIRPC_STANDALONE)
+install(TARGETS ntirpc DESTINATION ${LIB_INSTALL_DIR})
 
 ########### install files ###############
 


### PR DESCRIPTION
Previously, the CMake build system was primarily used for building
within the Ganesha source tree.  Re-organize the system to allow proper
standalone building out-of-the-box, and still build properly within
Ganesha.

This includes installing the library as a full versioned library.

Signed-off-by: Daniel Gryniewicz dang@redhat.com
