### PR TITLE
Remove allocators from ntirpc_pkg_params

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ project(NTIRPC C)
 
 # version numbers
 set(NTIRPC_MAJOR_VERSION 1)
-set(NTIRPC_MINOR_VERSION 7)
+set(NTIRPC_MINOR_VERSION 8)
 set(NTIRPC_PATCH_LEVEL 1)
 set(VERSION_COMMENT
   "Full-duplex and bi-directional ONC RPC on TCP."

--- a/ntirpc/rpc/types.h
+++ b/ntirpc/rpc/types.h
@@ -159,13 +159,6 @@ typedef int32_t rpc_inline_t;
 
 #define TIRPC_DEBUG_FLAG_CLNT_RPCB      (TIRPC_DEBUG_FLAG_CLNT)
 
-typedef void *(*mem_1_size_t) (size_t,
-	     const char *file, int line, const char *function);
-typedef void *(*mem_2_size_t) (size_t, size_t,
-	     const char *file, int line, const char *function);
-typedef void *(*mem_p_size_t) (void *, size_t,
-	     const char *file, int line, const char *function);
-typedef void (*mem_free_size_t) (void *, size_t);
 typedef void (*mem_format_t) (const char *fmt, ...);
 typedef void (*mem_char_t) (const char *);
 
@@ -177,11 +170,6 @@ typedef struct tirpc_pkg_params {
 	uint32_t other_flags;
 	mem_char_t	thread_name_;
 	mem_format_t	warnx_;
-	mem_free_size_t	free_size_;
-	mem_1_size_t	malloc_;
-	mem_2_size_t	aligned_;
-	mem_2_size_t	calloc_;
-	mem_p_size_t	realloc_;
 } tirpc_pkg_params;
 
 extern tirpc_pkg_params __ntirpc_pkg_params;
@@ -197,22 +185,18 @@ extern tirpc_pkg_params __ntirpc_pkg_params;
 
 #define __debug_flag(flags) (__ntirpc_pkg_params.debug_flags & (flags))
 
-#define mem_alloc(size) __ntirpc_pkg_params.malloc_((size), \
-			__FILE__, __LINE__, __func__)
-#define mem_aligned(align, size) __ntirpc_pkg_params.aligned_((align), (size), \
-			__FILE__, __LINE__, __func__)
-#define mem_calloc(count, size) __ntirpc_pkg_params.calloc_((count), (size), \
-			__FILE__, __LINE__, __func__)
-#define mem_realloc(p, size) __ntirpc_pkg_params.realloc_((p), (size), \
-			__FILE__, __LINE__, __func__)
-#define mem_zalloc(size) __ntirpc_pkg_params.calloc_(1, (size), \
-			__FILE__, __LINE__, __func__)
+#define mem_alloc(size) malloc(size)
+#define mem_calloc(count, size) calloc(count, size)
+#define mem_realloc(p, size) realloc(p, size)
+#define mem_zalloc(size) calloc(1, size)
+#define mem_aligned(align, size) ({ \
+	void *p_; \
+	if (posix_memalign(&p_, align, size) != 0) \
+		abort(); \
+	p_; \
+	})
 
-static inline void
-mem_free(void *p, size_t n)
-{
-	__ntirpc_pkg_params.free_size_(p, n);
-}
+#define mem_free(p, n) free(p)
 
 /*
  * Uses allocator with indirections, if any.
@@ -220,17 +204,7 @@ mem_free(void *p, size_t n)
 
 #include <string.h>
 
-static inline void *
-mem_strdup_(const char *s, const char *file, int line, const char *function)
-{
-	size_t l = strlen(s) + 1;
-	void *t = __ntirpc_pkg_params.malloc_(l, file, line, function);
-
-	memcpy(t, s, l);
-	return (t);
-}
-
-#define mem_strdup(s) mem_strdup_((s), __FILE__, __LINE__, __func__)
+#define mem_strdup(s) strdup(s)
 
 #ifndef _MSC_VER
 #include <sys/time.h>

--- a/src/rpc_generic.c
+++ b/src/rpc_generic.c
@@ -76,66 +76,11 @@ tirpc_thread_name(const char *p)
 	/* do nothing */
 }
 
-static void
-tirpc_free(void *p, size_t unused)
-{
-	free(p);
-}
-
-static void *
-tirpc_malloc(size_t size, const char *file, int line, const char *function)
-{
-	void *r = malloc(size);
-
-	assert(r != NULL);
-	return r;
-}
-
-static void *
-tirpc_aligned(size_t alignment, size_t size, const char *file, int line,
-	      const char *function)
-{
-	void *r;
-
-#if defined(_ISOC11_SOURCE)
-	r = aligned_alloc(alignment, size);
-#else
-	(void) posix_memalign(&r, alignment, size);
-#endif
-	assert(r != NULL);
-	return r;
-}
-
-static void *
-tirpc_calloc(size_t count, size_t size, const char *file, int line,
-	     const char *function)
-{
-	void *r = calloc(count, size);
-
-	assert(r != NULL);
-	return r;
-}
-
-static void *
-tirpc_realloc(void *p, size_t size, const char *file, int line,
-	      const char *function)
-{
-	void *r = realloc(p, size);
-
-	assert(r != NULL);
-	return r;
-}
-
 tirpc_pkg_params __ntirpc_pkg_params = {
 	TIRPC_FLAG_NONE,
 	TIRPC_DEBUG_FLAG_NONE,
 	tirpc_thread_name,
 	warnx,
-	tirpc_free,
-	tirpc_malloc,
-	tirpc_aligned,
-	tirpc_calloc,
-	tirpc_realloc,
 };
 
 bool


### PR DESCRIPTION
Directly using malloc and friends should be better than having our own
functions to trace memory allocations using mtrace/muntrace etc.

Changed minor version to 8.