### PR TITLE
timespec: fix timespec to ms helper

### DIFF
--- a/ntirpc/misc/timespec.h
+++ b/ntirpc/misc/timespec.h
@@ -35,7 +35,7 @@
 
 /* Convert to coarse milliseconds with round up */
 #define timespec_ms(tsp) \
-	((tsp)->tv_sec * 1000 + ((tsp)->tv_nsec + 999999) % 1000000)
+	((tsp)->tv_sec * 1000 + ((tsp)->tv_nsec + 999999) / 1000000)
 
 /* Operations on timespecs */
 #define timespecclear(tvp)      ((tvp)->tv_sec = (tvp)->tv_nsec = 0)


### PR DESCRIPTION
this causes issues when recalling delegations in nfs-ganesha
rpc replies are randomly assumed timed out because timespec_ms returns wrong values