### PR TITLE
ntirpc: find libnsl.so in /usr/lib64/nsl on fedora28 with libnsl2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,12 @@ include_directories(BEFORE
 
 # Find misc system libs
 find_library(LIBRT rt)   # extended Pthreads functions
-find_library(LIBNSL nsl) # sockets
+
+if(EXISTS /usr/lib64/nsl/libnsl.so)
+  set(PATH_LIBNSL "/usr/lib64/nsl/libnsl.so" CACHE_INTERNAL "libnsl2")
+else(EXISTS /usr/lib64/nsl/libnsl.so)
+  find_library(LIBNSL nsl) # sockets
+endif(EXISTS /usr/lib64/nsl/libnsl.so)
 
 set(SYSTEM_LIBRARIES
   ${LIBTIRPC_LIBRARIES}


### PR DESCRIPTION
legacy libnsl in /usr/lib64 from glibc has been removed in fedora28, see

https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/IXFFPJYVI67WWSMJUJCSPV744VUADYIM/

FWIW, libnsl2 has been available since at least fedora26 (with better
IPv6 support? Perhaps we should be using it instead?)

Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>