### PR TITLE
Require EPOLL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,6 @@ set(NTIRPC_BASE_DIR ${PROJECT_SOURCE_DIR} CACHE
 
 option (USE_GSS "enable RPCSEC_GSS support" ON)
 
-option(TIRPC_EPOLL "platform supports EPOLL or emulation" ON)
-
 option(USE_RPC_RDMA "platform supports RDMA" OFF)
 if (USE_RPC_RDMA)
   find_package(RDMA REQUIRED)
@@ -112,6 +110,8 @@ endif(${BIGENDIAN})
 
 find_package(Threads REQUIRED)
 find_package(Krb5 REQUIRED gssapi)
+find_package(EPOLL REQUIRED)
+set(TIRPC_EPOLL ${EPOLL_FOUND})
 
 if(KRB5_FOUND)
   set(HAVE_KRB5 ON)

--- a/cmake/modules/FindEPOLL.cmake
+++ b/cmake/modules/FindEPOLL.cmake
@@ -1,0 +1,22 @@
+# - Find EPOLL
+#
+# This module defines the following variables:
+#    EPOLL_FOUND       = Was EPOLL found or not?
+#
+# On can set EPOLL_PATH_HINT before using find_package(EPOLL) and the
+# module with use the PATH as a hint to find EPOLL.
+#
+# The hint can be given on the command line too:
+#   cmake -DEPOLL_PATH_HINT=/DATA/ERIC/EPOLL /path/to/source
+
+include(CheckIncludeFiles)
+include(CheckFunctionExists)
+
+check_include_files("sys/epoll.h" EPOLL_HEADER)
+check_function_exists(epoll_create EPOLL_FUNC)
+
+# handle the QUIETLY and REQUIRED arguments and set PRELUDE_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(EPOLL REQUIRED_VARS EPOLL_HEADER EPOLL_FUNC)
+


### PR DESCRIPTION
At this time, EPOLL is the only method we have of getting data, so
require it.  If other methods are added later, this can be made
optional.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>