### PR TITLE
Use partition size for deleting GSS contexts

### DIFF
--- a/src/authgss_hash.c
+++ b/src/authgss_hash.c
@@ -187,7 +187,7 @@ authgss_ctx_hash_set(struct svc_rpc_gss_data *gd)
 	gss_ctx = (gss_union_ctx_id_desc *) (gd->ctx);
 	gd->hk.k = gss_ctx_hash(gss_ctx);
 
-	++(gd->refcnt);		/* locked */
+	(void)atomic_inc_uint32_t(&gd->refcnt);
 	t = rbtx_partition_of_scalar(&authgss_hash_st.xt, gd->hk.k);
 	mutex_lock(&t->mtx);
 	rslt =

--- a/src/svc_auth_gss.c
+++ b/src/svc_auth_gss.c
@@ -612,7 +612,7 @@ _svcauth_gss(struct svc_req *req, struct rpc_msg *msg,
 
 		*no_dispatch = true;
 
-		(void)authgss_ctx_hash_del(gd);	/* unrefs, can destroy gd */
+		(void)authgss_ctx_hash_del(gd);
 
 		/* avoid lock order reversal gd->lock, xprt->xp_lock */
 		mutex_unlock(&gd->lock);
@@ -622,6 +622,11 @@ _svcauth_gss(struct svc_req *req, struct rpc_msg *msg,
 		    svc_sendreply(req->rq_xprt, req, (xdrproc_t) xdr_void,
 				  (caddr_t) NULL);
 
+		/* We acquired a reference on gd with authgss_ctx_hash_get
+		 * call.  Time to release the reference as we don't need
+		 * gd anymore.
+		 */
+		unref_svc_rpc_gss_data(gd, SVC_RPC_GSS_FLAG_NONE);
 		req->rq_auth = &svc_auth_none;
 
 		break;


### PR DESCRIPTION
Currently we don't have a count of GSS contexts in a cache partition,
and mistakenly use global cache size for deleting GSS contexts from a
partition. This patch adds number of GSS contexts in a cache partition
and uses it while deleting GSS contexts.

Signed-off-by: Malahal Naineni malahal@us.ibm.com
