### PR TITLE
[valgrind] memory referenced by child attributes not free'd

### DIFF
--- a/src/clnt_vc.c
+++ b/src/clnt_vc.c
@@ -312,7 +312,7 @@ clnt_vc_ncreate2(int fd,	/* open file descriptor */
 		if (ct->ct_addr.len)
 			mem_free(ct->ct_addr.buf, ct->ct_addr.len);
 
-		if (xd->refcnt == 1) {
+		if (xd->refcnt == 0) {
 			XDR_DESTROY(&xd->shared.xdrs_in);
 			XDR_DESTROY(&xd->shared.xdrs_out);
 			free_x_vc_data(xd);

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -658,10 +658,13 @@ svc_rdvs_destroy(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 	mem_free(rdvs, sizeof(struct cf_rendezvous));
 	mem_free(xprt, sizeof(SVCXPRT));
 
-	refcnt = rpc_dplx_unref(rec,
-				RPC_DPLX_FLAG_LOCKED | RPC_DPLX_FLAG_UNLOCK);
-	if (!refcnt)
-		mem_free(xd, sizeof(struct x_vc_data));
+	(void)rpc_dplx_unref(rec, RPC_DPLX_FLAG_LOCKED | RPC_DPLX_FLAG_UNLOCK);
+
+	if (xd->refcnt == 0) {
+		XDR_DESTROY(&xd->shared.xdrs_in);
+		XDR_DESTROY(&xd->shared.xdrs_out);
+		free_x_vc_data(xd);
+	}
 }
 
 static void


### PR DESCRIPTION
==29057== 262,144 bytes in 1 blocks are indirectly lost in loss record 405 of 420
==29057==    at 0x4C28BF6: malloc (vg_replace_malloc.c:299)
==29057==    by 0x44B5C5: gsh_malloc__ (abstract_mem.h:78)
==29057==    by 0x6AB00F1: xdr_inrec_create (xdr_inrec.c:166)
==29057==    by 0x6AA9963: makefd_xprt (svc_vc.c:425)
==29057==    by 0x6AA9C5B: rendezvous_request (svc_vc.c:545)
==29057==    by 0x45103B: thr_decode_rpc_request (nfs_rpc_dispatcher_thread.c:1864)
==29057==    by 0x45184D: thr_decode_rpc_requests (nfs_rpc_dispatcher_thread.c:2045)
==29057==    by 0x4FD6B7: fridgethr_start_routine (fridgethr.c:550)
==29057==    by 0x6660619: start_thread (in /usr/lib64/libpthread-2.22.so)
==29057==    by 0x6FE859C: clone (in /usr/lib64/libc-2.22.so)
==29057==
==29057== 262,144 bytes in 1 blocks are indirectly lost in loss record 406 of 420
==29057==    at 0x4C28BF6: malloc (vg_replace_malloc.c:299)
==29057==    by 0x44B5C5: gsh_malloc__ (abstract_mem.h:78)
==29057==    by 0x6AAE7A0: xdrrec_create (xdr_rec.c:177)
==29057==    by 0x6AA99A1: makefd_xprt (svc_vc.c:429)
==29057==    by 0x6AA9C5B: rendezvous_request (svc_vc.c:545)
==29057==    by 0x45103B: thr_decode_rpc_request (nfs_rpc_dispatcher_thread.c:1864)
==29057==    by 0x45184D: thr_decode_rpc_requests (nfs_rpc_dispatcher_thread.c:2045)
==29057==    by 0x4FD6B7: fridgethr_start_routine (fridgethr.c:550)
==29057==    by 0x6660619: start_thread (in /usr/lib64/libpthread-2.22.so)
==29057==    by 0x6FE859C: clone (in /usr/lib64/libc-2.22.so)
==29057==
==29057== 262,144 bytes in 1 blocks are indirectly lost in loss record 407 of 420
==29057==    at 0x4C28BF6: malloc (vg_replace_malloc.c:299)
==29057==    by 0x44B5C5: gsh_malloc__ (abstract_mem.h:78)
==29057==    by 0x6AAE7E5: xdrrec_create (xdr_rec.c:179)
==29057==    by 0x6AA99A1: makefd_xprt (svc_vc.c:429)
==29057==    by 0x6AA9C5B: rendezvous_request (svc_vc.c:545)
==29057==    by 0x45103B: thr_decode_rpc_request (nfs_rpc_dispatcher_thread.c:1864)
==29057==    by 0x45184D: thr_decode_rpc_requests (nfs_rpc_dispatcher_thread.c:2045)
==29057==    by 0x4FD6B7: fridgethr_start_routine (fridgethr.c:550)
==29057==    by 0x6660619: start_thread (in /usr/lib64/libpthread-2.22.so)
==29057==    by 0x6FE859C: clone (in /usr/lib64/libc-2.22.so)
==29057==
==29057== 787,949 (32 direct, 787,917 indirect) bytes in 1 blocks are definitely lost in loss record 410 of 420
==29057==    at 0x4C28BF6: malloc (vg_replace_malloc.c:299)
==29057==    by 0x44B5C5: gsh_malloc__ (abstract_mem.h:78)
==29057==    by 0x44BDA5: alloc_gsh_xprt_private (gsh_rpc.h:163)
==29057==    by 0x44EAE8: nfs_rpc_recv_user_data (nfs_rpc_dispatcher_thread.c:1141)
==29057==    by 0x6AA9E5C: rendezvous_request (svc_vc.c:605)
==29057==    by 0x45103B: thr_decode_rpc_request (nfs_rpc_dispatcher_thread.c:1864)
==29057==    by 0x45184D: thr_decode_rpc_requests (nfs_rpc_dispatcher_thread.c:2045)
==29057==    by 0x4FD6B7: fridgethr_start_routine (fridgethr.c:550)
==29057==    by 0x6660619: start_thread (in /usr/lib64/libpthread-2.22.so)
==29057==    by 0x6FE859C: clone (in /usr/lib64/libc-2.22.so)

Signed-off-by: Swen Schillig swen@vnet.ibm.com
