### PR TITLE
svc_xprt_lookup - Add extra ref on create

### DIFF
--- a/src/svc_xprt.c
+++ b/src/svc_xprt.c
@@ -174,6 +174,9 @@ svc_xprt_lookup(int fd, svc_xprt_setup_t setup)
 			xprt->xp_fd = fd;
 			xprt->xp_flags = SVC_XPRT_FLAG_INITIAL;
 
+			/* Get ref for caller */
+			SVC_REF(xprt, SVC_REF_FLAG_NONE);
+
 			rec = REC_XPRT(xprt);
 			rpc_dplx_rli(rec);
 			if (opr_rbtree_insert(&t->t, &rec->fd_node)) {


### PR DESCRIPTION
An xprt has a ref for the hash table (that's released by SVC_DESTROY());
but when it's first created, only 1 ref was taken, so there wasn't a ref
for the caller.

Add an extra ref for the caller when the xprt is first created.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>