### PR TITLE
Make sure auth flavor of response is set

### DIFF
--- a/src/svc_auth.c
+++ b/src/svc_auth.c
@@ -92,6 +92,7 @@ svc_auth_authenticate(struct svc_req *req, bool *no_dispatch)
 	/* VARIABLES PROTECTED BY authsvc_lock: asp, Auths */
 	req->rq_msg.RPCM_ack.ar_verf = _null_auth;
 	cred_flavor = req->rq_msg.cb_cred.oa_flavor;
+	req->rq_msg.RPCM_ack.ar_verf.oa_flavor = cred_flavor;
 	switch (cred_flavor) {
 #ifdef _HAVE_GSSAPI
 	case RPCSEC_GSS:

--- a/src/svc_auth_gss.c
+++ b/src/svc_auth_gss.c
@@ -397,9 +397,6 @@ _svcauth_gss(struct svc_req *req, bool *no_dispatch)
 	OM_uint32 min_stat;
 	enum auth_stat rc = AUTH_OK;
 
-	/* Initialize reply. */
-	req->rq_msg.RPCM_ack.ar_verf = _null_auth;
-
 	/* Unserialize client credentials. */
 	if (req->rq_msg.cb_cred.oa_length <= 0) {
 		return AUTH_BADCRED;


### PR DESCRIPTION
Even if the auth fails, the caller might want to know the auth flavor.
Set the flavor early, so that it's always correct.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>