### PR TITLE
XDR and netbuf:  fix decoder overruns from guidovranken

### DIFF
--- a/src/rpc_generic.c
+++ b/src/rpc_generic.c
@@ -759,6 +759,8 @@ __rpc_taddr2uaddr_af(int af, const struct netbuf *nbuf)
 
 	switch (af) {
 	case AF_INET:
+		if (nbuf->len < sizeof(*sin))
+			return NULL;
 		sin = nbuf->buf;
 		if (inet_ntop(af, &sin->sin_addr, namebuf, sizeof(namebuf))
 		    == NULL)
@@ -773,6 +775,8 @@ __rpc_taddr2uaddr_af(int af, const struct netbuf *nbuf)
 		break;
 #ifdef INET6
 	case AF_INET6:
+		if (nbuf->len < sizeof(*sin6))
+			return NULL;
 		sin6 = nbuf->buf;
 		if (inet_ntop(af, &sin6->sin6_addr, namebuf6, sizeof(namebuf6))
 		    == NULL) {
@@ -839,6 +843,8 @@ __rpc_uaddr2taddr_af(int af, const char *uaddr)
 
 	port = 0;
 	sin = NULL;
+	if (uaddr == NULL)
+		return NULL;
 	addrstr = mem_strdup(uaddr);
 
 	/*

--- a/src/rpcb_st_xdr.c
+++ b/src/rpcb_st_xdr.c
@@ -39,6 +39,8 @@
 #include <sys/cdefs.h>
 
 #include <rpc/rpc.h>
+#include <rpc/xdr.h>
+#include <rpc/xdr_inline.h>
 
 /* Link list of all the stats about getport and getaddr */
 
@@ -53,7 +55,7 @@ xdr_rpcbs_addrlist(XDR *xdrs, rpcbs_addrlist *objp)
 		return (false);
 	if (!xdr_int(xdrs, &objp->failure))
 		return (false);
-	if (!xdr_string(xdrs, &objp->netid, (u_int) ~0))
+	if (!xdr_string(xdrs, &objp->netid, RPC_MAXDATASIZE))
 		return (false);
 	if (!xdr_pointer
 	    (xdrs, (char **)&objp->next, sizeof(rpcbs_addrlist),
@@ -93,7 +95,7 @@ xdr_rpcbs_rmtcalllist(XDR *xdrs, rpcbs_rmtcalllist *objp)
 			IXDR_PUT_INT32(buf, objp->failure);
 			IXDR_PUT_INT32(buf, objp->indirect);
 		}
-		if (!xdr_string(xdrs, &objp->netid, (u_int) ~0))
+		if (!xdr_string(xdrs, &objp->netid, RPC_MAXDATASIZE))
 			return (false);
 		if (!xdr_pointer
 		    (xdrs, (char **)&objp->next, sizeof(rpcbs_rmtcalllist),
@@ -123,7 +125,7 @@ xdr_rpcbs_rmtcalllist(XDR *xdrs, rpcbs_rmtcalllist *objp)
 			objp->failure = (int)IXDR_GET_INT32(buf);
 			objp->indirect = (int)IXDR_GET_INT32(buf);
 		}
-		if (!xdr_string(xdrs, &objp->netid, (u_int) ~0))
+		if (!xdr_string(xdrs, &objp->netid, RPC_MAXDATASIZE))
 			return (false);
 		if (!xdr_pointer
 		    (xdrs, (char **)&objp->next, sizeof(rpcbs_rmtcalllist),
@@ -143,7 +145,7 @@ xdr_rpcbs_rmtcalllist(XDR *xdrs, rpcbs_rmtcalllist *objp)
 		return (false);
 	if (!xdr_int(xdrs, &objp->indirect))
 		return (false);
-	if (!xdr_string(xdrs, &objp->netid, (u_int) ~0))
+	if (!xdr_string(xdrs, &objp->netid, RPC_MAXDATASIZE))
 		return (false);
 	if (!xdr_pointer
 	    (xdrs, (char **)&objp->next, sizeof(rpcbs_rmtcalllist),


### PR DESCRIPTION
Fixes issues reported in RPCB and generic XDR routines.  In ntirpc,
xdr_inline.h updated along with xdr.c

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>