### PR TITLE
(clnt_internal) time_not_ok_trace inverted result

### DIFF
--- a/src/clnt_internal.h
+++ b/src/clnt_internal.h
@@ -73,12 +73,12 @@ time_not_ok_trace(struct timeval *t, const char *func, int line)
 {
 	if (t->tv_usec < 0 || t->tv_usec > 999999
 	 || t->tv_sec < 0 || !(t->tv_sec + t->tv_usec))
-		return (false);
+		return (true);
 	if (t->tv_sec > 10)
 		__warnx(TIRPC_DEBUG_FLAG_WARN,
 			"%s:%d tv_sec %ld > 10",
 			func, line, t->tv_sec);
-	return (true);
+	return (false);
 }
 #define time_not_ok(t) \
 	time_not_ok_trace(t, __func__, __LINE__)


### PR DESCRIPTION
That's what I get for not running a full test after merely adding a warnx.