### PR TITLE
xdr_ioq: fix memory leak on FreeBSD

### DIFF
--- a/src/xdr_ioq.c
+++ b/src/xdr_ioq.c
@@ -721,6 +721,7 @@ xdr_ioq_destroy(struct xdr_ioq *xioq, size_t qsize)
 		return;
 	}
 	poolq_head_destroy(&xioq->ioq_uv.uvqh);
+	pthread_cond_destroy(&xioq->ioq_cond);
 
 	if (xioq->xdrs[0].x_flags & XDR_FLAG_FREE) {
 		mem_free(xioq, qsize);


### PR DESCRIPTION
pthread_cond object should be destroyed

Signed-off-by: Fatih Acar <fatih.acar@gandi.net>