### PR TITLE
Minimum worker threads

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -126,6 +126,7 @@ typedef struct svc_init_params {
 	u_int max_events;	/* evchan events */
 	u_int ioq_send_max;
 	u_int ioq_thrd_max;
+	u_int ioq_thrd_min;
 	u_int gss_ctx_hash_partitions;
 	u_int gss_max_ctx;
 	u_int gss_max_idle_gen;

--- a/src/svc_internal.h
+++ b/src/svc_internal.h
@@ -67,6 +67,7 @@ struct svc_params {
 	struct {
 		u_int send_max;
 		u_int thrd_max;
+		u_int thrd_min;
 	} ioq;
 
 	u_long flags;


### PR DESCRIPTION
Bugfix: ensure minimum at least one per (EPOLL) channel, plus at least 2 for work.

Signed-off-by: William Allen Simpson <william.allen.simpson@redhat.com>