### PR TITLE
(work_pool) shutdown bug fixes

### DIFF
--- a/ntirpc/rpc/work_pool.h
+++ b/ntirpc/rpc/work_pool.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2015 CohortFS, LLC.
+ * Copyright (c) 2013-2018 Red Hat, Inc. and/or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -54,6 +55,7 @@ struct work_pool {
 	char *name;
 	pthread_attr_t attr;
 	struct work_pool_params params;
+	long timeout_ms;
 	uint32_t n_threads;
 	uint32_t worker_index;
 };


### PR DESCRIPTION
 * Straighten code for easier analysis.
 * Ensure max >= min on startup.
 * Always remove entry from pool queue after all signals!

During shutdown:
 * Reduce cond_timedwait.
 * Signal threads only once.
 * Reduce nanosleep().

Reported-by: Dominique Martinet <Dominique.MARTINET@cea.fr>
Signed-off-by: William Allen Simpson <william.allen.simpson@redhat.com>