### PR TITLE
xdr_inline invalid memory access:

### DIFF
--- a/ntirpc/rpc/xdr_inline.h
+++ b/ntirpc/rpc/xdr_inline.h
@@ -571,7 +571,7 @@ inline_xdr_bytes(XDR *xdrs, char **cpp, u_int *sizep,
 
 	case XDR_FREE:
 		if (sp != NULL) {
-			mem_free(sp, nodesize);
+			mem_free(sp, -1);
 			*cpp = NULL;
 		}
 		return (true);
@@ -661,7 +661,7 @@ inline_xdr_string(XDR *xdrs, char **cpp, u_int maxsize)
 	case XDR_FREE:
 		if (sp == NULL)
 			return (true);	/* already free */
-		/* FALLTHROUGH */
+		break;
 	case XDR_ENCODE:
 		if (sp == NULL)
 			return false;
@@ -672,7 +672,7 @@ inline_xdr_string(XDR *xdrs, char **cpp, u_int maxsize)
 	}
 	if (!inline_xdr_u_int(xdrs, &size))
 		return (false);
-	if (size > maxsize)
+	if (size > maxsize && xdrs->x_op != XDR_FREE)
 		return (false);
 	nodesize = size + 1;
 	if (nodesize == 0) {
@@ -698,7 +698,7 @@ inline_xdr_string(XDR *xdrs, char **cpp, u_int maxsize)
 		return (inline_xdr_putopaque(xdrs, sp, size));
 
 	case XDR_FREE:
-		mem_free(sp, nodesize);
+		mem_free(sp, -1);
 		*cpp = NULL;
 		return (true);
 	}


### PR DESCRIPTION
- inline_xdr_string tries to compute strlen on strings that are not
  necessarily valid, for a value we do not need
- mem_free does not use its second argument, which already was invalid
  in inline_xdr_bytes and now is in inline_xdr_free. mem_free has a comment
  cautioning about using second argument where it is defined, hopefully -1
  should be easier to spot than some uninitialized variable if someone ever
  tries to change it.

Signed-off-by: Dominique Martinet dominique.martinet@cea.fr
