### PR TITLE
In _svcauth_gss() in case of failure set 'req->rq_auth' to NULL

### DIFF
--- a/src/svc_auth_gss.c
+++ b/src/svc_auth_gss.c
@@ -658,6 +658,7 @@ gd_free:
 	if (rc != AUTH_OK) {
 		/* On success, the ref gets returned to the caller */
 		unref_svc_rpc_gss_data(gd);
+		req->rq_auth = NULL;
 	}
 
 cred_free:


### PR DESCRIPTION
Currently in _svcauth_gss() after having a valid 'gd' we increment
'gd->refcnt' and set 'req->rq_auth=gd->auth'.
In case of failure for a valid 'gd' we call unref_svc_rpc_gss_data()
which decrements 'gd->refcnt' and may destroy 'gd' if 'gd->refcnt'
becomes 0. But later on when free_nfs_request() is called, as
'req->rq_auth' is still valid, we call SVCAUTH_RELEASE() which either
leads to a crash if 'gd' was already freed or if 'gd' was not freed
then we decrement 'gd->refcnt' for the second time.
Fixed this by setting 'req->rq_auth=NULL' in case of failure in
_svcauth_gss().

Signed-off-by: Madhu Thorat <madhu.punjabi@in.ibm.com>