### PR TITLE
[rpc_dplx.c] initialize rpc_dplx_rec on creation.

### DIFF
--- a/src/rpc_dplx.c
+++ b/src/rpc_dplx.c
@@ -201,10 +201,8 @@ rpc_dplx_init()
 static inline struct rpc_dplx_rec *
 alloc_dplx_rec(void)
 {
-	struct rpc_dplx_rec *rec = mem_alloc(sizeof(struct rpc_dplx_rec));
+	struct rpc_dplx_rec *rec = mem_zalloc(sizeof(struct rpc_dplx_rec));
 
-	rec->refcnt = 0;
-	rec->hdl.xprt = NULL;
 	mutex_init(&rec->locktrace.mtx, NULL);
 	/* send channel */
 	rpc_dplx_lock_init(&rec->send.lock);


### PR DESCRIPTION
Memory allocated for a newly created rpc_dplx_rec must
be fully initialized.
Otherwise a succeeding attribute check, e.g. rec->hdl.xd,
might result in a false true situation.

Signed-off-by: Swen Schillig swen@vnet.ibm.com
