### PR TITLE
Close in destroy_task(s)

### DIFF
--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -1,6 +1,7 @@
 
 /*
  * Copyright (c) 2009, Sun Microsystems, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc. and/or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,8 +36,6 @@
 
 /*
  * svc_dg.c, Server side for connectionless RPC.
- *
- * Does some caching in the hopes of achieving execute-at-most-once semantics.
  */
 #include <sys/cdefs.h>
 #include <sys/types.h>
@@ -412,10 +411,20 @@ svc_dg_destroy_task(struct work_pool_entry *wpe)
 	struct rpc_dplx_rec *rec =
 			opr_containerof(wpe, struct rpc_dplx_rec, ioq.ioq_wpe);
 
+	__warnx(TIRPC_DEBUG_FLAG_REFCNT,
+		"%s() %p fd %d xp_refs %" PRIu32,
+		__func__, rec, rec->xprt.xp_fd, rec->xprt.xp_refs);
+
 	if (rec->xprt.xp_refs) {
 		/* instead of nanosleep */
 		work_pool_submit(&svc_work_pool, &(rec->ioq.ioq_wpe));
 		return;
+	}
+
+	if ((rec->xprt.xp_flags & SVC_XPRT_FLAG_CLOSE)
+	    && rec->xprt.xp_fd != RPC_ANYFD) {
+		(void)close(rec->xprt.xp_fd);
+		rec->xprt.xp_fd = RPC_ANYFD;
 	}
 
 	if (rec->xprt.xp_ops->xp_free_user_data)
@@ -449,9 +458,6 @@ svc_dg_destroy_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 		"%s() %p fd %d xp_refs %" PRIu32
 		" should actually destroy things @ %s:%d",
 		__func__, xprt, xprt->xp_fd, xprt->xp_refs, tag, line);
-
-	if ((xprt->xp_flags & SVC_XPRT_FLAG_CLOSE) && xprt->xp_fd != -1)
-		(void)close(xprt->xp_fd);
 
 	while (atomic_postset_uint16_t_bits(&(REC_XPRT(xprt)->ioq.ioq_s.qflags),
 					    IOQ_FLAG_WORKING)

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -770,9 +770,12 @@ svc_rqst_epoll_event(struct svc_rqst_rec *sr_rec, struct epoll_event *ev)
 	xp_flags = atomic_postclear_uint16_t_bits(&rec->xprt.xp_flags,
 						  SVC_XPRT_FLAG_ADDED);
 
-	__warnx(TIRPC_DEBUG_FLAG_SVC_RQST,
-		"%s: %p fd %d event %d",
-		__func__, rec, rec->xprt.xp_fd, ev->events);
+	__warnx(TIRPC_DEBUG_FLAG_SVC_RQST |
+		TIRPC_DEBUG_FLAG_REFCNT,
+		"%s: %p fd %d xp_refs %" PRIu32
+		" event %d",
+		__func__, rec, rec->xprt.xp_fd, rec->xprt.xp_refs,
+		ev->events);
 
 	if (rec->xprt.xp_refs > 1
 	 && (xp_flags & SVC_XPRT_FLAG_ADDED)

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -526,10 +526,20 @@ svc_vc_destroy_task(struct work_pool_entry *wpe)
 	struct rpc_dplx_rec *rec =
 			opr_containerof(wpe, struct rpc_dplx_rec, ioq.ioq_wpe);
 
+	__warnx(TIRPC_DEBUG_FLAG_REFCNT,
+		"%s() %p fd %d xp_refs %" PRIu32,
+		__func__, rec, rec->xprt.xp_fd, rec->xprt.xp_refs);
+
 	if (rec->xprt.xp_refs) {
 		/* instead of nanosleep */
 		work_pool_submit(&svc_work_pool, &(rec->ioq.ioq_wpe));
 		return;
+	}
+
+	if ((rec->xprt.xp_flags & SVC_XPRT_FLAG_CLOSE)
+	    && rec->xprt.xp_fd != RPC_ANYFD) {
+		(void)close(rec->xprt.xp_fd);
+		rec->xprt.xp_fd = RPC_ANYFD;
 	}
 
 	if (rec->xprt.xp_ops->xp_free_user_data)
@@ -561,10 +571,6 @@ svc_vc_destroy_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 		"%s() %p fd %d xp_refs %" PRIu32
 		" should actually destroy things @ %s:%d",
 		__func__, xprt, xprt->xp_fd, xprt->xp_refs, tag, line);
-
-	if ((xprt->xp_flags & SVC_XPRT_FLAG_CLOSE)
-	    && xprt->xp_fd != RPC_ANYFD)
-		(void)close(xprt->xp_fd);
 
 	while (atomic_postset_uint16_t_bits(&(REC_XPRT(xprt)->ioq.ioq_s.qflags),
 					    IOQ_FLAG_WORKING)


### PR DESCRIPTION
Move closing the fd into the destroy_task(s) where we are reasonably sure
any outstanding poll for that fd has had the opportunity to terminate.

Signed-off-by: William Allen Simpson <william.allen.simpson@redhat.com>