### PR TITLE
Add make rpm target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,8 +261,6 @@ configure_file(
 )
 
 if (NOT TARGET dist)
-# Define CPACK component (to deal with sub packages)
-set(CPACK_COMPONENTS_ALL daemon fsal headers )
 set(CPACK_COMPONENT_DAEMON_DISPLAY_NAME "libntirpc")
 
 # Include custom config and cpack module
@@ -273,6 +271,20 @@ set( PKG_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}.tar.gz")
 	add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
 endif (NOT TARGET dist)
 
+if (NOT TARGET rpm)
+add_custom_target( rpm DEPENDS dist)
+add_custom_command(TARGET rpm
+                  COMMAND sh -c "rpmbuild -ta ${PKG_NAME}"
+		  VERBATIM
+		  DEPENDS dist)
+
+set(RPMDEST "--define '_srcrpmdir ${CMAKE_CURRENT_BINARY_DIR}'")
+add_custom_target( srpm DEPENDS dist)
+add_custom_command(TARGET srpm
+                  COMMAND sh -c "rpmbuild ${RPMDEST} -ts ${PKG_NAME}"
+		  VERBATIM
+		  DEPENDS dist)
+endif (NOT TARGET rpm)
 ########### install files ###############
 
 install(FILES  ${PROJECT_BINARY_DIR}/libntirpc.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)

--- a/libntirpc.spec-in.cmake
+++ b/libntirpc.spec-in.cmake
@@ -53,8 +53,8 @@ install -p -m 0755 src/%{name}.so.%{version} %{buildroot}%{_libdir}/
 ln -s %{name}.so.%{version} %{buildroot}%{_libdir}/%{name}.so.1
 ln -s %{name}.so.%{version} %{buildroot}%{_libdir}/%{name}.so
 mkdir -p %{buildroot}%{_includedir}/ntirpc
-cp -a ntirpc %{buildroot}%{_includedir}/
-install -p -m 644 libntirpc.pc %{buildroot}%{_libdir}/pkgconfig/
+
+make DESTDIR=%{buildroot} install
 
 %post -p /sbin/ldconfig
 


### PR DESCRIPTION
Add a make target to build rpms.  Also, do a "make install" in the spec
file to handle the case where the build dir isn't the source dir.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>