### PR TITLE
Consolidate rpc_ctx definitions in rpc_ctx files

### DIFF
--- a/src/clnt_internal.h
+++ b/src/clnt_internal.h
@@ -43,10 +43,10 @@ struct ct_wait_entry
 	cond_t  cv;
 };
 
-#include <misc/rbtree_x.h>
 #include <rpc/work_pool.h>
 #include <rpc/xdr_ioq.h>
-#include <misc/wait_queue.h>
+
+#include "rpc_ctx.h"
 
 typedef struct rpc_dplx_lock {
 	struct wait_entry we;
@@ -58,34 +58,6 @@ typedef struct rpc_dplx_lock {
 } rpc_dplx_lock_t;
 
 #define MCALL_MSG_SIZE 24
-
-#define CT_NONE                 0x0000
-#define CT_EVENTS_BLOCKED       0x0002
-#define CT_EPOLL_ACTIVE         0x0004
-#define CT_XPRT_DESTROYED       0x0008
-
-/*
- * A client call context.  Intended to enable efficient multiplexing of
- * client calls sharing a client channel.
- */
-typedef struct rpc_call_ctx {
-	struct opr_rbtree_node node_k;
-	struct wait_entry we;
-	uint32_t xid;
-	uint32_t flags;
-	struct rpc_err error;
-	union {
-		struct {
-			struct rpc_client *clnt;
-			struct x_vc_data *xd;
-			struct timespec timeout;
-		} clnt;
-		struct {
-			/* nothing */
-		} svc;
-	} ctx_u;
-	struct rpc_msg cc_msg;
-} rpc_ctx_t;
 
 static inline int call_xid_cmpf(const struct opr_rbtree_node *lhs,
 				const struct opr_rbtree_node *rhs)

--- a/src/rpc_ctx.c
+++ b/src/rpc_ctx.c
@@ -47,6 +47,15 @@
 
 #define tv_to_ms(tv) (1000 * ((tv)->tv_sec) + (tv)->tv_usec/1000)
 
+void
+rpc_msg_init(struct rpc_msg *msg)
+{
+	/* required for REPLY decodes */
+	msg->RPCM_ack.ar_verf = _null_auth;
+	msg->RPCM_ack.ar_results.where = NULL;
+	msg->RPCM_ack.ar_results.proc = (xdrproc_t) xdr_void;
+}
+
 rpc_ctx_t *
 alloc_rpc_call_ctx(CLIENT *clnt, rpcproc_t proc, xdrproc_t xdr_args,
 		   void *args_ptr, xdrproc_t xdr_results,
@@ -56,7 +65,9 @@ alloc_rpc_call_ctx(CLIENT *clnt, rpcproc_t proc, xdrproc_t xdr_args,
 	struct rpc_dplx_rec *rec = xd->rec;
 	rpc_ctx_t *ctx = mem_alloc(sizeof(rpc_ctx_t));
 
-	/* potects this */
+	rpc_msg_init(&ctx->cc_msg);
+
+	/* protects this */
 	mutex_init(&ctx->we.mtx, NULL);
 	cond_init(&ctx->we.cv, 0, NULL);
 

--- a/src/svc.c
+++ b/src/svc.c
@@ -230,15 +230,6 @@ svc_init(svc_init_params *params)
 	return true;
 }
 
-void
-rpc_msg_init(struct rpc_msg *msg)
-{
-	/* required for REPLY decodes */
-	msg->RPCM_ack.ar_verf = _null_auth;
-	msg->RPCM_ack.ar_results.where = NULL;
-	msg->RPCM_ack.ar_results.proc = (xdrproc_t) xdr_void;
-}
-
 /* ***************  SVCXPRT related stuff **************** */
 
 /*

--- a/src/svc_internal.h
+++ b/src/svc_internal.h
@@ -204,7 +204,6 @@ epoll_create_wr(size_t size, int flags)
 extern void __rpc_set_blkin_endpoint(SVCXPRT *xprt, const char *tag);
 #endif
 
-void rpc_msg_init(struct rpc_msg *msg);
 void svc_rqst_shutdown(void);
 
 #endif				/* TIRPC_SVC_INTERNAL_H */


### PR DESCRIPTION
Initialize empty rpc_msg in rpc_ctx tree (bugfix).

Move rpc_msg_init() into rpc_ctx.c (where it is now used) instead of svc.c
(where it was not used).  Likewise, move its header into rpc_ctx.h.

Move rpc_ctx_t to rpc_ctx.h (where it is used).

Remove 4 unused obsolete defined flags.

Signed-off-by: William Allen Simpson <william.allen.simpson@redhat.com>