### PR TITLE
In order to fix (hack) the coverity runs on fedora27 w/ gcc-7 need to

### DIFF
--- a/src/auth_gss.c
+++ b/src/auth_gss.c
@@ -36,7 +36,7 @@
 
 */
 
-#include <config.h>
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/auth_none.c
+++ b/src/auth_none.c
@@ -42,7 +42,7 @@
  *
  * Copyright (C) 1984, Sun Microsystems, Inc.
  */
-#include <config.h>
+#include "config.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/src/auth_unix.c
+++ b/src/auth_unix.c
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/authgss_hash.c
+++ b/src/authgss_hash.c
@@ -25,7 +25,7 @@
 
 /* Portions Copyright (c) 2010-2011, ** others, update */
 
-#include <config.h>
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/authgss_prot.c
+++ b/src/authgss_prot.c
@@ -34,7 +34,7 @@
 
 */
 
-#include <config.h>
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/src/authunix_prot.c
+++ b/src/authunix_prot.c
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/bindresvport.c
+++ b/src/bindresvport.c
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/city-test.c
+++ b/src/city-test.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include "config.h"
 #include <string.h>
 #include <stdio.h>
 

--- a/src/city.c
+++ b/src/city.c
@@ -33,6 +33,7 @@
  * compromising on hash quality.
  */
 
+#include "config.h"
 #include <string.h>
 #include <misc/city.h>
 

--- a/src/clnt_bcast.c
+++ b/src/clnt_bcast.c
@@ -28,7 +28,7 @@
 /*
  * Copyright (c) 1986-1991 by Sun Microsystems Inc.
  */
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/clnt_dg.c
+++ b/src/clnt_dg.c
@@ -33,7 +33,7 @@
 /*
  * Implements a connectionless client side RPC.
  */
-#include <config.h>
+#include "config.h"
 
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/src/clnt_generic.c
+++ b/src/clnt_generic.c
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 #include <pthread.h>
 #include <reentrant.h>
 #include <sys/types.h>

--- a/src/clnt_perror.c
+++ b/src/clnt_perror.c
@@ -36,7 +36,7 @@
  * Copyright (C) 1984, Sun Microsystems, Inc.
  *
  */
-#include <config.h>
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/clnt_raw.c
+++ b/src/clnt_raw.c
@@ -37,7 +37,7 @@
  * This lets us similate rpc and get round trip overhead, without
  * any interference from the kernel.
  */
-#include <config.h>
+#include "config.h"
 #include <pthread.h>
 #include <reentrant.h>
 #include <assert.h>

--- a/src/clnt_rdma.c
+++ b/src/clnt_rdma.c
@@ -31,7 +31,7 @@
 /*
  * Implements an msk connection client side RPC.
  */
-#include <config.h>
+#include "config.h"
 #include <pthread.h>
 #include <reentrant.h>
 #include <sys/types.h>

--- a/src/clnt_simple.c
+++ b/src/clnt_simple.c
@@ -30,7 +30,7 @@
  * Copyright (c) 1986-1991 by Sun Microsystems Inc.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/clnt_vc.c
+++ b/src/clnt_vc.c
@@ -45,7 +45,7 @@
  *
  * Now go hang yourself.  [Ouch, that was intemperate.]
  */
-#include <config.h>
+#include "config.h"
 
 #include <sys/types.h>
 #include <sys/poll.h>

--- a/src/des_crypt.c
+++ b/src/des_crypt.c
@@ -30,6 +30,7 @@
  * Copyright (C) 1986, Sun Microsystems, Inc.
  */
 
+#include "config.h"
 #include <sys/types.h>
 #include <rpc/types.h>
 #include <rpc/des_crypt.h>

--- a/src/getnetconfig.c
+++ b/src/getnetconfig.c
@@ -30,7 +30,7 @@
  * Copyright (c) 1989 by Sun Microsystems, Inc.
  */
 
-#include <config.h>
+#include "config.h"
 #include <pthread.h>
 #include <reentrant.h>
 #include <sys/cdefs.h>

--- a/src/getnetpath.c
+++ b/src/getnetpath.c
@@ -25,7 +25,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/getpeereid.c
+++ b/src/getpeereid.c
@@ -12,7 +12,7 @@
  *-------------------------------------------------------------------------
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdint.h>
 #include <sys/param.h>

--- a/src/getpublickey.c
+++ b/src/getpublickey.c
@@ -37,6 +37,7 @@
 /*
  * Public key lookup routines
  */
+#include "config.h"
 #include <stdio.h>
 #include <pwd.h>
 #include <rpc/rpc.h>

--- a/src/getrpcent.c
+++ b/src/getrpcent.c
@@ -30,7 +30,7 @@
  * Copyright (c) 1984 by Sun Microsystems, Inc.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/types.h>
 
 #include <netinet/in.h>

--- a/src/key_call.c
+++ b/src/key_call.c
@@ -29,6 +29,7 @@
  * Copyright (c) 1986-1991 by Sun Microsystems Inc.
  */
 
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/mt_misc.c
+++ b/src/mt_misc.c
@@ -1,5 +1,5 @@
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 #include <pthread.h>
 #include <reentrant.h>

--- a/src/netname.c
+++ b/src/netname.c
@@ -34,6 +34,7 @@
  * the sun NIS domain architecture.
  */
 
+#include "config.h"
 #include <sys/param.h>
 #include <rpc/rpc.h>
 #include "rpc_com.h"

--- a/src/netnamer.c
+++ b/src/netnamer.c
@@ -32,6 +32,7 @@
  * will work with any unix system that has adopted the sun NIS domain
  * architecture.
  */
+#include "config.h"
 #include <sys/param.h>
 #include <rpc/rpc.h>
 #include "rpc_com.h"

--- a/src/pmap_prot.c
+++ b/src/pmap_prot.c
@@ -33,7 +33,7 @@
  * Copyright (C) 1984, Sun Microsystems, Inc.
  */
 
-#include <config.h>
+#include "config.h"
 #include <assert.h>
 
 #include <rpc/types.h>

--- a/src/pmap_prot2.c
+++ b/src/pmap_prot2.c
@@ -33,7 +33,7 @@
  * Copyright (C) 1984, Sun Microsystems, Inc.
  */
 
-#include <config.h>
+#include "config.h"
 #include <assert.h>
 
 #include <rpc/types.h>

--- a/src/pmap_rmt.c
+++ b/src/pmap_rmt.c
@@ -34,7 +34,7 @@
  * Copyright (C) 1984, Sun Microsystems, Inc.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/poll.h>

--- a/src/portable.c
+++ b/src/portable.c
@@ -23,7 +23,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 #include <misc/portable.h>
 #include <misc/stdio.h>
 #include <stdbool.h>

--- a/src/rbtree.c
+++ b/src/rbtree.c
@@ -31,7 +31,7 @@
  *     *) Use 'NULL' to represent empty nodes, rather than a magic pointer
  */
 
-#include <config.h>
+#include "config.h"
 #include <stdlib.h>
 #include "misc/rbtree.h"
 

--- a/src/rbtree_x.c
+++ b/src/rbtree_x.c
@@ -23,7 +23,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <sys/types.h>
 #if !defined(_WIN32)

--- a/src/rpc_callmsg.c
+++ b/src/rpc_callmsg.c
@@ -34,7 +34,7 @@
  *
  */
 
-#include <config.h>
+#include "config.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/rpc_commondata.c
+++ b/src/rpc_commondata.c
@@ -26,6 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "config.h"
 #include <rpc/rpc.h>
 
 /*

--- a/src/rpc_crc32.c
+++ b/src/rpc_crc32.c
@@ -42,6 +42,7 @@
  * CRC32 code derived from work by Gary S. Brown.
  */
 
+#include "config.h"
 #include <sys/cdefs.h>
 
 #include <stdint.h>

--- a/src/rpc_dplx_msg.c
+++ b/src/rpc_dplx_msg.c
@@ -37,7 +37,7 @@
  *
  */
 
-#include <config.h>
+#include "config.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/rpc_dtablesize.c
+++ b/src/rpc_dtablesize.c
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 #include <unistd.h>
 
 #include <sys/select.h>

--- a/src/rpc_generic.c
+++ b/src/rpc_generic.c
@@ -30,7 +30,7 @@
  * Copyright (c) 1986-1991 by Sun Microsystems Inc.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/rpc_prot.c
+++ b/src/rpc_prot.c
@@ -39,7 +39,7 @@
  * routines are also in this program.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/param.h>
 
 #include <assert.h>

--- a/src/rpc_rdma.c
+++ b/src/rpc_rdma.c
@@ -37,7 +37,7 @@
  */
 
 #if HAVE_CONFIG_H
-#  include <config.h>
+#  include "config.h"
 #endif
 
 #include <stdio.h>	//printf

--- a/src/rpcb_clnt.c
+++ b/src/rpcb_clnt.c
@@ -31,7 +31,7 @@
  * rpcb_clnt.c
  * interface to rpcbind rpc service.
  */
-#include <config.h>
+#include "config.h"
 #include <pthread.h>
 #include <reentrant.h>
 #include <sys/stat.h>

--- a/src/rpcb_prot.c
+++ b/src/rpcb_prot.c
@@ -37,7 +37,7 @@
  * Copyright (C) 1984, 1988, Sun Microsystems, Inc.
  */
 
-#include <config.h>
+#include "config.h"
 #include <rpc/rpc.h>
 #include <rpc/types.h>
 #include <rpc/xdr_inline.h>

--- a/src/rpcb_st_xdr.c
+++ b/src/rpcb_st_xdr.c
@@ -36,7 +36,7 @@
  * routines used with the rpcbind stats facility.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 #include <rpc/rpc.h>

--- a/src/rpcdname.c
+++ b/src/rpcdname.c
@@ -25,6 +25,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/strlcat.c
+++ b/src/strlcat.c
@@ -16,6 +16,7 @@
 
 #ifndef HAVE_STRLCAT
 
+#include "config.h"
 #include <sys/types.h>
 #include <string.h>
 

--- a/src/strlcpy.c
+++ b/src/strlcpy.c
@@ -16,6 +16,7 @@
 
 #ifndef HAVE_STRLCPY
 
+#include "config.h"
 #include <sys/types.h>
 
 /*

--- a/src/svc.c
+++ b/src/svc.c
@@ -36,7 +36,7 @@
  *
  * Copyright (C) 1984, Sun Microsystems, Inc.
  */
-#include <config.h>
+#include "config.h"
 
 #include <sys/types.h>
 #include <assert.h>

--- a/src/svc_auth.c
+++ b/src/svc_auth.c
@@ -34,7 +34,7 @@
  * svc_auth.c, Server-side rpc authenticator interface.
  *
  */
-#include <config.h>
+#include "config.h"
 #include <pthread.h>
 #include <reentrant.h>
 #include <sys/types.h>

--- a/src/svc_auth_gss.c
+++ b/src/svc_auth_gss.c
@@ -34,7 +34,7 @@
 
 */
 
-#include <config.h>
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/svc_auth_none.c
+++ b/src/svc_auth_none.c
@@ -35,7 +35,7 @@
   $Id: svc_auth_none.c,v 1.1 2004/10/22 17:24:30 bfields Exp $
 */
 
-#include <config.h>
+#include "config.h"
 #include <rpc/rpc.h>
 #include <rpc/svc_auth.h>
 

--- a/src/svc_auth_unix.c
+++ b/src/svc_auth_unix.c
@@ -36,7 +36,7 @@
  *
  * Copyright (C) 1984, Sun Microsystems, Inc.
  */
-#include <config.h>
+#include "config.h"
 #include <pthread.h>
 #include <assert.h>
 #include <stdio.h>

--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -32,7 +32,7 @@
  * Copyright (c) 1986-1991 by Sun Microsystems Inc.
  */
 
-#include <config.h>
+#include "config.h"
 
 /*
  * svc_dg.c, Server side for connectionless RPC.

--- a/src/svc_generic.c
+++ b/src/svc_generic.c
@@ -35,7 +35,7 @@
  * svc_generic.c, Server side for RPC.
  *
  */
-#include <config.h>
+#include "config.h"
 #include <pthread.h>
 #include <reentrant.h>
 #include <sys/types.h>

--- a/src/svc_ioq.c
+++ b/src/svc_ioq.c
@@ -24,6 +24,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "config.h"
 #include <sys/cdefs.h>
 #include <sys/socket.h>
 #include <sys/types.h>

--- a/src/svc_raw.c
+++ b/src/svc_raw.c
@@ -37,7 +37,7 @@
  * any interference from the kernel.
  *
  */
-#include <config.h>
+#include "config.h"
 #include <pthread.h>
 #include <reentrant.h>
 #include <sys/types.h>

--- a/src/svc_rdma.c
+++ b/src/svc_rdma.c
@@ -31,7 +31,7 @@
  * Implements connection server side RPC/RDMA.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <sys/cdefs.h>
 #include <pthread.h>

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -25,7 +25,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <sys/types.h>
 #include <sys/poll.h>

--- a/src/svc_simple.c
+++ b/src/svc_simple.c
@@ -29,7 +29,7 @@
  * Copyright (c) 1986-1991 by Sun Microsystems Inc.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 
 /*
  * svc_vc.c, Server side for Connection Oriented RPC.

--- a/src/svc_xprt.c
+++ b/src/svc_xprt.c
@@ -25,7 +25,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <sys/types.h>
 #include <sys/poll.h>

--- a/src/work_pool.c
+++ b/src/work_pool.c
@@ -36,7 +36,7 @@
  *          Matt Benjamin <matt@cohortfs.com>
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <sys/types.h>
 #if !defined(_WIN32)

--- a/src/xdr.c
+++ b/src/xdr.c
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/xdr_array.c
+++ b/src/xdr_array.c
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/xdr_float.c
+++ b/src/xdr_float.c
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/xdr_ioq.c
+++ b/src/xdr_ioq.c
@@ -24,7 +24,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <sys/types.h>
 #if !defined(_WIN32)

--- a/src/xdr_mem.c
+++ b/src/xdr_mem.c
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*

--- a/src/xdr_rdma.c
+++ b/src/xdr_rdma.c
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 #include "namespace.h"

--- a/src/xdr_reference.c
+++ b/src/xdr_reference.c
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/cdefs.h>
 
 /*


### PR DESCRIPTION
add a typedef to the generated config.h (coverity-87)

change
 #include <config.h>
to
 #include "config.h"
and add missing #include "config.h" as necessary

Hopefully the next coverity will remove the need to add the typedef.
Meanwile "config.h" is correct. <config.h> could find a config.h in
/usr/include or other system include directories. Fortunately there
hasn't been one. (yet)