### PR TITLE
Force urcu-bp for now

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ include_directories(BEFORE
   "${EXTRA_INCLUDE_DIR}"
 )
 
-find_library(LIBURCU urcu)
+find_library(LIBURCU urcu-bp)
 
 # Find misc system libs
 find_library(LIBRT rt)   # extended Pthreads functions

--- a/src/rpc_rdma.c
+++ b/src/rpc_rdma.c
@@ -51,7 +51,7 @@
 #include <unistd.h>	//fcntl
 #include <fcntl.h>	//fcntl
 #include <sys/epoll.h>
-#include <urcu.h>
+#include <urcu-bp.h>
 
 #define EPOLL_SIZE (10)
 /*^ expected number of fd, must be > 0 */

--- a/src/work_pool.c
+++ b/src/work_pool.c
@@ -55,7 +55,7 @@
 #include <string.h>
 #include <errno.h>
 #include <intrinsic.h>
-#include <urcu.h>
+#include <urcu-bp.h>
 
 #include <rpc/work_pool.h>
 


### PR DESCRIPTION
When _LGPL_SOURCE is defined the lttng headers will inline some of the
RCU functions with the "bulletproof" functions. This means that we can't
currently select a urcu flavor at runtime that will be used universally.
I'm a little unclear on what happens if you mix different flavored urcu
calls, but I doubt that it's anything good.

Let's switch back to using urcu-bp universally for now until this has a
better solution. It's not ideal for performance, but our use of URCU is
pretty minimal for now, and it's better to be safe than fast.

Signed-off-by: Jeff Layton <jlayton@redhat.com>