### PR TITLE
[gss_internal.h] fix refcounting and locking for unref_svc_rpc_gss_data

### DIFF
--- a/ntirpc/rpc/gss_internal.h
+++ b/ntirpc/rpc/gss_internal.h
@@ -67,7 +67,6 @@ typedef gss_union_ctx_id_desc *gss_union_ctx_id_t;
 
 #define SVC_RPC_GSS_FLAG_NONE    0x0000
 #define SVC_RPC_GSS_FLAG_MSPAC   0x0001
-#define SVC_RPC_GSS_FLAG_LOCKED  0x0002
 
 struct svc_rpc_gss_data {
 	struct opr_rbtree_node node_k;
@@ -113,30 +112,17 @@ svc_rpc_gss_data *alloc_svc_rpc_gss_data(void)
 }
 
 static inline void
-unref_svc_rpc_gss_data(struct svc_rpc_gss_data *gd,
-		       uint32_t flags)
+unref_svc_rpc_gss_data(struct svc_rpc_gss_data *gd)
 {
-	u_int refcnt;
-	bool gd_locked = flags & SVC_RPC_GSS_FLAG_LOCKED;
-
-	refcnt = atomic_dec_uint32_t(&gd->refcnt);
+	mutex_lock(&gd->lock);
 
 	/* if refcnt is 0, gd is not reachable */
-	if (unlikely(refcnt == 0)) {
-		if (!gd_locked) {
-			mutex_lock(&gd->lock);
-			gd_locked = true;
-			if (likely(refcnt == 0)) {
-				mutex_unlock(&gd->lock);
-				/* XXX disposes gd */
-				svcauth_gss_destroy(gd->auth);
-				return;
-			}
-		}
+	if (unlikely(atomic_dec_uint32_t(&gd->refcnt) == 0)) {
+		svcauth_gss_destroy(gd->auth);
+		return;
 	}
 
-	if (gd_locked)
-		mutex_unlock(&gd->lock);
+	mutex_unlock(&gd->lock);
 }
 
 void authgss_hash_init();

--- a/src/authgss_hash.c
+++ b/src/authgss_hash.c
@@ -225,7 +225,7 @@ authgss_ctx_hash_del(struct svc_rpc_gss_data *gd)
 	(void)atomic_dec_uint32_t(&authgss_hash_st.size);
 
 	/* release gd */
-	unref_svc_rpc_gss_data(gd, SVC_RPC_GSS_FLAG_NONE);
+	unref_svc_rpc_gss_data(gd);
 
 	return (true);
 }
@@ -280,7 +280,7 @@ void authgss_ctx_gc_idle(void)
 			(void)atomic_dec_uint32_t(&authgss_hash_st.size);
 
 			/* drop sentinel ref (may free gd) */
-			unref_svc_rpc_gss_data(gd, SVC_RPC_GSS_FLAG_NONE);
+			unref_svc_rpc_gss_data(gd);
 
 			if (++cnt < __svc_params->gss.max_gc)
 				goto again;

--- a/src/svc_auth_gss.c
+++ b/src/svc_auth_gss.c
@@ -626,7 +626,7 @@ _svcauth_gss(struct svc_req *req, struct rpc_msg *msg,
 		 * call.  Time to release the reference as we don't need
 		 * gd anymore.
 		 */
-		unref_svc_rpc_gss_data(gd, SVC_RPC_GSS_FLAG_NONE);
+		unref_svc_rpc_gss_data(gd);
 		req->rq_auth = &svc_auth_none;
 
 		break;
@@ -647,7 +647,7 @@ svcauth_gss_release(SVCAUTH *auth, struct svc_req *req)
 
 	gd = SVCAUTH_PRIVATE(auth);
 	if (gd)
-		unref_svc_rpc_gss_data(gd, SVC_RPC_GSS_FLAG_NONE);
+		unref_svc_rpc_gss_data(gd);
 	req->rq_auth = NULL;
 
 	if ((last_oa_base = req->rq_verf.oa_base)) {
@@ -678,6 +678,8 @@ svcauth_gss_destroy(SVCAUTH *auth)
 		gss_release_buffer(&min_stat, &gd->pac.ms_pac);
 
 	gss_release_buffer(&min_stat, &gd->checksum);
+
+	mutex_unlock(&gd->lock);
 	mutex_destroy(&gd->lock);
 
 	mem_free(gd, sizeof(*gd));


### PR DESCRIPTION
we must fetch the lock before modifying the structure svc_rpc_gss_data
and we must keep the lock if we are about to call svcauth_gss_destroy
once the refcount hits the zero value.

Signed-off-by: Swen Schillig swen@vnet.ibm.com
