### PR TITLE
[authgss_hash.c] check whether authgss_hash was initialised under lock.

### DIFF
--- a/src/authgss_hash.c
+++ b/src/authgss_hash.c
@@ -99,6 +99,9 @@ authgss_hash_init()
 
 	mutex_lock(&authgss_hash_st.lock);
 
+	if (authgss_hash_st.initialized)
+		goto unlock;
+
 	code =
 	    rbtx_init(&authgss_hash_st.xt, svc_rpc_gss_cmpf,
 		      __svc_params->gss.ctx_hash_partitions,
@@ -126,15 +129,17 @@ authgss_hash_init()
 	    __svc_params->gss.max_ctx / authgss_hash_st.xt.npart;
 	authgss_hash_st.initialized = true;
 
+unlock:
 	mutex_unlock(&authgss_hash_st.lock);
 }
 
 #define cond_init_authgss_hash() { \
-		do { \
-			if (!authgss_hash_st.initialized) \
-				authgss_hash_init(); \
-		} while (0); \
-	}
+	do { \
+		if (!authgss_hash_st.initialized) \
+			authgss_hash_init(); \
+	} while (0); \
+}
+
 
 struct svc_rpc_gss_data *
 authgss_ctx_hash_get(struct rpc_gss_cred *gc)


### PR DESCRIPTION
The authgss_hash should only be initialised once.
This check must be performed while locked to prevent
a double init race condition.

Signed-off-by: Swen Schillig swen@vnet.ibm.com
