### PR TITLE
Ensure thread per request

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -136,7 +136,7 @@ typedef struct svc_init_params {
 #define SVC_XPRT_FLAG_NONE		0x0000
 /* uint16_t actually used */
 #define SVC_XPRT_FLAG_ADDED		0x0001
-#define SVC_XPRT_FLAG_BLOCKED		0x0002
+
 #define SVC_XPRT_FLAG_INITIAL		0x0004
 #define SVC_XPRT_FLAG_INITIALIZED	0x0008
 #define SVC_XPRT_FLAG_CLOSE		0x0010

--- a/ntirpc/rpc/svc_rqst.h
+++ b/ntirpc/rpc/svc_rqst.h
@@ -75,7 +75,7 @@ int svc_rqst_foreach_xprt(uint32_t chan_id, svc_rqst_xprt_each_func_t each_f,
 
 #define SVC_RQST_STATE_NONE           0x00000
 #define SVC_RQST_STATE_ACTIVE         0x00001	/* thrd in event loop */
-#define SVC_RQST_STATE_BLOCKED        0x00002	/* channel blocked */
+
 #define SVC_RQST_STATE_DESTROYED      0x00004
 
 #define SVC_RQST_SIGNAL_SHUTDOWN      0x00008	/* chan shutdown */

--- a/src/rpc_ctx.c
+++ b/src/rpc_ctx.c
@@ -107,7 +107,7 @@ rpc_ctx_alloc(CLIENT *clnt, struct timeval timeout)
 	return (ctx);
 }
 
-/* RPC_DPLX_FLAG_LOCKED
+/* unlocked
  */
 enum xprt_stat
 rpc_ctx_xfer_replymsg(struct svc_req *req)
@@ -118,10 +118,12 @@ rpc_ctx_xfer_replymsg(struct svc_req *req)
 	rpc_ctx_t ctx_k, *ctx;
 	struct opr_rbtree_node *nv;
 
+	rpc_dplx_rli(rec);
 	ctx_k.xid = req->rq_msg.rm_xid;
 	nv = opr_rbtree_lookup(&rec->call_replies, &ctx_k.node_k);
 	if (!nv) {
 		/* release internal locks */
+		rpc_dplx_rui(rec);
 		return SVC_STAT(xprt);
 	}
 
@@ -165,6 +167,7 @@ rpc_ctx_xfer_replymsg(struct svc_req *req)
 		__func__, xprt, xprt->xp_fd, ctx->xid);
 
 	/* release internal locks */
+	rpc_dplx_rui(rec);
 	return SVC_STAT(xprt);
 }
 

--- a/src/rpc_dplx_internal.h
+++ b/src/rpc_dplx_internal.h
@@ -196,17 +196,4 @@ rpc_dplx_rsi(struct rpc_dplx_rec *rec)
 	cond_signal(&lk->we.cv);
 }
 
-static inline void
-rpc_dplx_ioq_submit(struct rpc_dplx_rec *rec, struct work_pool_thread *wpt)
-{
-	if (wpt == rec->ioq.ioq_wpe.wpt && rec->ev_count > 1) {
-		/* Unlikely spawn prior to lengthy queueing or system call;
-		 * xprt should pass through this test one-at-a-time
-		 * preceded by prior locking/unlocking barrier.
-		 */
-		rec->ioq.ioq_wpe.wpt = NULL;
-		work_pool_submit(&svc_work_pool, &rec->ioq.ioq_wpe);
-	}
-}
-
 #endif				/* RPC_DPLX_INTERNAL_H */

--- a/src/svc_ioq.c
+++ b/src/svc_ioq.c
@@ -213,11 +213,6 @@ svc_ioq_write(SVCXPRT *xprt, struct xdr_ioq *xioq, struct poolq_head *ifph)
 		if (svc_work_pool.params.thrd_max
 		 && !(xprt->xp_flags & SVC_XPRT_FLAG_DESTROYED)) {
 			/* all systems are go! */
-			if (xioq->ioq_wpe.wpt) {
-				/* Spawn worker for more events */
-				rpc_dplx_ioq_submit(REC_XPRT(xprt),
-						    xioq->ioq_wpe.wpt);
-			}
 			svc_ioq_flushv(xprt, xioq);
 		}
 		SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
@@ -256,14 +251,6 @@ svc_ioq_write_now(SVCXPRT *xprt, struct xdr_ioq *xioq)
 	mutex_lock(&ifph->qmutex);
 
 	if ((ifph->qcount)++ > 0) {
-		if (!xioq->ioq_wpe.wpt) {
-			/* Temporarily remember any existing task for queue */
-			xioq->ioq_wpe.wpt = REC_XPRT(xprt)->ioq.ioq_wpe.wpt;
-		} else {
-			/* Spawn worker for more events */
-			rpc_dplx_ioq_submit(REC_XPRT(xprt), xioq->ioq_wpe.wpt);
-		}
-
 		/* queue additional output requests without task switch */
 		TAILQ_INSERT_TAIL(&ifph->qh, &(xioq->ioq_s), q);
 		mutex_unlock(&ifph->qmutex);
@@ -293,14 +280,6 @@ svc_ioq_write_submit(SVCXPRT *xprt, struct xdr_ioq *xioq)
 	mutex_lock(&ifph->qmutex);
 
 	if ((ifph->qcount)++ > 0) {
-		if (!xioq->ioq_wpe.wpt) {
-			/* Temporarily remember any existing task for queue */
-			xioq->ioq_wpe.wpt = REC_XPRT(xprt)->ioq.ioq_wpe.wpt;
-		} else {
-			/* Spawn worker for more events */
-			rpc_dplx_ioq_submit(REC_XPRT(xprt), xioq->ioq_wpe.wpt);
-		}
-
 		/* queue additional output requests, they will be handled by
 		 * existing thread without another task switch.
 		 */

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -402,8 +402,7 @@ svc_rqst_rearm_events(SVCXPRT *xprt)
 	if (sr_rec->states & SVC_RQST_STATE_DESTROYED)
 		return (0);
 
-	if (!(xprt->xp_flags & SVC_XPRT_FLAG_BLOCKED))
-		rpc_dplx_rli(rec);
+	rpc_dplx_rli(rec);
 
 	/* assuming success */
 	atomic_set_uint16_t_bits(&xprt->xp_flags, SVC_XPRT_FLAG_ADDED);
@@ -449,8 +448,7 @@ svc_rqst_rearm_events(SVCXPRT *xprt)
 		break;
 	}			/* switch */
 
-	if (!(xprt->xp_flags & SVC_XPRT_FLAG_BLOCKED))
-		rpc_dplx_rui(rec);
+	rpc_dplx_rui(rec);
 
 	return (code);
 }

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -461,8 +461,12 @@ svc_vc_rendezvous(SVCXPRT *xprt)
 		}
 		return (XPRT_DIED);
 	}
-	if (svc_rqst_rearm_events(xprt))
+	if (unlikely(svc_rqst_rearm_events(xprt))) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			"%s: %p fd %d svc_rqst_rearm_events failed (will set dead)",
+			__func__, xprt, xprt->xp_fd);
 		return (XPRT_DIED);
+	}
 
 	(void) setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &n, sizeof(n));
 
@@ -650,9 +654,12 @@ svc_vc_recv(SVCXPRT *xprt)
 	u_int flags;
 	int code;
 
-	/* See also svc_clnt (rpc_ctx via svc_vc_decode) and svc_vc_recv_task */
-	rpc_dplx_rli(rec);
-	atomic_set_uint16_t_bits(&xprt->xp_flags, SVC_XPRT_FLAG_BLOCKED);
+	/* no need for locking, only one svc_rqst_xprt_task() per event.
+	 * depends upon svc_rqst_rearm_events() for ordering.
+	 */
+	if (xprt->xp_flags & SVC_XPRT_FLAG_DESTROYED) {
+		return (XPRT_DESTROYED);
+	}
 
 	(void)clock_gettime(CLOCK_MONOTONIC_FAST, &xd->sx_recv);
 
@@ -731,14 +738,6 @@ svc_vc_recv(SVCXPRT *xprt)
 		return SVC_STAT(xprt);
 	}
 
-	if (unlikely(svc_rqst_rearm_events(xprt))) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
-			"%s: %p fd %d svc_rqst_rearm_events failed (will set dead)",
-			__func__, xprt, xprt->xp_fd);
-		SVC_DESTROY(xprt);
-		return SVC_STAT(xprt);
-	}
-
 	__warnx(TIRPC_DEBUG_FLAG_SVC_VC,
 		"%s: %p fd %d recv %zd of %" PRIu32,
 		__func__, xprt, xprt->xp_fd, rlen, xd->sx_fbtbc);
@@ -747,6 +746,12 @@ svc_vc_recv(SVCXPRT *xprt)
 	xd->sx_fbtbc -= rlen;
 
 	if (xd->sx_fbtbc || (flags & UIO_FLAG_MORE)) {
+		if (unlikely(svc_rqst_rearm_events(xprt))) {
+			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				"%s: %p fd %d svc_rqst_rearm_events failed (will set dead)",
+				__func__, xprt, xprt->xp_fd);
+			SVC_DESTROY(xprt);
+		}
 		return SVC_STAT(xprt);
 	}
 
@@ -754,6 +759,16 @@ svc_vc_recv(SVCXPRT *xprt)
 	(rec->ioq.ioq_uv.uvqh.qcount)--;
 	TAILQ_REMOVE(&rec->ioq.ioq_uv.uvqh.qh, &xioq->ioq_s, q);
 	xdr_ioq_reset(xioq, 0);
+
+	if (unlikely(svc_rqst_rearm_events(xprt))) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			"%s: %p fd %d svc_rqst_rearm_events failed (will set dead)",
+			__func__, xprt, xprt->xp_fd);
+		xdr_ioq_destroy(xioq, xioq->ioq_s.qsize);
+		SVC_DESTROY(xprt);
+		return SVC_STAT(xprt);
+	}
+
 	return (__svc_params->request_cb(xprt, xioq->xdrs));
 }
 
@@ -762,7 +777,6 @@ svc_vc_decode(struct svc_req *req)
 {
 	XDR *xdrs = req->rq_xdrs;
 	SVCXPRT *xprt = req->rq_xprt;
-	enum xprt_stat result;
 
 	/* No need, already positioned to beginning ...
 	XDR_SETPOS(xdrs, 0);
@@ -779,25 +793,24 @@ svc_vc_decode(struct svc_req *req)
 		return SVC_STAT(xprt);
 	}
 
-	switch (req->rq_msg.rm_direction) {
-	case CALL:
+	/* in order of likelihood */
+	if (req->rq_msg.rm_direction == CALL) {
 		/* an ordinary call header */
-		result = xprt->xp_dispatch.process_cb(req);
-		break;
-	case REPLY:
-		/* reply header (xprt OK) */
-		result = rpc_ctx_xfer_replymsg(req);
-		break;
-	default:
-		__warnx(TIRPC_DEBUG_FLAG_WARN,
-			"%s: %p fd %d failed direction %" PRIu32
-			" (will set dead)",
-			__func__, xprt, xprt->xp_fd,
-			req->rq_msg.rm_direction);
-		SVC_DESTROY(xprt);
-		return SVC_STAT(xprt);
+		return xprt->xp_dispatch.process_cb(req);
 	}
-	return (result);
+
+	if (req->rq_msg.rm_direction == REPLY) {
+		/* reply header (xprt OK) */
+		return rpc_ctx_xfer_replymsg(req);
+	}
+
+	__warnx(TIRPC_DEBUG_FLAG_WARN,
+		"%s: %p fd %d failed direction %" PRIu32
+		" (will set dead)",
+		__func__, xprt, xprt->xp_fd,
+		req->rq_msg.rm_direction);
+	SVC_DESTROY(xprt);
+	return SVC_STAT(xprt);
 }
 
 static void

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -629,13 +629,6 @@ svc_vc_rendezvous_control(SVCXPRT *xprt, const u_int rq, void *in)
 static enum xprt_stat
 svc_vc_stat(SVCXPRT *xprt)
 {
-	uint16_t xp_flags = atomic_postclear_uint16_t_bits(&xprt->xp_flags,
-							SVC_XPRT_FLAG_BLOCKED);
-
-	if (xp_flags & SVC_XPRT_FLAG_BLOCKED) {
-		rpc_dplx_rui(REC_XPRT(xprt));
-		rpc_dplx_rsi(REC_XPRT(xprt));
-	}
 	if (xprt->xp_flags & SVC_XPRT_FLAG_DESTROYED)
 		return (XPRT_DESTROYED);
 
@@ -830,15 +823,7 @@ static enum xprt_stat
 svc_vc_reply(struct svc_req *req)
 {
 	SVCXPRT *xprt = req->rq_xprt;
-	struct rpc_dplx_rec *rec = REC_XPRT(xprt);
 	struct xdr_ioq *xioq;
-	uint16_t xp_flags = atomic_postclear_uint16_t_bits(&xprt->xp_flags,
-							SVC_XPRT_FLAG_BLOCKED);
-
-	if (xp_flags & SVC_XPRT_FLAG_BLOCKED) {
-		rpc_dplx_rui(rec);
-		rpc_dplx_rsi(rec);
-	}
 
 	/* XXX Until gss_get_mic and gss_wrap can be replaced with
 	 * iov equivalents, replies with RPCSEC_GSS security must be

--- a/src/svc_xprt.c
+++ b/src/svc_xprt.c
@@ -203,9 +203,8 @@ svc_xprt_lookup(int fd, svc_xprt_setup_t setup)
  * Clear an xprt
  *
  * @note Locking
- * - xprt is locked, unless SVC_XPRT_FLAG_BLOCKED
- * - xprt is unlocked, unless SVC_XPRT_FLAG_BLOCKED
- *   otherwise it is returned locked
+ * - xprt is locked
+ *   returned unlocked
  */
 void
 svc_xprt_clear(SVCXPRT *xprt)
@@ -215,8 +214,7 @@ svc_xprt_clear(SVCXPRT *xprt)
 	if (svc_xprt_init_failure())
 		return;
 
-	if (!(xprt->xp_flags & SVC_XPRT_FLAG_BLOCKED))
-		rpc_dplx_rli(REC_XPRT(xprt));
+	rpc_dplx_rli(REC_XPRT(xprt));
 
 	if (opr_rbtree_node_valid(&REC_XPRT(xprt)->fd_node)) {
 		t = rbtx_partition_of_scalar(&svc_xprt_fd.xt, xprt->xp_fd);
@@ -226,8 +224,7 @@ svc_xprt_clear(SVCXPRT *xprt)
 		rwlock_unlock(&t->lock);
 	}
 
-	if (!(xprt->xp_flags & SVC_XPRT_FLAG_BLOCKED))
-		rpc_dplx_rui(REC_XPRT(xprt));
+	rpc_dplx_rui(REC_XPRT(xprt));
 }
 
 int


### PR DESCRIPTION
Partial revert "(svc_ioq) track threads"
 * reverts commit 9fed5b913cab146b45104fc9b27539d2f6f478f1.

(svc_dg)
 * rearm after recvmsg() for longer back-to-back event window.

(svc_rqst)
 * rework task loop for multiple concurrent tasks on same transport.
 * SVC_REF tasks instead of events.

(svc_vc)
 * delay SVC_RECV() locking until near callback.
 * convert SVC_DECODE() switch to ordered test series.

Signed-off-by: William Allen Simpson <william.allen.simpson@redhat.com>