### PR TITLE
Fix crash in ntirpc for RPCSEC_GSS

### DIFF
--- a/src/svc_auth_gss.c
+++ b/src/svc_auth_gss.c
@@ -660,7 +660,7 @@ _svcauth_gss(struct svc_req *req, bool *no_dispatch)
 	}
 gd_free:
 	mutex_unlock(&gd->lock);
-	if (gd_hashed) {
+	if (gd_hashed && (gc->gc_proc != RPCSEC_GSS_DATA)) {
 		unref_svc_rpc_gss_data(gd);
 		gd_hashed = false;
 	}


### PR DESCRIPTION
Due to recent changes by commit 'Do not use macro "svcauth_gss_return"',
ntirpc code is crashing while handling RPCSEC_GSS_DATA sequence.

Signed-off-by: Sachin Punadikar <psachin@in.ibm.com>