### PR TITLE
Fix addr size check in clnt_dg_control()

### DIFF
--- a/src/clnt_dg.c
+++ b/src/clnt_dg.c
@@ -332,7 +332,7 @@ clnt_dg_control(CLIENT *clnt, u_int request, void *info)
 		break;
 	case CLSET_SVC_ADDR:	/* set to new address */
 		addr = (struct netbuf *)info;
-		if (addr->len < sizeof(cu->cu_raddr)) {
+		if (addr->len > sizeof(cu->cu_raddr)) {
 			rslt = false;
 			break;
 


### PR DESCRIPTION
The check to see if the given address will fit in the storage is
backwards.  Fix it, so that IPv4 can fit in the storage, and so that a
huge address doesn't overflow.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>