### PR TITLE
Cleanups and bugfixes for 1.7

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2009, Sun Microsystems, Inc.
- * Copyright (c) 2012-2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2012-2018 Red Hat, Inc. and/or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -264,7 +264,7 @@ struct svc_xprt {
 	int xp_si_type;		/* si type */
 	int xp_type;		/* xprt type */
 
-	uint32_t xp_refs;	/* handle reference count */
+	int32_t xp_refcnt;	/* handle reference count */
 	uint16_t xp_flags;	/* flags */
 };
 
@@ -317,7 +317,7 @@ struct svc_req {
 	/* blkin tracing */
 	struct blkin_trace bl_trace;
 #endif
-	uint32_t rq_refs;
+	uint32_t rq_refcnt;
 };
 
 /*
@@ -372,15 +372,15 @@ __END_DECLS
 	if (((req)->rq_xprt)->xp_ops->xp_checksum) \
 		(*((req)->rq_xprt)->xp_ops->xp_checksum)(req, what, length)
 
-/* Protect a SVCXPRT with a SVC_REF for each call or request.
+/* Protect a SVCXPRT with SVC_REF() for each call, request, or task thread.
  */
 static inline void svc_ref_it(SVCXPRT *xprt, u_int flags,
 			      const char *tag, const int line)
 {
 #ifdef USE_LTTNG_NTIRPC
-	uint32_t refs =
+	int32_t refs =
 #endif /* USE_LTTNG_NTIRPC */
-		atomic_inc_uint32_t(&xprt->xp_refs);
+		atomic_inc_int32_t(&xprt->xp_refcnt);
 
 	if (flags & SVC_REF_FLAG_LOCKED)  {
 		/* unlock before warning trace */
@@ -396,10 +396,14 @@ static inline void svc_ref_it(SVCXPRT *xprt, u_int flags,
 #define SVC_REF(xprt, flags)						\
 	svc_ref_it(xprt, flags, __func__, __LINE__)
 
+/* SVC_RELEASE() the SVC_REF().
+ * Idempotent SVC_XPRT_FLAG_DESTROYED (bit SVC_XPRT_FLAG_RELEASING)
+ * indicates that more references should not be taken.
+ */
 static inline void svc_release_it(SVCXPRT *xprt, u_int flags,
 				  const char *tag, const int line)
 {
-	uint32_t refs = atomic_dec_uint32_t(&xprt->xp_refs);
+	int32_t refs = atomic_dec_int32_t(&xprt->xp_refcnt);
 	uint16_t xp_flags;
 
 	if (flags & SVC_RELEASE_FLAG_LOCKED) {
@@ -433,8 +437,9 @@ static inline void svc_release_it(SVCXPRT *xprt, u_int flags,
 #define SVC_RELEASE(xprt, flags)					\
 	svc_release_it(xprt, flags, __func__, __LINE__)
 
-/* SVC_DESTROY is SVC_RELEASE with once-only semantics.  Also, idempotent
- * SVC_XPRT_FLAG_DESTROYED indicates that more references should not be taken.
+/* SVC_DESTROY() is SVC_RELEASE() with once-only semantics.
+ * Idempotent SVC_XPRT_FLAG_DESTROYED (bit SVC_XPRT_FLAG_DESTROYING)
+ * indicates that more references should not be taken.
  */
 static inline void svc_destroy_it(SVCXPRT *xprt,
 				  const char *tag, const int line)

--- a/src/clnt_generic.c
+++ b/src/clnt_generic.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010, Oracle America, Inc.
- * Copyright (c) 2012-2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2012-2018 Red Hat, Inc. and/or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -665,15 +665,19 @@ clnt_req_wait_reply(struct clnt_req *cc)
 int
 clnt_req_release(struct clnt_req *cc)
 {
-	uint32_t refs = atomic_dec_uint32_t(&cc->cc_refs);
+	int refs = atomic_dec_int32_t(&cc->cc_refcnt);
 
-	if (refs)
+	if (likely(refs > 0)) {
+		/* normal case */
 		return (refs);
+	}
 
 	clnt_req_reset(cc);
 	clnt_req_fini(cc);
+	CLNT_RELEASE(cc->cc_clnt, CLNT_RELEASE_FLAG_NONE);
+
 	(*cc->cc_free_cb)(cc, cc->cc_size);
-	return (0);
+	return (refs);
 }
 
 /*

--- a/src/clnt_internal.h
+++ b/src/clnt_internal.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 Linux Box Corporation.
- * Copyright (c) 2012-2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2012-2018 Red Hat, Inc. and/or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/rpc_dplx_internal.h
+++ b/src/rpc_dplx_internal.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 Linux Box Corporation.
- * Copyright (c) 2012-2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2012-2018 Red Hat, Inc. and/or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -79,9 +79,9 @@ struct rpc_dplx_rec {
 };
 #define REC_XPRT(p) (opr_containerof((p), struct rpc_dplx_rec, xprt))
 
-#define RPC_DPLX_FLAG_NONE          0x0000
-#define RPC_DPLX_FLAG_LOCKED        0x0001
-#define RPC_DPLX_FLAG_UNLOCK        0x0002
+/* > SVC_XPRT_FLAG_LOCKED */
+#define RPC_DPLX_LOCKED		0x00100000
+#define RPC_DPLX_UNLOCK		0x00200000
 
 #ifndef HAVE_STRLCAT
 extern size_t strlcat(char *, const char *, size_t);

--- a/src/rpc_dplx_internal.h
+++ b/src/rpc_dplx_internal.h
@@ -119,7 +119,7 @@ rpc_dplx_rec_init(struct rpc_dplx_rec *rec)
 	/* Stop this xprt being cleaned immediately */
 	(void)clock_gettime(CLOCK_MONOTONIC_FAST, &(rec->recv.ts));
 
-	rec->xprt.xp_refs = 1;
+	rec->xprt.xp_refcnt = 1;
 }
 
 static inline void

--- a/src/rpc_rdma.c
+++ b/src/rpc_rdma.c
@@ -1366,7 +1366,7 @@ rpc_rdma_allocate(const struct rpc_rdma_attr *xa)
 	xd = mem_zalloc(sizeof(*xd));
 
 	xd->sm_dr.xprt.xp_type = XPRT_RDMA;
-	xd->sm_dr.xprt.xp_refs = 1;
+	xd->sm_dr.xprt.xp_refcnt = 1;
 	xd->sm_dr.xprt.xp_ops = &rpc_rdma_ops;
 
 	xd->xa = xa;

--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -430,13 +430,14 @@ svc_dg_destroy_task(struct work_pool_entry *wpe)
 {
 	struct rpc_dplx_rec *rec =
 			opr_containerof(wpe, struct rpc_dplx_rec, ioq.ioq_wpe);
+	SVCXPRT *xprt = &rec->xprt;
 	uint16_t xp_flags;
 
 	__warnx(TIRPC_DEBUG_FLAG_REFCNT,
-		"%s() %p fd %d xp_refs %" PRIu32,
-		__func__, rec, rec->xprt.xp_fd, rec->xprt.xp_refs);
+		"%s() %p fd %d xp_refcnt %" PRId32,
+		__func__, xprt, xprt->xp_fd, xprt->xp_refcnt);
 
-	if (rec->xprt.xp_refs) {
+	if (rec->xprt.xp_refcnt) {
 		/* instead of nanosleep */
 		work_pool_submit(&svc_work_pool, &(rec->ioq.ioq_wpe));
 		return;
@@ -478,9 +479,8 @@ svc_dg_destroy_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 	}
 
 	__warnx(TIRPC_DEBUG_FLAG_REFCNT,
-		"%s() %p fd %d xp_refs %" PRIu32
-		" should actually destroy things @ %s:%d",
-		__func__, xprt, xprt->xp_fd, xprt->xp_refs, tag, line);
+		"%s() %p fd %d xp_refcnt %" PRId32 " @%s:%d",
+		__func__, xprt, xprt->xp_fd, xprt->xp_refcnt, tag, line);
 
 	while (atomic_postset_uint16_t_bits(&(REC_XPRT(xprt)->ioq.ioq_s.qflags),
 					    IOQ_FLAG_WORKING)

--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -1,7 +1,7 @@
 
 /*
  * Copyright (c) 2009, Sun Microsystems, Inc.
- * Copyright (c) 2012-2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2012-2018 Red Hat, Inc. and/or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -199,7 +199,7 @@ svc_dg_ncreatef(const int fd, const u_int sendsz, const u_int recvsz,
 	     && !(flags & SVC_CREATE_FLAG_XPRT_NOREG))
 	    || (flags & SVC_CREATE_FLAG_XPRT_DOREG))
 		svc_rqst_evchan_reg(__svc_params->ev_u.evchan.id, xprt,
-				    SVC_RQST_FLAG_LOCKED |
+				    RPC_DPLX_LOCKED |
 				    SVC_RQST_FLAG_CHAN_AFFINITY);
 
 	/* release */
@@ -474,7 +474,7 @@ svc_dg_destroy_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 
 	if (!xprt->xp_parent) {
 		/* only original parent is registered */
-		svc_rqst_xprt_unregister(xprt);
+		svc_rqst_xprt_unregister(xprt, flags);
 	}
 
 	__warnx(TIRPC_DEBUG_FLAG_REFCNT,

--- a/src/svc_internal.h
+++ b/src/svc_internal.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012 Linux Box Corporation.
+ * Copyright (c) 2012-2018 Red Hat, Inc. and/or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -150,6 +151,6 @@ svc_override_ops(struct xp_ops *ops, SVCXPRT *rendezvous)
 /* in svc_rqst.c */
 int svc_rqst_rearm_events(SVCXPRT *);
 int svc_rqst_xprt_register(SVCXPRT *, SVCXPRT *);
-void svc_rqst_xprt_unregister(SVCXPRT *);
+void svc_rqst_xprt_unregister(SVCXPRT *, uint32_t);
 
 #endif				/* TIRPC_SVC_INTERNAL_H */

--- a/src/svc_rdma.c
+++ b/src/svc_rdma.c
@@ -226,9 +226,9 @@ svc_rdma_destroy(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 	RDMAXPRT *xd = RDMA_DR(REC_XPRT(xprt));
 
 	__warnx(TIRPC_DEBUG_FLAG_REFCNT,
-		"%s() %p xp_refs %" PRId32
+		"%s() %p xp_refcnt %" PRId32
 		" should actually destroy things @ %s:%d",
-		__func__, xprt, xprt->xp_refs, tag, line);
+		__func__, xprt, xprt->xp_refcnt, tag, line);
 
 	xdr_rdma_destroy(xd);
 

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -81,8 +81,6 @@ struct svc_rqst_rec {
 
 	int sv[2];
 	uint32_t id_k;		/* chan id */
-	uint32_t refcnt;
-	uint16_t flags;
 
 	/*
 	 * union of event processor types
@@ -101,6 +99,9 @@ struct svc_rqst_rec {
 			fd_set set;	/* select/fd_set (currently unhooked) */
 		} fd;
 	} ev_u;
+
+	int32_t ev_refcnt;
+	uint16_t ev_flags;
 };
 
 struct svc_rqst_set {
@@ -184,11 +185,11 @@ svc_rqst_lookup_chan(uint32_t chan_id)
 		return (NULL);
 
 	sr_rec = &svc_rqst_set.srr[chan_id];
-	if (!sr_rec->refcnt)
+	if (atomic_fetch_int32_t(&sr_rec->ev_refcnt) <= 0)
 		return (NULL);
 
-	atomic_inc_uint32_t(&sr_rec->refcnt);
-
+	/* do not pre-increment to avoid accidental new channel */
+	atomic_inc_int32_t(&sr_rec->ev_refcnt);
 	return (sr_rec);
 }
 
@@ -266,10 +267,13 @@ svc_rqst_expire_task(struct work_pool_entry *wpe)
 {
 	struct clnt_req *cc = opr_containerof(wpe, struct clnt_req, cc_wpe);
 
-	if (!(atomic_postset_uint16_t_bits(&cc->cc_flags,
+	if (atomic_fetch_int32_t(&cc->cc_refcnt) > 1
+	 && !(atomic_postset_uint16_t_bits(&cc->cc_flags,
 					   CLNT_REQ_FLAG_BACKSYNC)
 	      & (CLNT_REQ_FLAG_ACKSYNC | CLNT_REQ_FLAG_BACKSYNC))) {
-		/* task switch takes time, response wasn't previously queued */
+		/* (idempotent) cc_flags and cc_refcnt are set atomic.
+		 * cc_refcnt need more than 1 (this task).
+		 */
 		cc->cc_error.re_status = RPC_TIMEDOUT;
 		(*cc->cc_process_cb)(cc);
 	}
@@ -295,7 +299,7 @@ svc_rqst_new_evchan(uint32_t *chan_id /* OUT */, void *u_data, uint32_t flags)
 	n_id = --(svc_rqst_set.next_id);
 	sr_rec = &svc_rqst_set.srr[n_id];
 
-	if (sr_rec->refcnt) {
+	if (atomic_postinc_int32_t(&sr_rec->ev_refcnt) > 0) {
 		/* already exists */
 		*chan_id = n_id;
 		mutex_unlock(&svc_rqst_set.mtx);
@@ -371,13 +375,12 @@ svc_rqst_new_evchan(uint32_t *chan_id /* OUT */, void *u_data, uint32_t flags)
 
 	*chan_id =
 	sr_rec->id_k = n_id;
-	sr_rec->refcnt = 1;	/* svc_rqst_set ref */
-	sr_rec->flags = flags & SVC_RQST_FLAG_MASK;
+	sr_rec->ev_flags = flags & SVC_RQST_FLAG_MASK;
 	opr_rbtree_init(&sr_rec->call_expires, svc_rqst_expire_cmpf);
 	mutex_init(&sr_rec->ev_lock, NULL);
 
 	if (!code) {
-		sr_rec->refcnt = 2;
+		atomic_inc_int32_t(&sr_rec->ev_refcnt);
 		sr_rec->ev_wpe.fun = svc_rqst_run_task;
 		sr_rec->ev_wpe.arg = u_data;
 		work_pool_submit(&svc_work_pool, &sr_rec->ev_wpe);
@@ -394,7 +397,7 @@ svc_rqst_new_evchan(uint32_t *chan_id /* OUT */, void *u_data, uint32_t flags)
 static inline void
 svc_rqst_release(struct svc_rqst_rec *sr_rec)
 {
-	if (atomic_dec_uint32_t(&sr_rec->refcnt))
+	if (atomic_dec_int32_t(&sr_rec->ev_refcnt) > 0)
 		return;
 
 	__warnx(TIRPC_DEBUG_FLAG_SVC_RQST,
@@ -425,23 +428,23 @@ svc_rqst_unhook_events(struct rpc_dplx_rec *rec, struct svc_rqst_rec *sr_rec)
 		if (code) {
 			code = errno;
 			__warnx(TIRPC_DEBUG_FLAG_WARN,
-				"%s: %p fd %d xp_refs %" PRIu32
-				" sr_rec %p evchan %d refcnt %" PRIu32
+				"%s: %p fd %d xp_refcnt %" PRId32
+				" sr_rec %p evchan %d ev_refcnt %" PRId32
 				" epoll_fd %d control fd pair (%d:%d) unhook failed (%d)",
 				__func__, rec, rec->xprt.xp_fd,
-				rec->xprt.xp_refs,
-				sr_rec, sr_rec->id_k, sr_rec->refcnt,
+				rec->xprt.xp_refcnt,
+				sr_rec, sr_rec->id_k, sr_rec->ev_refcnt,
 				sr_rec->ev_u.epoll.epoll_fd,
 				sr_rec->sv[0], sr_rec->sv[1], code);
 		} else {
 			__warnx(TIRPC_DEBUG_FLAG_SVC_RQST |
 				TIRPC_DEBUG_FLAG_REFCNT,
-				"%s: %p fd %d xp_refs %" PRIu32
-				" sr_rec %p evchan %d refcnt %" PRIu32
+				"%s: %p fd %d xp_refcnt %" PRId32
+				" sr_rec %p evchan %d ev_refcnt %" PRId32
 				" epoll_fd %d control fd pair (%d:%d) unhook",
 				__func__, rec, rec->xprt.xp_fd,
-				rec->xprt.xp_refs,
-				sr_rec, sr_rec->id_k, sr_rec->refcnt,
+				rec->xprt.xp_refcnt,
+				sr_rec, sr_rec->id_k, sr_rec->ev_refcnt,
 				sr_rec->ev_u.epoll.epoll_fd,
 				sr_rec->sv[0], sr_rec->sv[1]);
 		}
@@ -471,7 +474,7 @@ svc_rqst_rearm_events(SVCXPRT *xprt)
 		return (0);
 
 	/* MUST follow the destroyed check above */
-	if (sr_rec->flags & SVC_RQST_FLAG_SHUTDOWN)
+	if (sr_rec->ev_flags & SVC_RQST_FLAG_SHUTDOWN)
 		return (0);
 
 	rpc_dplx_rli(rec);
@@ -496,23 +499,23 @@ svc_rqst_rearm_events(SVCXPRT *xprt)
 			atomic_clear_uint16_t_bits(&xprt->xp_flags,
 						   SVC_XPRT_FLAG_ADDED);
 			__warnx(TIRPC_DEBUG_FLAG_ERROR,
-				"%s: %p fd %d xp_refs %" PRIu32
-				" sr_rec %p evchan %d refcnt %" PRIu32
+				"%s: %p fd %d xp_refcnt %" PRId32
+				" sr_rec %p evchan %d ev_refcnt %" PRId32
 				" epoll_fd %d control fd pair (%d:%d) rearm failed (%d)",
 				__func__, rec, rec->xprt.xp_fd,
-				rec->xprt.xp_refs,
-				sr_rec, sr_rec->id_k, sr_rec->refcnt,
+				rec->xprt.xp_refcnt,
+				sr_rec, sr_rec->id_k, sr_rec->ev_refcnt,
 				sr_rec->ev_u.epoll.epoll_fd,
 				sr_rec->sv[0], sr_rec->sv[1], code);
 		} else {
 			__warnx(TIRPC_DEBUG_FLAG_SVC_RQST |
 				TIRPC_DEBUG_FLAG_REFCNT,
-				"%s: %p fd %d xp_refs %" PRIu32
-				" sr_rec %p evchan %d refcnt %" PRIu32
+				"%s: %p fd %d xp_refcnt %" PRId32
+				" sr_rec %p evchan %d ev_refcnt %" PRId32
 				" epoll_fd %d control fd pair (%d:%d) rearm",
 				__func__, rec, rec->xprt.xp_fd,
-				rec->xprt.xp_refs,
-				sr_rec, sr_rec->id_k, sr_rec->refcnt,
+				rec->xprt.xp_refcnt,
+				sr_rec, sr_rec->id_k, sr_rec->ev_refcnt,
 				sr_rec->ev_u.epoll.epoll_fd,
 				sr_rec->sv[0], sr_rec->sv[1]);
 		}
@@ -558,23 +561,23 @@ svc_rqst_hook_events(struct rpc_dplx_rec *rec, struct svc_rqst_rec *sr_rec)
 			atomic_clear_uint16_t_bits(&rec->xprt.xp_flags,
 						   SVC_XPRT_FLAG_ADDED);
 			__warnx(TIRPC_DEBUG_FLAG_ERROR,
-				"%s: %p fd %d xp_refs %" PRIu32
-				" sr_rec %p evchan %d refcnt %" PRIu32
+				"%s: %p fd %d xp_refcnt %" PRId32
+				" sr_rec %p evchan %d ev_refcnt %" PRId32
 				" epoll_fd %d control fd pair (%d:%d) hook failed (%d)",
 				__func__, rec, rec->xprt.xp_fd,
-				rec->xprt.xp_refs,
-				sr_rec, sr_rec->id_k, sr_rec->refcnt,
+				rec->xprt.xp_refcnt,
+				sr_rec, sr_rec->id_k, sr_rec->ev_refcnt,
 				sr_rec->ev_u.epoll.epoll_fd,
 				sr_rec->sv[0], sr_rec->sv[1], code);
 		} else {
 			__warnx(TIRPC_DEBUG_FLAG_SVC_RQST |
 				TIRPC_DEBUG_FLAG_REFCNT,
-				"%s: %p fd %d xp_refs %" PRIu32
-				" sr_rec %p evchan %d refcnt %" PRIu32
+				"%s: %p fd %d xp_refcnt %" PRId32
+				" sr_rec %p evchan %d ev_refcnt %" PRId32
 				" epoll_fd %d control fd pair (%d:%d) hook",
 				__func__, rec, rec->xprt.xp_fd,
-				rec->xprt.xp_refs,
-				sr_rec, sr_rec->id_k, sr_rec->refcnt,
+				rec->xprt.xp_refcnt,
+				sr_rec, sr_rec->id_k, sr_rec->ev_refcnt,
 				sr_rec->ev_u.epoll.epoll_fd,
 				sr_rec->sv[0], sr_rec->sv[1]);
 		}
@@ -700,7 +703,7 @@ svc_rqst_xprt_register(SVCXPRT *newxprt, SVCXPRT *xprt)
 					   SVC_RQST_FLAG_CHAN_AFFINITY);
 
 	/* if round robin policy, begin with global/legacy event channel */
-	if (!(sr_rec->flags & SVC_RQST_FLAG_CHAN_AFFINITY)) {
+	if (!(sr_rec->ev_flags & SVC_RQST_FLAG_CHAN_AFFINITY)) {
 		int code = svc_rqst_evchan_reg(round_robin, newxprt,
 					       SVC_RQST_FLAG_NONE);
 
@@ -754,10 +757,11 @@ svc_rqst_xprt_task(struct work_pool_entry *wpe)
 
 	atomic_clear_uint16_t_bits(&rec->ioq.ioq_s.qflags, IOQ_FLAG_WORKING);
 
-	if (rec->xprt.xp_refs > 1
+	/* atomic barrier (above) should protect following values */
+	if (rec->xprt.xp_refcnt > 1
 	 && !(rec->xprt.xp_flags & SVC_XPRT_FLAG_DESTROYED)) {
-		/* (idempotent) xp_flags and xp_refs are set atomic.
-		 * xp_refs need more than 1 (this task).
+		/* (idempotent) xp_flags and xp_refcnt are set atomic.
+		 * xp_refcnt need more than 1 (this task).
 		 */
 		(void)clock_gettime(CLOCK_MONOTONIC_FAST, &(rec->recv.ts));
 		(void)SVC_RECV(&rec->xprt);
@@ -871,19 +875,19 @@ svc_rqst_epoll_event(struct svc_rqst_rec *sr_rec, struct epoll_event *ev)
 
 	__warnx(TIRPC_DEBUG_FLAG_SVC_RQST |
 		TIRPC_DEBUG_FLAG_REFCNT,
-		"%s: %p fd %d xp_refs %" PRIu32
+		"%s: %p fd %d xp_refcnt %" PRId32
 		" event %d",
-		__func__, rec, rec->xprt.xp_fd, rec->xprt.xp_refs,
+		__func__, rec, rec->xprt.xp_fd, rec->xprt.xp_refcnt,
 		ev->events);
 
-	if (rec->xprt.xp_refs > 1
+	if (rec->xprt.xp_refcnt > 1
 	 && (xp_flags & SVC_XPRT_FLAG_ADDED)
 	 && !(xp_flags & SVC_XPRT_FLAG_DESTROYED)
 	 && !(atomic_postset_uint16_t_bits(&rec->ioq.ioq_s.qflags,
 					   IOQ_FLAG_WORKING)
 	      & IOQ_FLAG_WORKING)) {
-		/* (idempotent) xp_flags and xp_refs are set atomic.
-		 * xp_refs need more than 1 (this event).
+		/* (idempotent) xp_flags and xp_refcnt are set atomic.
+		 * xp_refcnt need more than 1 (this event).
 		 */
 		return (rec);
 	}
@@ -927,7 +931,7 @@ svc_rqst_epoll_events(struct svc_rqst_rec *sr_rec, int n_events)
 	}
 
 	/* submit another task to handle events in order */
-	atomic_inc_uint32_t(&sr_rec->refcnt);
+	atomic_inc_int32_t(&sr_rec->ev_refcnt);
 	work_pool_submit(&svc_work_pool, &sr_rec->ev_wpe);
 
 	/* in most cases have only one event, use this hot thread */
@@ -976,7 +980,7 @@ svc_rqst_epoll_loop(struct svc_rqst_rec *sr_rec)
 			opr_rbtree_remove(&sr_rec->call_expires, &cc->cc_rqst);
 			cc->cc_expire_ms = 0;	/* atomic barrier(s) */
 
-			atomic_inc_uint32_t(&cc->cc_refs);
+			atomic_inc_uint32_t(&cc->cc_refcnt);
 			cc->cc_wpe.fun = svc_rqst_expire_task;
 			cc->cc_wpe.arg = NULL;
 			work_pool_submit(&svc_work_pool, &cc->cc_wpe);
@@ -994,7 +998,7 @@ svc_rqst_epoll_loop(struct svc_rqst_rec *sr_rec)
 				      sr_rec->ev_u.epoll.max_events,
 				      timeout_ms);
 
-		if (unlikely(sr_rec->flags & SVC_RQST_FLAG_SHUTDOWN)) {
+		if (unlikely(sr_rec->ev_flags & SVC_RQST_FLAG_SHUTDOWN)) {
 			__warnx(TIRPC_DEBUG_FLAG_SVC_RQST,
 				"%s: epoll_fd %d epoll_wait shutdown (%d)",
 				__func__,
@@ -1066,7 +1070,7 @@ svc_rqst_run_task(struct work_pool_entry *wpe)
 		 *	+1	this work_pool thread
 		 * so, DROP one here so the final release will go to 0.
 		 */
-		atomic_dec_uint32_t(&sr_rec->refcnt);	/* svc_rqst_set */
+		atomic_dec_int32_t(&sr_rec->ev_refcnt);	/* svc_rqst_set */
 	}
 	svc_rqst_release(sr_rec);
 }
@@ -1103,7 +1107,7 @@ svc_rqst_delete_evchan(uint32_t chan_id)
 	if (!sr_rec) {
 		return (ENOENT);
 	}
-	atomic_set_uint16_t_bits(&sr_rec->flags, SVC_RQST_FLAG_SHUTDOWN);
+	atomic_set_uint16_t_bits(&sr_rec->ev_flags, SVC_RQST_FLAG_SHUTDOWN);
 	ev_sig(sr_rec->sv[0], SVC_RQST_FLAG_SHUTDOWN);
 
 	svc_rqst_release(sr_rec);

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -508,10 +508,10 @@ svc_vc_destroy_task(struct work_pool_entry *wpe)
 	uint16_t xp_flags;
 
 	__warnx(TIRPC_DEBUG_FLAG_REFCNT,
-		"%s() %p fd %d xp_refs %" PRIu32,
-		__func__, rec, rec->xprt.xp_fd, rec->xprt.xp_refs);
+		"%s() %p fd %d xp_refcnt %" PRId32,
+		__func__, rec, rec->xprt.xp_fd, rec->xprt.xp_refcnt);
 
-	if (rec->xprt.xp_refs) {
+	if (rec->xprt.xp_refcnt) {
 		/* instead of nanosleep */
 		work_pool_submit(&svc_work_pool, &(rec->ioq.ioq_wpe));
 		return;
@@ -550,9 +550,8 @@ svc_vc_destroy_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 	svc_rqst_xprt_unregister(xprt, flags);
 
 	__warnx(TIRPC_DEBUG_FLAG_REFCNT,
-		"%s() %p fd %d xp_refs %" PRIu32
-		" should actually destroy things @ %s:%d",
-		__func__, xprt, xprt->xp_fd, xprt->xp_refs, tag, line);
+		"%s() %p fd %d xp_refcnt %" PRId32 " @%s:%d",
+		__func__, xprt, xprt->xp_fd, xprt->xp_refcnt, tag, line);
 
 	while (atomic_postset_uint16_t_bits(&(REC_XPRT(xprt)->ioq.ioq_s.qflags),
 					    IOQ_FLAG_WORKING)

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009, Sun Microsystems, Inc.
- * Copyright (c) 2012-2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2012-2018 Red Hat, Inc. and/or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -248,7 +248,7 @@ svc_vc_ncreatef(const int fd, const u_int sendsz, const u_int recvsz,
 	     && !(flags & SVC_CREATE_FLAG_XPRT_NOREG))
 	    || (flags & SVC_CREATE_FLAG_XPRT_DOREG))
 		svc_rqst_evchan_reg(__svc_params->ev_u.evchan.id, xprt,
-				    SVC_RQST_FLAG_LOCKED |
+				    RPC_DPLX_LOCKED |
 				    SVC_RQST_FLAG_CHAN_AFFINITY);
 
 	/* release */
@@ -547,8 +547,7 @@ svc_vc_destroy_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 		.tv_nsec = 0,
 	};
 
-	/* clears xprt from the xprt table (eg, idle scans) */
-	svc_rqst_xprt_unregister(xprt);
+	svc_rqst_xprt_unregister(xprt, flags);
 
 	__warnx(TIRPC_DEBUG_FLAG_REFCNT,
 		"%s() %p fd %d xp_refs %" PRIu32

--- a/src/svc_xprt.c
+++ b/src/svc_xprt.c
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2012 Linux Box Corporation.
- * Copyright (c) 2013-2015 CohortFS, LLC.
- * Copyright (c) 2017 Red Hat, Inc.
+ * Copyright (c) 2013-2018 Red Hat, Inc. and/or its affiliates.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -133,7 +132,7 @@ svc_xprt_init_failure(void)
 }
 
 /*
- * On success, returns with RPC_DPLX_FLAG_LOCKED
+ * On success, returns with RPC_DPLX_LOCKED
  */
 SVCXPRT *
 svc_xprt_lookup(int fd, svc_xprt_setup_t setup)

--- a/src/svc_xprt.c
+++ b/src/svc_xprt.c
@@ -170,7 +170,7 @@ svc_xprt_lookup(int fd, svc_xprt_setup_t setup)
 					__svc_params->max_connections);
 				return (NULL);
 			}
-			(*setup)(&xprt); /* zalloc, xp_refs = 1 */
+			(*setup)(&xprt); /* zalloc, xp_refcnt = 1 */
 			xprt->xp_fd = fd;
 			xprt->xp_flags = SVC_XPRT_FLAG_INITIAL;
 
@@ -366,7 +366,7 @@ svc_xprt_shutdown()
 			/* prevent repeats, see svc_xprt_clear() */
 			opr_rbtree_remove(&t->t, &rec->fd_node);
 
-			/* fd_node is counted by initial xp_refs = 1,
+			/* fd_node is counted by initial xp_refcnt = 1,
 			 * SVC_DESTROY() decrements that reference.
 			 */
 			rwlock_unlock(&t->lock);
@@ -387,9 +387,9 @@ void
 svc_xprt_trace(SVCXPRT *xprt, const char *func, const char *tag, const int line)
 {
 	__warnx(TIRPC_DEBUG_FLAG_REFCNT,
-		"%s() %p fd %d xp_refs %" PRId32
-		" af %u port %u @ %s:%d",
-		func, xprt, xprt->xp_fd, xprt->xp_refs,
+		"%s() %p fd %d xp_refcnt %" PRId32
+		" af %u port %u @%s:%d",
+		func, xprt, xprt->xp_fd, xprt->xp_refcnt,
 		xprt->xp_remote.ss.ss_family,
 		__rpc_address_port(&xprt->xp_remote),
 		tag, line);

--- a/tests/rpcping.c
+++ b/tests/rpcping.c
@@ -203,7 +203,7 @@ decode_request(SVCXPRT *xprt, XDR *xdrs)
 	SVC_REF(xprt, SVC_REF_FLAG_NONE);
 	req->rq_xprt = xprt;
 	req->rq_xdrs = xdrs;
-	req->rq_refs = 1;
+	req->rq_refcnt = 1;
 
 	stat = SVC_DECODE(req);
 


### PR DESCRIPTION
Clean up a lock flag that was used twice, and fix a bug which could unlock a lock we didn't take

Convert refcounts to integers, to allow catching negative refcounts.