### PR TITLE
Raise thread stack size to 1M

### DIFF
--- a/src/work_pool.c
+++ b/src/work_pool.c
@@ -57,7 +57,7 @@
 
 #include <rpc/work_pool.h>
 
-#define WORK_POOL_STACK_SIZE MAX(64 * 1024, PTHREAD_STACK_MIN)
+#define WORK_POOL_STACK_SIZE MAX(1 * 1024 * 1024, PTHREAD_STACK_MIN)
 #define WORK_POOL_TIMEOUT_MS (31 /* seconds (prime) */ * 1000)
 
 /* forward declaration in lieu of moving code, was inline */


### PR DESCRIPTION
Now that Ganesha is using ntirpc threads for everything, 64k is not
a large enough stack size.  Before, Ganesha was using the default of 2M.
Compromise on 1M for now.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>