### PR TITLE
Double check clnt_req timeout

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -313,6 +313,7 @@ struct svc_req {
 	/* blkin tracing */
 	struct blkin_trace bl_trace;
 #endif
+	uint32_t rq_refs;
 };
 
 /*

--- a/src/clnt_internal.h
+++ b/src/clnt_internal.h
@@ -67,7 +67,6 @@ clnt_data_destroy(struct cx_data *cx)
 
 /* in svc_rqst.c */
 void svc_rqst_expire_insert(struct clnt_req *);
-void svc_rqst_expire_refresh(struct clnt_req *);
 void svc_rqst_expire_remove(struct clnt_req *);
 
 #endif				/* _CLNT_INTERNAL_H */


### PR DESCRIPTION
clnt.h
 * split CLNT_REQ_FLAG_CALLBACK into _EXPIRING & _BACKSYNC.
 + cc_free_cb, cc_size, cc_refs (renamed)

svc.h
 + rq_refs (for user symmetry)

clnt_req_process_reply()
 * set CLNT_REQ_FLAG_ACKSYNC
 * check CLNT_REQ_FLAG_BACKSYNC
 * clear CLNT_REQ_FLAG_EXPIRING,
   conditionally svc_rqst_expire_remove() and zero cc_expire_ms

svc_rqst_expire_task()
 + set CLNT_REQ_FLAG_BACKSYNC
 + check CLNT_REQ_FLAG_ACKSYNC
 + reference counted release

Signed-off-by: William Allen Simpson <william.allen.simpson@redhat.com>