### PR TITLE
(rpcping) finer grained timing

### DIFF
--- a/tests/rpcping.c
+++ b/tests/rpcping.c
@@ -33,21 +33,32 @@
 #include <rpc/rpc.h>
 #include <rpc/svc_auth.h>
 
-static pthread_mutex_t rpcpring_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t rpcpring_cond = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t rpcping_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t rpcping_cond = PTHREAD_COND_INITIALIZER;
 static uint32_t rpcping_threads;
 
 static struct timespec to = {30, 0};
 
 struct state {
 	CLIENT *handle;
-	double averageTime;
-	clock_t rtime;
+	pthread_cond_t s_cond;
+	pthread_mutex_t s_mutex;
+	struct timespec starting;
+	struct timespec stopping;
 	int count;
 	int proc;
 	int id;
-	uint32_t requests;
+	uint32_t responses;
 };
+
+static uint64_t timespec_elapsed(const struct timespec *starting,
+				 const struct timespec *stopping)
+{
+	time_t elapsed = stopping->tv_sec - starting->tv_sec;
+	long nsec = stopping->tv_nsec - starting->tv_nsec;
+
+	return (elapsed * 1000000000L) + nsec;
+}
 
 static int
 get_conn_fd(const char *host, int hbport)
@@ -112,19 +123,13 @@ worker_cb(struct clnt_req *cc)
 {
 	CLIENT *clnt = cc->cc_clnt;
 	struct state *s = clnt->cl_u1;
-	struct tms dumm;
 
 	clnt_req_release(cc);
-	if (atomic_dec_uint32_t(&s->requests) > 0) {
+	if (atomic_inc_uint32_t(&s->responses) < s->count) {
 		return;
 	}
-	s->averageTime = s->count
-			 / ((double) (times(&dumm) - s->rtime)
-			 / (double) sysconf(_SC_CLK_TCK));
 
-	CLNT_DESTROY(clnt);
-	(void)atomic_dec_uint32_t(&rpcping_threads);
-	pthread_cond_broadcast(&rpcpring_cond);
+	pthread_cond_broadcast(&s->s_cond);
 }
 
 static void *
@@ -132,21 +137,22 @@ worker(void *arg)
 {
 	struct state *s = arg;
 	struct clnt_req *cc;
-	struct tms dumm;
 	int i;
 
-	s->rtime = times(&dumm);
+	pthread_cond_init(&s->s_cond, NULL);
+	pthread_mutex_init(&s->s_mutex, NULL);
+
+	clock_gettime(CLOCK_MONOTONIC, &s->starting);
 	for (i = 0; i < s->count; i++) {
 		cc = calloc(1, sizeof(*cc));
 		clnt_req_fill(cc, s->handle, authnone_ncreate(), s->proc,
 			      (xdrproc_t) xdr_void, NULL,
 			      (xdrproc_t) xdr_void, NULL);
 
-		(void)atomic_inc_uint32_t(&s->requests);
 		if (clnt_req_setup(cc, to) != RPC_SUCCESS) {
 			rpc_perror(&cc->cc_error, "clnt_req_setup failed");
-			s->count = s->requests;
-			worker_cb(cc);
+			s->count = i;
+			clnt_req_release(cc);
 			break;
 		}
 		cc->cc_refreshes = 1;
@@ -155,12 +161,22 @@ worker(void *arg)
 		cc->cc_error.re_status = CLNT_CALL_BACK(cc);
 		if (cc->cc_error.re_status != RPC_SUCCESS) {
 			rpc_perror(&cc->cc_error, "CLNT_CALL_BACK failed");
-			s->count = s->requests;
-			worker_cb(cc);
+			s->count = i;
+			clnt_req_release(cc);
 			break;
 		}
 	}
 
+	pthread_mutex_lock(&s->s_mutex);
+	pthread_cond_wait(&s->s_cond, &s->s_mutex);
+	pthread_mutex_unlock(&s->s_mutex);
+	clock_gettime(CLOCK_MONOTONIC, &s->stopping);
+
+	if (atomic_dec_uint32_t(&rpcping_threads) > 0) {
+		return NULL;
+	}
+
+	pthread_cond_broadcast(&rpcping_cond);
 	return NULL;
 }
 
@@ -188,14 +204,15 @@ decode_request(SVCXPRT *xprt, XDR *xdrs)
 
 static void usage()
 {
-	printf("Usage: rpcping <raw|rdma|tcp|udp> <host> [--rpcbind] [--threads=<n>] [--count=<n>] [--port=<n>] [--program=<n>] [--version=<n>] [--procedure=<n>]\n");
+	printf("Usage: rpcping <raw|rdma|tcp|udp> <host> [--rpcbind] [--count=<n>] [--threads=<n>] [--workers=<n>] [--port=<n>] [--program=<n>] [--version=<n>] [--procedure=<n>]\n");
 }
 
 static struct option long_options[] =
 {
-	{"port", required_argument, NULL, 'p'},
-	{"threads", required_argument, NULL, 't'},
 	{"count", required_argument, NULL, 'c'},
+	{"threads", required_argument, NULL, 't'},
+	{"workers", required_argument, NULL, 'w'},
+	{"port", required_argument, NULL, 'p'},
 	{"program", required_argument, NULL, 'm'},
 	{"version", required_argument, NULL, 'v'},
 	{"procedure", required_argument, NULL, 'x'},
@@ -212,17 +229,19 @@ int main(int argc, char *argv[])
 	char *proto;
 	char *host;
 	double total;
+	double elapsed_ns;
 	int i;
 	int opt;
+	int count = 500; /* minimal concurrent requests */
 	int nthreads = 1;
-	int count = 1500; /* observed optimal concurrent requests */
+	int nworkers = 5;
 	int port = 2049;
 	int prog = 100003; /* nfs */
 	int vers = 3; /* allow raw, rdma, tcp, udp by default */
 	int proc = 0;
 	int send_sz = 8192;
 	int recv_sz = 8192;
-	int rpcbind = false;
+	bool rpcbind = false;
 
 	/* protocol and host/dest positional */
 	if (argc < 3) {
@@ -234,15 +253,18 @@ int main(int argc, char *argv[])
 	host = argv[2];
 
 	optind = 3;
-	while ((opt = getopt_long(argc, argv, "bt:c:p:m:v:x:",
+	while ((opt = getopt_long(argc, argv, "bc:m:p:t:v:w:x:",
 				  long_options, NULL)) != -1) {
 		switch (opt)
 		{
+		case 'c':
+			count = atoi(optarg);
+			break;
 		case 't':
 			nthreads = atoi(optarg);
 			break;
-		case 'c':
-			count = atoi(optarg);
+		case 'w':
+			nworkers = atoi(optarg);
 			break;
 		case 'p':
 			port = atoi(optarg);
@@ -276,12 +298,14 @@ int main(int argc, char *argv[])
 	svc_params.request_cb = decode_request;
 	svc_params.flags = SVC_INIT_EPOLL | SVC_INIT_NOREG_XPRTS;
 	svc_params.max_events = 512;
+	svc_params.ioq_thrd_max = nworkers;
 
 	if (!svc_init(&svc_params)) {
 		perror("svc_init failed");
 		exit(1);
 	}
 
+	rpcping_threads = nthreads;
 	for (i = 0; i < nthreads; i++) {
 		pthread_t t;
 
@@ -289,7 +313,7 @@ int main(int argc, char *argv[])
 			clnt = clnt_ncreate(host, prog, vers, proto);
 			if (CLNT_FAILURE(clnt)) {
 				rpc_perror(&clnt->cl_error,
-					"clnt_ncreate failed");
+					   "clnt_ncreate failed");
 				exit(2);
 			}
 		} else {
@@ -311,7 +335,7 @@ int main(int argc, char *argv[])
 						CLNT_CREATE_FLAG_CLOSE);
 			if (CLNT_FAILURE(clnt)) {
 				rpc_perror(&clnt->cl_error,
-					"clnt_ncreate failed");
+					   "clnt_ncreate failed");
 				exit(4);
 			}
 		}
@@ -323,21 +347,25 @@ int main(int argc, char *argv[])
 		s->count = count;
 		s->proc = proc;
 		pthread_create(&t, NULL, worker, s);
-		(void)atomic_inc_uint32_t(&rpcping_threads);
 	}
 
-	while (atomic_fetch_uint32_t(&rpcping_threads)) {
-		pthread_cond_wait(&rpcpring_cond, &rpcpring_mutex);
-	}
+	pthread_mutex_lock(&rpcping_mutex);
+	pthread_cond_wait(&rpcping_cond, &rpcping_mutex);
+	pthread_mutex_unlock(&rpcping_mutex);
 
 	total = 0.0;
+	elapsed_ns = 0.0;
 	for (i = 0; i < nthreads; i++) {
 		s = &states[i];
-		total += s->averageTime;
+		total += s->responses;
+		elapsed_ns += timespec_elapsed(&s->starting, &s->stopping);
+		CLNT_DESTROY(s->handle);
 	}
+	total *= 1000000000.0;
+	total /= elapsed_ns;
 
-	fprintf(stdout, "rpcping %s %s threads=%d count=%d (port=%d program=%d version=%d procedure=%d): %2.4lf, total %2.4lf\n",
-		proto, host, nthreads, count, port, prog, vers, proc,
+	fprintf(stdout, "rpcping %s %s count=%d threads=%d workers=%d (port=%d program=%d version=%d procedure=%d): mean %2.4lf, total %2.4lf\n",
+		proto, host, count, nthreads, nworkers, port, prog, vers, proc,
 		total / nthreads, total);
 	fflush(stdout);
 	return (0);


### PR DESCRIPTION
 * CLOCK_MONOTONIC has to be in the same thread.
 * reduce worker threads closer to number of cores.
 * new parameter -w --workers.
 * surround cond_wait with mutex lock/unlock.
 * also fix misspelling.

Signed-off-by: William Allen Simpson <william.allen.simpson@redhat.com>