### PR TITLE
Fix the various paths in the pc file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ configure_file(
 configure_file(
   "${NTIRPC_BASE_DIR}/libntirpc.pc.in.cmake"
   "${PROJECT_BINARY_DIR}/libntirpc.pc"
+  @ONLY
 )
 
 configure_file(

--- a/libntirpc.pc.in.cmake
+++ b/libntirpc.pc.in.cmake
@@ -1,11 +1,11 @@
-prefix=@prefix@
-exec_prefix=@exec_prefix@
-libdir=@libdir@
-includedir=@includedir@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@LIB_INSTALL_DIR@
+includedir=${prefix}/include/ntirpc
 
 Name: libntirpc
 Description: New Transport Independent RPC Library
 Requires:
 Version: @NTIRPC_VERSION@
-Libs: -L@libdir@ -lntirpc
-Cflags: -I@includedir@/ntirpc
+Libs: -lntirpc
+Cflags: -I${prefix}/include/ntirpc


### PR DESCRIPTION
The .pc file is completely broken, since the paths are all unset. They need to refer to variables in the CMakeLists.txt ... 

Please if possible also backport to any stable branches.