### PR TITLE
Don't attempt to destroy XPRT if CLNT create was unsuccessful

### DIFF
--- a/src/clnt_vc.c
+++ b/src/clnt_vc.c
@@ -460,12 +460,12 @@ clnt_vc_destroy(CLIENT *clnt)
 
 	if (cx->cx_rec) {
 		SVC_RELEASE(&cx->cx_rec->xprt, SVC_RELEASE_FLAG_NONE);
-	}
-	if (clnt->cl_flags & CLNT_FLAG_LOCAL) {
-		/* Local client; destroy the xprt */
-		SVC_DESTROY(&cx->cx_rec->xprt);
-	}
 
+		if (clnt->cl_flags & CLNT_FLAG_LOCAL) {
+			/* Local client; destroy the xprt */
+			SVC_DESTROY(&cx->cx_rec->xprt);
+		}
+	}
 	clnt_vc_data_free(CT_DATA(cx));
 }
 


### PR DESCRIPTION
Currently in clnt_vc_destroy() we call SVC_DESTROY for a XPRT,
but if CLNT (client handle) creation failed then the related
'cx->cx_rec' won't be valid and this will lead to a crash.
Fixed this by calling SVC_DESTROY only when 'cx->cx_rec' is valid.

Signed-off-by: Madhu Thorat <madhu.punjabi@in.ibm.com>