### PR TITLE
XDR IOQ - Update position to end of XDR

### DIFF
--- a/src/xdr_ioq.c
+++ b/src/xdr_ioq.c
@@ -1129,6 +1129,7 @@ xdr_ioq_allochdrs(XDR *xdrs, u_int start, xdr_vio *vector, int iov_count)
 	int idx = 0;
 	struct xdr_ioq *xioq = XIOQ(xdrs);
 	struct poolq_entry *have;
+	u_int totlen = 0;
 
 	/* update the most recent data length, just in case */
 	xdr_tail_update(xdrs);
@@ -1198,6 +1199,9 @@ xdr_ioq_allochdrs(XDR *xdrs, u_int start, xdr_vio *vector, int iov_count)
 
 		uv = xdr_ioq_use_or_allocate(xioq, &vector[idx], uv);
 
+		/* Record used space */
+		totlen += vector[idx].vio_length;
+
 		/* Advance to next (DATA) buffer */
 		idx++;
 	}
@@ -1219,6 +1223,9 @@ xdr_ioq_allochdrs(XDR *xdrs, u_int start, xdr_vio *vector, int iov_count)
 			"Skipping idx %d for VIO_DATA",
 			idx);
 
+		/* Record used space */
+		totlen += vector[idx].vio_length;
+
 		if (have != NULL) {
 			/* Next buffer exists */
 			uv = IOQ_(have);
@@ -1237,9 +1244,15 @@ xdr_ioq_allochdrs(XDR *xdrs, u_int start, xdr_vio *vector, int iov_count)
 
 		uv = xdr_ioq_use_or_allocate(xioq, &vector[idx], uv);
 
+		/* Record used space */
+		totlen += vector[idx].vio_length;
+
 		/* Next vector buffer */
 		idx++;
 	}
+
+	/* Update position to end of the last buffer */
+	XDR_SETPOS(xdrs, start + totlen);
 
 	return true;
 }


### PR DESCRIPTION
When calling allochdrs(), it needs to update the posision to the end of
the XDR, or else only partial data is sent.  The position had been
previously updated to the location of the length field.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>