### PR TITLE
Make city.h includes consistent

### DIFF
--- a/ntirpc/misc/citycrc.h
+++ b/ntirpc/misc/citycrc.h
@@ -34,7 +34,7 @@
 #ifndef CITY_HASH_CRC_H_
 #define CITY_HASH_CRC_H_
 
-#include "city.h"
+#include <misc/city.h>
 
 /* Hash function for a byte array. */
 uint128 CityHashCrc128(const char *s, size_t len);

--- a/src/city-test.c
+++ b/src/city-test.c
@@ -27,7 +27,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "city.h"
+#include <misc/city.h>
 #ifdef __SSE4_2__
 #include "citycrc.h"
 #endif

--- a/src/citycrc.h
+++ b/src/citycrc.h
@@ -33,7 +33,7 @@
 #ifndef CITY_HASH_CRC_H_
 #define CITY_HASH_CRC_H_
 
-#include "city.h"
+#include <misc/city.h>
 
 /* Hash function for a byte array. */
 uint128 CityHashCrc128(const char *s, size_t len);


### PR DESCRIPTION
Most of the code base already uses <misc/city.h>.  Modify the places
that include "city.h" to follow that pattern.  cmake doesn't add misc to
the include paths passed to the compiler.  I ran into "can't find
city.h" errors when attempting to add an ebuild for gentoo.

Change-Id: I1e07d82bbe58fbae4759263734ac22170220eeb7
Signed-off-by: Dylan Reid <dgreid@chromium.org>