### PR TITLE
Include cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ if (MSVC)
    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif(MSVC)
 
-include_directories(
+include_directories(BEFORE
   "${PROJECT_BINARY_DIR}"
   "${NTIRPC_BASE_DIR}/ntirpc/"
   "${EXTRA_INCLUDE_DIR}"

--- a/ntirpc/rpc/gss_internal.h
+++ b/ntirpc/rpc/gss_internal.h
@@ -26,7 +26,6 @@
 #ifndef GSS_INTERNAL_H
 #define GSS_INTERNAL_H
 
-#include <config.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>


### PR DESCRIPTION
- Don't include config.h in a header; it will break things building
  against ntirpc
- Prepend our include paths, so that no system includes can override
  ours.

Signed-off-by: Daniel Gryniewicz dang@redhat.com
