### PR TITLE
Add FindNSL module for systems with split NSL packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,14 +153,14 @@ include_directories(BEFORE
 
 # Find misc system libs
 find_library(LIBRT rt)   # extended Pthreads functions
-find_library(LIBNSL nsl) # sockets
+find_package(NSL) # sockets
 
 set(SYSTEM_LIBRARIES
   ${LIBTIRPC_LIBRARIES}
   ${KRB5_LIBRARIES}
   ${SYSTEM_LIBRARIES}
   ${LIBRT}
-  ${LIBNSL}
+  ${NSL_LIBRARY}
 )
 
 set(LIBNTIRPC_MAP "${PROJECT_BINARY_DIR}/src/libntirpc.map")

--- a/cmake/modules/FindNSL.cmake
+++ b/cmake/modules/FindNSL.cmake
@@ -1,0 +1,27 @@
+# - Find NSL
+#
+# This module defines the following variables:
+#    NSL_FOUND       = Was NSL found or not?
+#
+# On can set NSL_PATH_HINT before using find_package(NSL) and the
+# module with use the PATH as a hint to find NSL.
+#
+# The hint can be given on the command line too:
+#   cmake -DNSL_PATH_HINT=/DATA/ERIC/NSL /path/to/source
+
+#find_path(NSL_INCLUDE_DIR
+  #NAMES yp.h
+  #PATHS ${NSL_HINT_PATH}
+  #PATH_SUFFIXES nsl/rpcsvc
+  #DOC "The NSL include headers")
+
+find_library(NSL_LIBRARY nsl PATH_SUFFIXES nsl)
+
+# handle the QUIETLY and REQUIRED arguments and set PRELUDE_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+#FIND_PACKAGE_HANDLE_STANDARD_ARGS(NSL REQUIRED_VARS NSL_INCLUDE_DIR NSL_LIBRARY)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(NSL REQUIRED_VARS NSL_LIBRARY)
+
+mark_as_advanced(NSL_INCLUDE_DIR)
+mark_as_advanced(NSL_LIBRARY)


### PR DESCRIPTION
Fedora starting with 28 has split NSL into a separate package, and put
the lib in the "nsl" subdir of the library path.  Add a FindNSL module
that can find it in both types of systems.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>