### PR TITLE
Export authnone_create_dummy for error handling in Ganesha

### DIFF
--- a/src/libntirpc.map.in.cmake
+++ b/src/libntirpc.map.in.cmake
@@ -43,6 +43,7 @@ NTIRPC_${NTIRPC_VERSION} {
     authgss_get_private_data;
     authgss_service;
     authnone_ncreate;
+    authnone_ncreate_dummy;
     authunix_ncreate;
     authunix_ncreate_default;
 


### PR DESCRIPTION
Signed-off-by: Daniel Gryniewicz <dang@redhat.com>