### PR TITLE
Make URCU a mandatory dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,8 @@ include_directories(BEFORE
   "${EXTRA_INCLUDE_DIR}"
 )
 
+find_library(LIBURCU urcu)
+
 # Find misc system libs
 find_library(LIBRT rt)   # extended Pthreads functions
 
@@ -188,6 +190,7 @@ set(SYSTEM_LIBRARIES
   ${KRB5_LIBRARIES}
   ${SYSTEM_LIBRARIES}
   ${LIBRT}
+  ${LIBURCU}
 )
 
 if (NOT FREEBSD)

--- a/cmake/modules/FindLTTng.cmake
+++ b/cmake/modules/FindLTTng.cmake
@@ -40,10 +40,9 @@ find_path(LTTNG_LIBRARY_DIR
           DOC "The LTTng libraries")
 
 find_library(LTTNG_UST_LIBRARY lttng-ust PATHS ${LTTNG_LIBRARY_DIR})
-find_library(URCU_LIBRARY urcu-bp PATHS ${LTTNG_LIBRARY_DIR})
 find_library(UUID_LIBRARY uuid)
 
-set(LTTNG_LIBRARIES ${LTTNG_UST_LIBRARY} ${URCU_LIBRARY} ${UUID_LIBRARY})
+set(LTTNG_LIBRARIES ${LTTNG_UST_LIBRARY} ${UUID_LIBRARY})
 
 find_path(LTTNG_CTL_INCLUDE_DIR
           NAMES lttng/lttng.h

--- a/src/rpc_rdma.c
+++ b/src/rpc_rdma.c
@@ -51,6 +51,7 @@
 #include <unistd.h>	//fcntl
 #include <fcntl.h>	//fcntl
 #include <sys/epoll.h>
+#include <urcu.h>
 
 #define EPOLL_SIZE (10)
 /*^ expected number of fd, must be > 0 */
@@ -571,6 +572,7 @@ rpc_rdma_stats_thread(void *arg)
 	int n;
 	int rc;
 
+	rcu_register_thread();
 	while (rpc_rdma_state.run_count > 0) {
 		n = epoll_wait(rpc_rdma_state.stats_epollfd,
 				epoll_events, EPOLL_EVENTS, EPOLL_WAIT_MS);
@@ -634,7 +636,7 @@ rpc_rdma_stats_thread(void *arg)
 			rc = close(childfd);
 		}
 	}
-
+	rcu_unregister_thread();
 	pthread_exit(NULL);
 }
 
@@ -836,6 +838,7 @@ rpc_rdma_cq_thread(void *arg)
 	int n;
 	int rc;
 
+	rcu_register_thread();
 	while (rpc_rdma_state.run_count > 0) {
 		n = epoll_wait(rpc_rdma_state.cq_epollfd,
 				epoll_events, EPOLL_EVENTS, EPOLL_WAIT_MS);
@@ -895,7 +898,7 @@ rpc_rdma_cq_thread(void *arg)
 			mutex_unlock(&xprt->cm_lock);
 		}
 	}
-
+	rcu_unregister_thread();
 	pthread_exit(NULL);
 }
 
@@ -1091,6 +1094,7 @@ rpc_rdma_cm_thread(void *nullarg)
 	int n;
 	int rc;
 
+	rcu_register_thread();
 	while (rpc_rdma_state.run_count > 0) {
 		n = epoll_wait(rpc_rdma_state.cm_epollfd,
 				epoll_events, EPOLL_EVENTS, EPOLL_WAIT_MS);
@@ -1166,7 +1170,7 @@ rpc_rdma_cm_thread(void *nullarg)
 				SVC_DESTROY(&cm_xprt->sm_dr.xprt);
 		}
 	}
-
+	rcu_unregister_thread();
 	pthread_exit(NULL);
 }
 

--- a/src/work_pool.c
+++ b/src/work_pool.c
@@ -55,6 +55,7 @@
 #include <string.h>
 #include <errno.h>
 #include <intrinsic.h>
+#include <urcu.h>
 
 #include <rpc/work_pool.h>
 
@@ -149,6 +150,8 @@ work_pool_thread(void *arg)
 	int rc;
 	bool spawn;
 
+	rcu_register_thread();
+
 	pthread_cond_init(&wpt->pqcond, NULL);
 	pthread_mutex_lock(&pool->pqh.qmutex);
 	TAILQ_INSERT_TAIL(&pool->wptqh, wpt, wptq);
@@ -238,6 +241,7 @@ work_pool_thread(void *arg)
 		__func__, wpt->worker_name);
 	cond_destroy(&wpt->pqcond);
 	mem_free(wpt, sizeof(*wpt));
+	rcu_unregister_thread();
 
 	return (NULL);
 }


### PR DESCRIPTION
In nfs-ganesha, there are some places where read-copy-update (RCU) would
be very useful. There is a (quite nice) library for doing RCU in
userspace called liburcu. When we build with LTTng, it gets built in
automatically, but otherwise it isn't.

This patch changes cmake to always link against liburcu, making it a
mandatory dependency. As part of this, we remove the cmake goop that
is checks for it when LTTng is enabled.

This means that we need to ensure that any thread that could possibly
call rcu_read_lock() register itself and unregister at exit. This patch
takes the conservative approach and registers and unregisters all
pthreads that get created.

Signed-off-by: Jeff Layton <jlayton@redhat.com>