### PR TITLE
fix new gcc warnings: defined but not used static consts

### DIFF
--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -571,7 +571,6 @@ svc_dg_ops(SVCXPRT *xprt)
  * Note: there is no disable.
  */
 static const char cache_enable_str[] = "svc_enablecache: %s %s";
-static const char alloc_err[] = "could not allocate cache ";
 static const char enable_err[] = "cache already enabled";
 
 int
@@ -609,8 +608,6 @@ svc_dg_enablecache(SVCXPRT *transp, u_int size)
 
 static const char cache_set_str[] = "cache_set: %s";
 static const char cache_set_err1[] = "victim not found";
-static const char cache_set_err2[] = "victim alloc failed";
-static const char cache_set_err3[] = "could not allocate new rpc buffer";
 
 static void
 svc_dg_cache_set(SVCXPRT *xprt, size_t replylen)

--- a/src/svc_simple.c
+++ b/src/svc_simple.c
@@ -75,7 +75,6 @@ static const char rpc_reg_msg[] = "rpc_reg: ";
 static const char __reg_err1[] = "can't find appropriate transport";
 static const char __reg_err2[] = "can't get protocol info";
 static const char __reg_err3[] = "unsupported transport size";
-static const char __no_mem_str[] = "out of memory";
 
 /*
  * For simplified, easy to use kind of rpc interfaces.


### PR DESCRIPTION
New gcc seems to whine about these:
src/libntirpc/src/svc_dg.c:612:19: error: ‘cache_set_err2’ defined but not used [-Werror=unused-const-variable=]
 static const char cache_set_err2[] = "victim alloc failed";
                   ^~~~~~~~~~~~~~
