### PR TITLE
Release lock after netconfig buffer is duplicated

### DIFF
--- a/src/getnetconfig.c
+++ b/src/getnetconfig.c
@@ -425,8 +425,9 @@ getnetconfigent(const char *netid)
 	if (ni.head != NULL) {
 		for (list = ni.head; list; list = list->next) {
 			if (strcmp(list->ncp->nc_netid, netid) == 0) {
+				ncp = dup_ncp(list->ncp);
 				mutex_unlock(&nc_mtx);
-				return (dup_ncp(list->ncp));
+				return ncp;
 			}
 		}
 		if (ni.eof == 1) {	/* that's all the entries */


### PR DESCRIPTION
Currently the getnetconfigent() releases the lock "nc_mtx"
before it duplicates the netconfig buffer using "dup_ncp". Due to
this "dup_ncp" can lead to a crash if the netconfig buffer has
been freed.
Fixed this by by duplicating the netconfig buffer before releasing
the lock "nc_mtx".

Signed-off-by: Madhu Thorat <madhu.punjabi@in.ibm.com>