### PR TITLE
(work_pool) thread_name function

### DIFF
--- a/ntirpc/rpc/types.h
+++ b/ntirpc/rpc/types.h
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2009, Sun Microsystems, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc. and/or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -167,6 +168,7 @@ typedef void *(*mem_p_size_t) (void *, size_t,
 	     const char *file, int line, const char *function);
 typedef void (*mem_free_size_t) (void *, size_t);
 typedef void (*mem_format_t) (const char *fmt, ...);
+typedef void (*mem_char_t) (const char *);
 
 /*
  * Package params support
@@ -174,6 +176,7 @@ typedef void (*mem_format_t) (const char *fmt, ...);
 typedef struct tirpc_pkg_params {
 	uint32_t debug_flags;
 	uint32_t other_flags;
+	mem_char_t	thread_name_;
 	mem_format_t	warnx_;
 	mem_free_size_t	free_size_;
 	mem_1_size_t	malloc_;

--- a/ntirpc/rpc/work_pool.h
+++ b/ntirpc/rpc/work_pool.h
@@ -67,6 +67,7 @@ struct work_pool_thread {
 
 	struct work_pool *pool;
 	struct work_pool_entry *work;
+	char worker_name[16];
 	pthread_t pt;
 	uint32_t worker_index;
 };
@@ -83,6 +84,5 @@ struct work_pool_entry {
 int work_pool_init(struct work_pool *, const char *, struct work_pool_params *);
 int work_pool_submit(struct work_pool *, struct work_pool_entry *);
 int work_pool_shutdown(struct work_pool *);
-char *work_pool_worker_name(void);
 
 #endif				/* WORK_POOL_H */

--- a/src/libntirpc.map.in.cmake
+++ b/src/libntirpc.map.in.cmake
@@ -200,9 +200,6 @@ NTIRPC_${NTIRPC_VERSION} {
     # u*
     uaddr2taddr;
 
-    # w*
-    work_pool_worker_name;
-
     # x*
     xdr_array;
     xdr_authunix_parms;

--- a/src/rpc_generic.c
+++ b/src/rpc_generic.c
@@ -71,6 +71,12 @@ thr_keyfree(void *k)
 }
 
 static void
+tirpc_thread_name(const char *p)
+{
+	/* do nothing */
+}
+
+static void
 tirpc_free(void *p, size_t unused)
 {
 	free(p);
@@ -123,6 +129,7 @@ tirpc_realloc(void *p, size_t size, const char *file, int line,
 tirpc_pkg_params __ntirpc_pkg_params = {
 	TIRPC_FLAG_NONE,
 	TIRPC_DEBUG_FLAG_NONE,
+	tirpc_thread_name,
 	warnx,
 	tirpc_free,
 	tirpc_malloc,


### PR DESCRIPTION
Partial revert "(work_pool) display worker name"
This reverts commit 0c39dec7f3371ac73aadf8b52f19467070aaeaea.

Instead, upcall to set thread_name for upcalls to __warnx.