### PR TITLE
[gss_internal.h] fix refcounting and locking for unref_svc_rpc_gss_data

### DIFF
--- a/src/authgss_hash.c
+++ b/src/authgss_hash.c
@@ -234,7 +234,7 @@ authgss_ctx_hash_del(struct svc_rpc_gss_data *gd)
 	(void)atomic_dec_uint32_t(&authgss_hash_st.size);
 
 	/* release gd */
-	unref_svc_rpc_gss_data(gd, SVC_RPC_GSS_FLAG_NONE);
+	unref_svc_rpc_gss_data(gd);
 
 	return (true);
 }
@@ -290,7 +290,7 @@ void authgss_ctx_gc_idle(void)
 			(void)atomic_dec_uint32_t(&authgss_hash_st.size);
 
 			/* drop sentinel ref (may free gd) */
-			unref_svc_rpc_gss_data(gd, SVC_RPC_GSS_FLAG_NONE);
+			unref_svc_rpc_gss_data(gd);
 
 			if (++cnt < __svc_params->gss.max_gc)
 				goto again;

--- a/src/svc_auth_gss.c
+++ b/src/svc_auth_gss.c
@@ -633,7 +633,7 @@ _svcauth_gss(struct svc_req *req, bool *no_dispatch)
 		 * call.  Time to release the reference as we don't need
 		 * gd anymore.
 		 */
-		unref_svc_rpc_gss_data(gd, SVC_RPC_GSS_FLAG_NONE);
+		unref_svc_rpc_gss_data(gd);
 		req->rq_auth = &svc_auth_none;
 
 		break;
@@ -653,7 +653,7 @@ svcauth_gss_release(SVCAUTH *auth, struct svc_req *req)
 
 	gd = SVCAUTH_PRIVATE(auth);
 	if (gd)
-		unref_svc_rpc_gss_data(gd, SVC_RPC_GSS_FLAG_NONE);
+		unref_svc_rpc_gss_data(gd);
 	req->rq_auth = NULL;
 	return (true);
 }
@@ -676,6 +676,8 @@ svcauth_gss_destroy(SVCAUTH *auth)
 		gss_release_buffer(&min_stat, &gd->pac.ms_pac);
 
 	gss_release_buffer(&min_stat, &gd->checksum);
+
+	mutex_unlock(&gd->lock);
 	mutex_destroy(&gd->lock);
 
 	mem_free(gd, sizeof(*gd));


### PR DESCRIPTION
we must fetch the lock before modifying the structure svc_rpc_gss_data
and we must keep the lock if we are about to call svcauth_gss_destroy
once the refcount hits the zero value.

Signed-off-by: Swen Schillig <swen@vnet.ibm.com>