### PR TITLE
Protect against multiple CPack inclusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ configure_file(
   "${PROJECT_SOURCE_DIR}/libntirpc.spec"
 )
 
+if (NOT TARGET dist)
 # Define CPACK component (to deal with sub packages)
 set(CPACK_COMPONENTS_ALL daemon fsal headers )
 set(CPACK_COMPONENT_DAEMON_DISPLAY_NAME "libntirpc")
@@ -218,7 +219,6 @@ include(${CMAKE_SOURCE_DIR}/cmake/cpack_config.cmake)
 include(CPack)
 
 set( PKG_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}.tar.gz")
-if (NOT TARGET dist)
 	add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
 endif (NOT TARGET dist)
 


### PR DESCRIPTION
Since both ntirpc and ganesha use CPack to generate tarballs, this means
that, when Ganesha is using ntirpc as a submodule, it multiply includes
CPack.  This breaks CPack config.

Protect against this by only including CPack if the dist target doesn't
already exist.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>