### PR TITLE
XPRT Refcount fixes

### DIFF
--- a/ntirpc/rpc/clnt.h
+++ b/ntirpc/rpc/clnt.h
@@ -182,6 +182,7 @@ struct rpc_timers {
 #define CLNT_FLAG_DESTROYING		SVC_XPRT_FLAG_DESTROYING
 #define CLNT_FLAG_RELEASING		SVC_XPRT_FLAG_RELEASING
 #define CLNT_FLAG_DESTROYED		SVC_XPRT_FLAG_DESTROYED
+#define CLNT_FLAG_LOCAL			0x8000 /* Client is unshared/local */
 
 /*
  * CLNT_REF flags

--- a/src/clnt_vc.c
+++ b/src/clnt_vc.c
@@ -461,6 +461,11 @@ clnt_vc_destroy(CLIENT *clnt)
 	if (cx->cx_rec) {
 		SVC_RELEASE(&cx->cx_rec->xprt, SVC_RELEASE_FLAG_NONE);
 	}
+	if (clnt->cl_flags & CLNT_FLAG_LOCAL) {
+		/* Local client; destroy the xprt */
+		SVC_DESTROY(&cx->cx_rec->xprt);
+	}
+
 	clnt_vc_data_free(CT_DATA(cx));
 }
 

--- a/src/rpcb_clnt.c
+++ b/src/rpcb_clnt.c
@@ -1311,6 +1311,8 @@ static CLIENT *local_rpcb(const char *tag)
 				  CLNT_CREATE_FLAG_CONNECT);
 
 	if (CLNT_SUCCESS(client)) {
+		/* This is a local client (we created the fd above) */
+		client->cl_flags |= CLNT_FLAG_LOCAL;
 		return client;
 	}
 	t = rpc_sperror(&client->cl_error, tag);

--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -94,6 +94,8 @@ svc_dg_xprt_zalloc(size_t iosz)
 
 	/* Init SVCXPRT locks, etc */
 	rpc_dplx_rec_init(&su->su_dr);
+	/* Extra ref to match TCP */
+	SVC_REF(&su->su_dr.xprt, SVC_REF_FLAG_NONE);
 	xdr_ioq_setup(&su->su_dr.ioq);
 	return (su);
 }
@@ -318,6 +320,7 @@ svc_dg_recv(SVCXPRT *xprt)
 	/* Only after checking SVC_XPRT_FLAG_DESTROYED:
 	 * because SVC_DESTROY() has decremented already.
 	 */
+	SVC_DESTROY(xprt);
 	SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 	return (stat);
 }

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -507,6 +507,8 @@ svc_vc_rendezvous(SVCXPRT *xprt)
 	if (xprt->xp_dispatch.rendezvous_cb(newxprt)
 	 || svc_rqst_xprt_register(newxprt, xprt)) {
 		SVC_DESTROY(newxprt);
+		/* Was never added to epoll */
+		SVC_RELEASE(newxprt, SVC_RELEASE_FLAG_NONE);
 		return (XPRT_DESTROYED);
 	}
 	return (XPRT_IDLE);


### PR DESCRIPTION
XPRT refcounting could leak a ref in some cases.  Fix this by dropping
the extra ref in error cases, and by passing the event ref (which should
have been dropped, because events are oneshot) to the event processor.
    
This fixes the FD depletion while doing mount/unmount in a tight loop