### PR TITLE
Add a PARENT_SCOPE version for embedding in Ganesha

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ set(VERSION_COMMENT
 # version string used for packaging
 set(NTIRPC_VERSION
   "${NTIRPC_MAJOR_VERSION}.${NTIRPC_MINOR_VERSION}.${NTIRPC_PATCH_LEVEL}")
+# Up scope for embedding in ganesha
+set(NTIRPC_VERSION_EMBED "${NTIRPC_VERSION}" PARENT_SCOPE)
 
 # Install destination, if built standalone
 get_property(USE_LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)


### PR DESCRIPTION
The Gansha RPM builds need to know the exact name of the library.  Add
NTIRPC_VERSION_EMBED that is put in parent scope, so that Ganesha can
use it in it's spec file to install the correct version of ntirpc.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>