### PR TITLE
Use CMake's internal concept of target dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,13 +24,14 @@ set(NTIRPC_VERSION
   "${NTIRPC_MAJOR_VERSION}.${NTIRPC_MINOR_VERSION}.${NTIRPC_PATCH_LEVEL}")
 
 # Install destination, if built standalone
-if( CMAKE_SIZEOF_VOID_P EQUAL 8 )
+get_property(USE_LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
+if (USE_LIB64)
 	set(LIB_INSTALL_DIR lib64 CACHE PATH
 		"Specify name of libdir inside install path")
-else( CMAKE_SIZEOF_VOID_P EQUAL 8 )
+else (USE_LIB64)
 	set(LIB_INSTALL_DIR lib CACHE PATH
 		"Specify name of libdir inside install path")
-endif( CMAKE_SIZEOF_VOID_P EQUAL 8 )
+endif (USE_LIB64)
 
 set(SYSTEM_LIBRARIES ${SYSTEM_LIBRARIES})
 


### PR DESCRIPTION
It turns out that ubuntu has some 64 bit systems with lib and lib64, and
some with lib and lib32.  This breaks with our current bitness checking.
CMake, howeevr, has a global property that knows this.  Attempt to use
this property.  This should have no effect on systems that use lib and
lib64.

Signed-off-by: Daniel Gryniewicz dang@redhat.com
