### PR TITLE
(svc_rqst) remove mutex

### DIFF
--- a/ntirpc/rpc/svc_rqst.h
+++ b/ntirpc/rpc/svc_rqst.h
@@ -50,6 +50,7 @@
 
 #define SVC_RQST_FLAG_NONE		SVC_XPRT_FLAG_NONE
 /* uint16_t actually used */
+#define SVC_RQST_FLAG_SHUTDOWN		SVC_XPRT_FLAG_DESTROYING
 #define SVC_RQST_FLAG_XPRT_UREG		SVC_XPRT_FLAG_UREG
 #define SVC_RQST_FLAG_CHAN_AFFINITY	0x1000 /* bind conn to parent chan */
 #define SVC_RQST_FLAG_MASK (SVC_RQST_FLAG_CHAN_AFFINITY)
@@ -73,7 +74,5 @@ typedef void (*svc_rqst_xprt_each_func_t) (uint32_t chan_id, SVCXPRT *xprt,
 int svc_rqst_foreach_xprt(uint32_t chan_id, svc_rqst_xprt_each_func_t each_f,
 			  void *arg);
 
-#define SVC_RQST_SIGNAL_SHUTDOWN      0x00008	/* chan shutdown */
-#define SVC_RQST_SIGNAL_MASK (SVC_RQST_SIGNAL_SHUTDOWN)
 
 #endif				/* TIRPC_SVC_RQST_H */

--- a/src/clnt_dg.c
+++ b/src/clnt_dg.c
@@ -315,6 +315,7 @@ clnt_dg_call(CLIENT *clnt,	/* client handle */
 	if (!rec->ev_p) {
 		xprt->xp_dispatch.rendezvous_cb = clnt_dg_rendezvous;
 		svc_rqst_evchan_reg(__svc_params->ev_u.evchan.id, xprt,
+				    SVC_RQST_FLAG_LOCKED |
 				    SVC_RQST_FLAG_CHAN_AFFINITY);
 	}
 	reply_msg.RPCM_ack.ar_verf = _null_auth;

--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -205,16 +205,17 @@ svc_dg_ncreatef(const int fd, const u_int sendsz, const u_int recvsz,
 	/* Enable reception of IP*_PKTINFO control msgs */
 	svc_dg_enable_pktinfo(fd, &si);
 
-	/* release */
-	rpc_dplx_rui(rec);
-	XPRT_TRACE(xprt, __func__, __func__, __LINE__);
-
 	/* Conditional register */
 	if ((!(__svc_params->flags & SVC_FLAG_NOREG_XPRTS)
 	     && !(flags & SVC_CREATE_FLAG_XPRT_NOREG))
 	    || (flags & SVC_CREATE_FLAG_XPRT_DOREG))
 		svc_rqst_evchan_reg(__svc_params->ev_u.evchan.id, xprt,
+				    SVC_RQST_FLAG_LOCKED |
 				    SVC_RQST_FLAG_CHAN_AFFINITY);
+
+	/* release */
+	rpc_dplx_rui(rec);
+	XPRT_TRACE(xprt, __func__, __func__, __LINE__);
 
 #if defined(HAVE_BLKIN)
 	__rpc_set_blkin_endpoint(xprt, "svc_dg");

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -253,16 +253,17 @@ svc_vc_ncreatef(const int fd, const u_int sendsz, const u_int recvsz,
 
 	xprt->xp_netid = mem_strdup(netid);
 
-	/* release rec */
-	rpc_dplx_rui(rec);
-	XPRT_TRACE(xprt, __func__, __func__, __LINE__);
-
 	/* Conditional register */
 	if ((!(__svc_params->flags & SVC_FLAG_NOREG_XPRTS)
 	     && !(flags & SVC_CREATE_FLAG_XPRT_NOREG))
 	    || (flags & SVC_CREATE_FLAG_XPRT_DOREG))
 		svc_rqst_evchan_reg(__svc_params->ev_u.evchan.id, xprt,
+				    SVC_RQST_FLAG_LOCKED |
 				    SVC_RQST_FLAG_CHAN_AFFINITY);
+
+	/* release */
+	rpc_dplx_rui(rec);
+	XPRT_TRACE(xprt, __func__, __func__, __LINE__);
 
 #if defined(HAVE_BLKIN)
 	__rpc_set_blkin_endpoint(xprt, "svc_vc");

--- a/src/svc_xprt.c
+++ b/src/svc_xprt.c
@@ -204,7 +204,7 @@ svc_xprt_lookup(int fd, svc_xprt_setup_t setup)
  *
  * @note Locking
  * - xprt is locked
- *   returned unlocked
+ *   returned locked
  */
 void
 svc_xprt_clear(SVCXPRT *xprt)
@@ -214,8 +214,6 @@ svc_xprt_clear(SVCXPRT *xprt)
 	if (svc_xprt_init_failure())
 		return;
 
-	rpc_dplx_rli(REC_XPRT(xprt));
-
 	if (opr_rbtree_node_valid(&REC_XPRT(xprt)->fd_node)) {
 		t = rbtx_partition_of_scalar(&svc_xprt_fd.xt, xprt->xp_fd);
 
@@ -223,8 +221,6 @@ svc_xprt_clear(SVCXPRT *xprt)
 		opr_rbtree_remove(&t->t, &REC_XPRT(xprt)->fd_node);
 		rwlock_unlock(&t->lock);
 	}
-
-	rpc_dplx_rui(REC_XPRT(xprt));
 }
 
 int


### PR DESCRIPTION
Substitute transport duplex lock as needed.

Remove signals, and rename SVC_RQST_FLAG_SHUTDOWN.

Update logging.

Signed-off-by: William Allen Simpson <william.allen.simpson@redhat.com>