### PR TITLE
(svc_rqst) faster shutdown

### DIFF
--- a/ntirpc/rpc/svc_rqst.h
+++ b/ntirpc/rpc/svc_rqst.h
@@ -73,11 +73,6 @@ typedef void (*svc_rqst_xprt_each_func_t) (uint32_t chan_id, SVCXPRT *xprt,
 int svc_rqst_foreach_xprt(uint32_t chan_id, svc_rqst_xprt_each_func_t each_f,
 			  void *arg);
 
-#define SVC_RQST_STATE_NONE           0x00000
-#define SVC_RQST_STATE_ACTIVE         0x00001	/* thrd in event loop */
-
-#define SVC_RQST_STATE_DESTROYED      0x00004
-
 #define SVC_RQST_SIGNAL_SHUTDOWN      0x00008	/* chan shutdown */
 #define SVC_RQST_SIGNAL_MASK (SVC_RQST_SIGNAL_SHUTDOWN)
 


### PR DESCRIPTION
Remove states flags; use only signals flags.

Bugfix: ensure enough workers for channels.
Bugfix: signal channel shutdown even with no registered transports.
Bugfix: shutdown all channels again, even though listener shutdown
        may already have been done by application.

Signed-off-by: William Allen Simpson <william.allen.simpson@redhat.com>