### PR TITLE
[authgss_hash.c] authgss_hash_init is not initialising parameter

### DIFF
--- a/ntirpc/rpc/gss_internal.h
+++ b/ntirpc/rpc/gss_internal.h
@@ -139,7 +139,6 @@ unref_svc_rpc_gss_data(struct svc_rpc_gss_data *gd,
 		mutex_unlock(&gd->lock);
 }
 
-void authgss_hash_init();
 struct svc_rpc_gss_data *authgss_ctx_hash_get(struct rpc_gss_cred *gc);
 bool authgss_ctx_hash_set(struct svc_rpc_gss_data *gd);
 bool authgss_ctx_hash_del(struct svc_rpc_gss_data *gd);

--- a/src/authgss_hash.c
+++ b/src/authgss_hash.c
@@ -91,16 +91,12 @@ svc_rpc_gss_cmpf(const struct opr_rbtree_node *lhs,
 	return (1);
 }
 
-void
+static void
 authgss_hash_init()
 {
 	int ix, code = 0;
 
 	mutex_lock(&authgss_hash_st.lock);
-
-	/* once */
-	if (authgss_hash_st.initialized)
-		goto unlock;
 
 	code =
 	    rbtx_init(&authgss_hash_st.xt, svc_rpc_gss_cmpf,
@@ -119,7 +115,7 @@ authgss_hash_init()
 			       sizeof(struct opr_rbtree_node *));
 
 		/* partition ctx LRU */
-		axp = (struct authgss_x_part *)mem_alloc(sizeof(*axp));
+		axp = (struct authgss_x_part *)mem_zalloc(sizeof(*axp));
 		TAILQ_INIT(&axp->lru_q);
 		xp->u1 = axp;
 	}
@@ -129,7 +125,6 @@ authgss_hash_init()
 	    __svc_params->gss.max_ctx / authgss_hash_st.xt.npart;
 	authgss_hash_st.initialized = true;
 
- unlock:
 	mutex_unlock(&authgss_hash_st.lock);
 }
 


### PR DESCRIPTION
This issue was found by Ashish Kr Srivastava and is documented at
http://permalink.gmane.org/gmane.comp.file-systems.nfs.ganesha.devel/2000

> > > > > Error Logs in nfsganesha at server side when issue is seen -

02/05/2016 10:52:01 : epoch 5726ef84 : DSA_LDAP :
ganesha.nfsd-4131[decoder] AuthenticateRequest :DISP :INFO :Could not
authenticate request... rejecting with AUTH_STAT=AUTH_REJECTEDCRED
02/05/2016 10:54:01 : epoch 5726ef84 : DSA_LDAP :
ganesha.nfsd-4131[decoder] AuthenticateRequest :DISP :INFO :Could not
authenticate request... rejecting with AUTH_STAT=AUTH_REJECTEDCRED

We debug and found that in libntirpc file authgss_hash.c function
authgss_hash_init, the axp->gen was never initialize & used directly and
due to that reason some garbage value is assigned and its behavior is
unexpected and the above logs comes multiple times. After fix the issue is
not seen.
<<<<

Signed-off-by: Swen Schillig swen@vnet.ibm.com
