### PR TITLE
Make the number of send queues configurable

### DIFF
--- a/src/svc.c
+++ b/src/svc.c
@@ -183,13 +183,12 @@ svc_init(svc_init_params *params)
 	if (__svc_params->ioq.thrd_max < params->ioq_thrd_max)
 		__svc_params->ioq.thrd_max = params->ioq_thrd_max;
 
-	svc_ioq_init();
-
 	work_pool_params.thrd_min = __svc_params->ioq.thrd_min + channels;
 	work_pool_params.thrd_max = __svc_params->ioq.thrd_max;
 	if (work_pool_params.thrd_max < work_pool_params.thrd_min)
 		work_pool_params.thrd_max = work_pool_params.thrd_min;
 
+	svc_ioq_init();
 	if (work_pool_init(&svc_work_pool, "svc_", &work_pool_params)) {
 		mutex_unlock(&__svc_params->mtx);
 		return false;


### PR DESCRIPTION
xp_ifindex defaults to zero for all sockets and all responses go to a
single queue leading to just one thread doing the replies. If a slow
client sends too many READ requests, the lone sender thread would be
diligently waiting in writev() call affecting other clients.

The number of send queues should be a power of 2 for quick hashing, so
it is rounded down from half of svc_work_pool.params.thrd_max. Deleted
xp_ifindex and instead used socket file descriptor for hashing.