### PR TITLE
[valgrind] mem-leak: free struct attribute memory before parent struc…

### DIFF
--- a/src/rpc_dplx.c
+++ b/src/rpc_dplx.c
@@ -349,6 +349,10 @@ rpc_dplx_unref(struct rpc_dplx_rec *rec, u_int flags)
 
 	if (rec->refcnt == 0) {
 		t = rbtx_partition_of_scalar(&rpc_dplx_rec_set.xt, rec->fd_k);
+		if (rec->hdl.xd) {
+			rec->hdl.xd->refcnt--;
+			rec->hdl.xd->rec = NULL;
+		}
 		REC_UNLOCK(rec);
 		rwlock_wrlock(&t->lock);
 		nv = opr_rbtree_lookup(&t->t, &rec->node_k);


### PR DESCRIPTION
…t is free'd.

Within function clnt_vc_ncreate2() memory might be allocated which is not free'd
in case of an error.
==24543== 262,144 bytes in 1 blocks are indirectly lost in loss record 368 of 382
==24543==    at 0x4C28BF6: malloc (vg_replace_malloc.c:299)
==24543==    by 0x6AAF772: xdr_inrec_create (xdr_inrec.c:175)
==24543==    by 0x6AA9035: makefd_xprt (svc_vc.c:426)
==24543==    by 0x6AA933F: rendezvous_request (svc_vc.c:549)
==24543==    by 0x44B2E3: thr_decode_rpc_request (nfs_rpc_dispatcher_thread.c:1791)
==24543==    by 0x44B825: thr_decode_rpc_requests (nfs_rpc_dispatcher_thread.c:1915)
==24543==    by 0x51AF9F: fridgethr_start_routine (fridgethr.c:561)
==24543==    by 0x6660619: start_thread (in /usr/lib64/libpthread-2.22.so)
==24543==    by 0x6FE659C: clone (in /usr/lib64/libc-2.22.so)
==24543==
==24543== 262,144 bytes in 1 blocks are indirectly lost in loss record 369 of 382
==24543==    at 0x4C28BF6: malloc (vg_replace_malloc.c:299)
==24543==    by 0x6AADDE3: xdrrec_create (xdr_rec.c:186)
==24543==    by 0x6AA9073: makefd_xprt (svc_vc.c:430)
==24543==    by 0x6AA933F: rendezvous_request (svc_vc.c:549)
==24543==    by 0x44B2E3: thr_decode_rpc_request (nfs_rpc_dispatcher_thread.c:1791)
==24543==    by 0x44B825: thr_decode_rpc_requests (nfs_rpc_dispatcher_thread.c:1915)
==24543==    by 0x51AF9F: fridgethr_start_routine (fridgethr.c:561)
==24543==    by 0x6660619: start_thread (in /usr/lib64/libpthread-2.22.so)
==24543==    by 0x6FE659C: clone (in /usr/lib64/libc-2.22.so)
==24543==
==24543== 262,144 bytes in 1 blocks are indirectly lost in loss record 370 of 382
==24543==    at 0x4C28BF6: malloc (vg_replace_malloc.c:299)
==24543==    by 0x6AADE5A: xdrrec_create (xdr_rec.c:194)
==24543==    by 0x6AA9073: makefd_xprt (svc_vc.c:430)
==24543==    by 0x6AA933F: rendezvous_request (svc_vc.c:549)
==24543==    by 0x44B2E3: thr_decode_rpc_request (nfs_rpc_dispatcher_thread.c:1791)
==24543==    by 0x44B825: thr_decode_rpc_requests (nfs_rpc_dispatcher_thread.c:1915)
==24543==    by 0x51AF9F: fridgethr_start_routine (fridgethr.c:561)
==24543==    by 0x6660619: start_thread (in /usr/lib64/libpthread-2.22.so)
==24543==    by 0x6FE659C: clone (in /usr/lib64/libc-2.22.so)
==24543==
==24543== 788,057 (96 direct, 787,961 indirect) bytes in 1 blocks are definitely lost in loss record 373 of 382
==24543==    at 0x4C28BF6: malloc (vg_replace_malloc.c:299)
==24543==    by 0x6A90015: clnt_vc_ncreate2 (clnt_vc.c:243)
==24543==    by 0x6AAAA13: clnt_vc_ncreate_svc (svc_vc.c:1278)
==24543==    by 0x436522: nfs_rpc_create_chan_v41 (nfs_rpc_callback.c:644)
==24543==    by 0x4647A9: nfs4_op_create_session (nfs4_op_create_session.c:498)
==24543==    by 0x45FA28: nfs4_Compound (nfs4_Compound.c:710)
==24543==    by 0x4448B1: nfs_rpc_execute (nfs_worker_thread.c:1288)
==24543==    by 0x4451EF: worker_run (nfs_worker_thread.c:1548)
==24543==    by 0x51AF9F: fridgethr_start_routine (fridgethr.c:561)
==24543==    by 0x6660619: start_thread (in /usr/lib64/libpthread-2.22.so)
==24543==    by 0x6FE659C: clone (in /usr/lib64/libc-2.22.so)

Signed-off-by: Swen Schillig swen@vnet.ibm.com
