### PR TITLE
Update timespec macros

### DIFF
--- a/ntirpc/misc/timespec.h
+++ b/ntirpc/misc/timespec.h
@@ -40,19 +40,24 @@
 /* Operations on timespecs */
 #define timespecclear(tvp)      ((tvp)->tv_sec = (tvp)->tv_nsec = 0)
 #define timespecisset(tvp)      ((tvp)->tv_sec || (tvp)->tv_nsec)
-#define timespeccmp(tvp, uvp, cmp)		\
-	(((tvp)->tv_sec == (uvp)->tv_sec) ?	\
-	 ((tvp)->tv_nsec cmp(uvp)->tv_nsec) :	\
-	 ((tvp)->tv_sec cmp(uvp)->tv_sec))
-#define timespecadd(vvp, uvp)				\
-	do {						\
-		(vvp)->tv_sec += (uvp)->tv_sec;		\
-		(vvp)->tv_nsec += (uvp)->tv_nsec;	\
-		if ((vvp)->tv_nsec >= 1000000000) {	\
-			(vvp)->tv_sec++;		\
-			(vvp)->tv_nsec -= 1000000000;	\
-		}					\
+#ifndef timespeccmp
+#define timespeccmp(tvp, uvp, cmp)					\
+	(((tvp)->tv_sec == (uvp)->tv_sec) ?				\
+	    ((tvp)->tv_nsec cmp (uvp)->tv_nsec) :			\
+	    ((tvp)->tv_sec cmp (uvp)->tv_sec))
+#endif	/* timespeccmp */
+#ifndef timespecadd
+#define timespecadd(tsp, usp, vsp)					\
+	do {								\
+		(vsp)->tv_sec = (tsp)->tv_sec + (usp)->tv_sec;		\
+		(vsp)->tv_nsec = (tsp)->tv_nsec + (usp)->tv_nsec;	\
+		if ((vsp)->tv_nsec >= 1000000000L) {			\
+			(vsp)->tv_sec++;				\
+			(vsp)->tv_nsec -= 1000000000L;			\
+		}							\
 	} while (0)
+#endif	/* timespecadd */
+
 #define timespec_adds(vvp, s)			\
 	do {					\
 		(vvp)->tv_sec += s;		\
@@ -67,13 +72,17 @@
 			(vvp)->tv_nsec -= 1000000000;		\
 		}						\
 	} while (0)
-#define timespecsub(vvp, uvp)				\
-	do {						\
-		(vvp)->tv_sec -= (uvp)->tv_sec;		\
-		(vvp)->tv_nsec -= (uvp)->tv_nsec;	\
-		if ((vvp)->tv_nsec < 0) {		\
-			(vvp)->tv_sec--;		\
-			(vvp)->tv_nsec += 1000000000;	\
-		}					\
+
+#ifndef timespecsub
+#define timespecsub(tsp, usp, vsp)					\
+	do {								\
+		(vsp)->tv_sec = (tsp)->tv_sec - (usp)->tv_sec;		\
+		(vsp)->tv_nsec = (tsp)->tv_nsec - (usp)->tv_nsec;	\
+		if ((vsp)->tv_nsec < 0) {				\
+			(vsp)->tv_sec--;				\
+			(vsp)->tv_nsec += 1000000000L;			\
+		}							\
 	} while (0)
+#endif /* timespecsub */
+
 #endif				/* TIMESPEC_H */

--- a/src/clnt_generic.c
+++ b/src/clnt_generic.c
@@ -639,7 +639,7 @@ clnt_req_wait_reply(struct clnt_req *cc)
 	}
 
 	(void)clock_gettime(CLOCK_REALTIME_FAST, &ts);
-	timespecadd(&ts, &cc->cc_timeout);
+	timespecadd(&ts, &cc->cc_timeout, &ts);
 	code = cond_timedwait(&cc->cc_we.cv, &cc->cc_we.mtx, &ts);
 
 	__warnx(TIRPC_DEBUG_FLAG_CLNT_REQ,

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -222,7 +222,7 @@ svc_rqst_expire_ms(struct timespec *to)
 
 	/* coarse nsec, not system time */
 	(void)clock_gettime(CLOCK_MONOTONIC_FAST, &ts);
-	timespecadd(&ts, to);
+	timespecadd(&ts, to, &ts);
 	return timespec_ms(&ts);
 }
 


### PR DESCRIPTION
timespec[add|sub|cmp] are now public in FreeBSD 12, these are clashing and preventing compiling. they now have an additional variable similar to NetBSD. We use the system macros by default, otherwise the updated version has been implemented.