### PR TITLE
fix the use of unsafe functions strcpy to strlcpy

### DIFF
--- a/src/clnt_simple.c
+++ b/src/clnt_simple.c
@@ -149,8 +149,8 @@ rpc_call(const char *host,	/* host name */
 		rcp->versnum = versnum;
 		if ((strlen(host) < (size_t) MAXHOSTNAMELEN)
 		    && (strlen(nettype) < (size_t) NETIDLEN)) {
-			(void)strcpy(rcp->host, host);
-			(void)strcpy(rcp->nettype, nettype);
+			(void)strlcpy(rcp->host, host, sizeof(rcp->host));
+			(void)strlcpy(rcp->nettype, nettype, sizeof(rcp->nettype);
 			rcp->valid = 1;
 		} else {
 			rcp->valid = 0;


### PR DESCRIPTION
function 'strcpy' does not check buffer boundaries but outputs to buffer 'rcp->host' of fixed size (64)   
function 'strcpy' does not check buffer boundaries but outputs to buffer 'rcp->nettype' of fixed size 
(32)   
Signed-off-by: luomuyao <luo.muyao@zte.com.cn>   