### PR TITLE
At the time of this writing, glibc-2.26 has a bug where

### DIFF
--- a/src/svc.c
+++ b/src/svc.c
@@ -227,7 +227,15 @@ svc_init(svc_init_params *params)
 	mutex_unlock(&__svc_params->mtx);
 
 #if defined(_SC_IOV_MAX) /* IRIX, MacOS X, FreeBSD, Solaris, ... */
-	__svc_maxiov = sysconf(_SC_IOV_MAX);
+	{
+		/*
+		 * some glibc (e.g. 2.26 in Fedora 27 beta) always
+		 * return -1
+		 */
+		int i = sysconf(_SC_IOV_MAX);
+		if (i != -1 && i > __svc_maxiov)
+			__svc_maxiov = i;
+	}
 #endif
 	return true;
 }


### PR DESCRIPTION
  sysconf(_SC_IOV_MAX);
always returns -1.

Versions known to have this bug are glibc-2.26-8 in Fedora 27 beta
and glibc-2.26.90-16 in Fedora 28 rawhide.

Upstream glibc BZ at
  https://sourceware.org/bugzilla/show_bug.cgi?id=22321

Linux does have a limit on the size of the iovec that is passed in
readv/writev syscalls; defined as UIO_MAXIOV (i.e. 1024) in
.../include/uapi/linux/uio.h. See kernel source readv/writev syscalls.

It's also possible to get _XOPEN_IOV_MAX (i.e. 16) and IOV_MAX (1024)
by wrapping <limits.h> with #define __USE_XOPEN ... #undef but that's
XOpen and theoretically Linux could change.