### PR TITLE
xdr_bytes_decode - only free if we allocated

### DIFF
--- a/ntirpc/rpc/xdr_inline.h
+++ b/ntirpc/rpc/xdr_inline.h
@@ -607,7 +607,10 @@ xdr_bytes_decode(XDR *xdrs, char **cpp, u_int *sizep, u_int maxsize)
 
 	ret = xdr_opaque_decode(xdrs, sp, size);
 	if (!ret) {
-		mem_free(sp, size);
+		if (!*cpp) {
+			/* Only free if we allocated */
+			mem_free(sp, size);
+		}
 		return (ret);
 	}
 	*cpp = sp;			/* only valid pointer */


### PR DESCRIPTION
On error, we free the memory we allocated.  However, the user is allowed
to pass in memory, which may not be on the heap, so only free if we
allocated.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>