### PR TITLE
SVC Request Rearm for Send Event

### DIFF
--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -717,7 +717,7 @@ svc_rqst_rearm_events_locked(SVCXPRT *xprt, uint16_t ev_flags)
 		}
 
 		if (ev_flags & SVC_XPRT_FLAG_ADDED_SEND) {
-			ev = &rec->ev_u.epoll.event_recv;
+			ev = &rec->ev_u.epoll.event_send;
 
 			/* set up epoll user data */
 			ev->data.ptr = rec;


### PR DESCRIPTION
Correct ev flags being sent to epoll_ctl to reference event_send
when rearming send events.

Signed-off-by: TweakySolution <nroiger@gmail.com>