### PR TITLE
Remove old sleep triggering Coverity errors

### DIFF
--- a/src/getnetconfig.c
+++ b/src/getnetconfig.c
@@ -411,18 +411,6 @@ getnetconfigent(const char *netid)
 	if (netid == NULL || strlen(netid) == 0)
 		return (NULL);
 
-	if (strcmp(netid, "unix") == 0) {
-		fprintf(stderr, "The local transport is called \"unix\" ");
-		fprintf(stderr, "in /etc/netconfig.\n");
-		fprintf(stderr, "Please change this to \"local\" manually ");
-		fprintf(stderr, "or run mergemaster(8).\n");
-		fprintf(stderr, "See UPDATING entry 20021216 for details.\n");
-		fprintf(stderr, "Continuing in 10 seconds\n\n");
-		fprintf(stderr, "This warning will be removed 20030301\n");
-		sleep(10);
-
-	}
-
 	/*
 	 * Look up table if the entries have already been read and parsed in
 	 * getnetconfig(), then copy this entry into a buffer and return it.


### PR DESCRIPTION
Coverity started complaining about sleeps while holding locks.  The
sleep in question was a very old configuration change warning.  Remove
it, to make coverity happy.

Fixes: 152547-152566

Signed-off-by: Daniel Gryniewicz dang@redhat.com
