### PR TITLE
svc_dg.c: cleanup pktinfo handling

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -273,6 +273,13 @@ struct svc_xprt {
 
 	int32_t xp_refcnt;	/* handle reference count */
 	uint16_t xp_flags;	/* flags */
+
+	union {
+		struct in_pktinfo in;
+#ifdef INET6
+		struct in6_pktinfo in6;
+#endif
+	} xp_pktinfo;
 };
 
 /* Service record used by exported search routines */

--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -382,8 +382,10 @@ svc_dg_reply(struct svc_req *req)
 	XDR *xdrs = rec->ioq.xdrs;
 	struct svc_dg_xprt *su = DG_DR(rec);
 	struct msghdr *msg = &su->su_msghdr;
+	struct cmsghdr* cmsg;
 	struct iovec iov;
 	size_t slen;
+        char msg_control[128];
 
 	if (!xprt->xp_remote.nb.len) {
 		__warnx(TIRPC_DEBUG_FLAG_WARN,
@@ -415,13 +417,29 @@ svc_dg_reply(struct svc_req *req)
 	msg->msg_iov = &iov;
 	msg->msg_iovlen = 1;
 	msg->msg_name = (struct sockaddr *)&xprt->xp_remote.ss;
-	msg->msg_namelen = xprt->xp_remote.nb.len;
-	/* cmsg already set in svc_dg_rendezvous */
+	msg->msg_namelen = sizeof(struct sockaddr_storage);
+	msg->msg_control = msg_control;
+	msg->msg_controllen = sizeof(msg_control);
+	msg->msg_flags = 0;
+
+	cmsg = CMSG_FIRSTHDR(msg);
+	cmsg->cmsg_level = (xprt->xp_local.ss.ss_family == AF_INET)
+		? IPPROTO_IP : IPPROTO_IPV6; /* a.k.a. SOL_IP and SOL_IPV6 */
+	cmsg->cmsg_type = (xprt->xp_local.ss.ss_family == AF_INET)
+		? IP_PKTINFO : IPV6_PKTINFO;
+	*(struct in_pktinfo*)CMSG_DATA(cmsg) =
+		*(struct in_pktinfo*) &xprt->xp_pktinfo;
+	cmsg->cmsg_len = (xprt->xp_local.ss.ss_family == AF_INET)
+		? CMSG_LEN(sizeof(struct in_pktinfo))
+		: CMSG_LEN(sizeof(struct in6_pktinfo));
+	msg->msg_controllen = (xprt->xp_local.ss.ss_family == AF_INET)
+		? CMSG_SPACE(sizeof(struct in_pktinfo))
+		: CMSG_SPACE(sizeof(struct in6_pktinfo));
 
 	if (sendmsg(xprt->xp_fd, msg, 0) != (ssize_t) slen) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
-			"%s: %p fd %d sendmsg failed (will set dead)",
-			__func__, xprt, xprt->xp_fd);
+			"%s: %p fd %d err %d sendmsg failed (will set dead)",
+			__func__, xprt, xprt->xp_fd, errno);
 		return (XPRT_DIED);
 	}
 
@@ -585,22 +603,24 @@ svc_dg_rendezvous_ops(SVCXPRT *xprt)
 void
 svc_dg_enable_pktinfo(int fd, const struct __rpc_sockinfo *si)
 {
-	int val = 1;
+	int on = 1, off = 0;
 
 	switch (si->si_af) {
 	case AF_INET:
 #ifdef SOL_IP
-		(void)setsockopt(fd, SOL_IP, IP_PKTINFO, &val, sizeof(val));
+		(void)setsockopt(fd, SOL_IP, IP_PKTINFO, &on, sizeof(on));
 #endif
 		break;
 
 	case AF_INET6:
 #ifdef SOL_IP
-		(void)setsockopt(fd, SOL_IP, IP_PKTINFO, &val, sizeof(val));
+		(void)setsockopt(fd, SOL_IP, IP_PKTINFO, &on, sizeof(on));
 #endif
 #ifdef SOL_IPV6
 		(void)setsockopt(fd, SOL_IPV6, IPV6_RECVPKTINFO,
-				&val, sizeof(val));
+				 &on, sizeof(on));
+		(void)setsockopt(fd, SOL_IPV6, IPV6_V6ONLY,
+				 &off, sizeof(off));
 #endif
 		break;
 	}
@@ -612,22 +632,13 @@ svc_dg_store_in_pktinfo(struct cmsghdr *cmsg, SVCXPRT *xprt)
 	if (cmsg->cmsg_level == SOL_IP &&
 	    cmsg->cmsg_type == IP_PKTINFO &&
 	    cmsg->cmsg_len >= CMSG_LEN(sizeof(struct in_pktinfo))) {
-		struct in_pktinfo *pkti = (struct in_pktinfo *)
-						CMSG_DATA(cmsg);
-		struct sockaddr_in *daddr = (struct sockaddr_in *)
-						&xprt->xp_local.ss;
-
-		daddr->sin_family = AF_INET;
-#ifdef __FreeBSD__
-		daddr->sin_addr = pkti->ipi_addr;
-#else
-		daddr->sin_addr.s_addr = pkti->ipi_spec_dst.s_addr;
-#endif
+		xprt->xp_pktinfo.in = *(struct in_pktinfo *) CMSG_DATA(cmsg);
+		xprt->xp_local.ss.ss_family = AF_INET;
+		xprt->xp_local.nb.buf = &xprt->xp_pktinfo;
 		xprt->xp_local.nb.len = sizeof(struct sockaddr_in);
 		return 1;
-	} else {
-		return 0;
 	}
+	return 0;
 }
 
 static int
@@ -636,19 +647,14 @@ svc_dg_store_in6_pktinfo(struct cmsghdr *cmsg, SVCXPRT *xprt)
 	if (cmsg->cmsg_level == SOL_IPV6 &&
 	    cmsg->cmsg_type == IPV6_PKTINFO &&
 	    cmsg->cmsg_len >= CMSG_LEN(sizeof(struct in6_pktinfo))) {
-		struct in6_pktinfo *pkti = (struct in6_pktinfo *)
-						CMSG_DATA(cmsg);
-		struct sockaddr_in6 *daddr = (struct sockaddr_in6 *)
-						&xprt->xp_local.ss;
 
-		daddr->sin6_family = AF_INET6;
-		daddr->sin6_addr = pkti->ipi6_addr;
-		daddr->sin6_scope_id = pkti->ipi6_ifindex;
+		xprt->xp_pktinfo.in6 = *(struct in6_pktinfo *) CMSG_DATA(cmsg);
+		xprt->xp_local.ss.ss_family = AF_INET6;
+		xprt->xp_local.nb.buf = &xprt->xp_pktinfo;
 		xprt->xp_local.nb.len = sizeof(struct sockaddr_in6);
 		return 1;
-	} else {
-		return 0;
 	}
+	return 0;
 }
 
 /*
@@ -667,32 +673,25 @@ svc_dg_store_pktinfo(struct msghdr *msg, SVCXPRT *xprt)
 	if (msg->msg_flags & MSG_CTRUNC)
 		return 0;
 
-	cmsg = CMSG_FIRSTHDR(msg);
-	if (cmsg == NULL || CMSG_NXTHDR(msg, cmsg) != NULL)
-		return 0;
+	for (cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL;
+	     cmsg = CMSG_NXTHDR(msg, cmsg)) {
 
-	switch (((struct sockaddr *)msg->msg_name)->sa_family) {
-	case AF_INET:
-#ifdef SOL_IP
-		if (svc_dg_store_in_pktinfo(cmsg, xprt))
-			return 1;
+		if (cmsg->cmsg_level == IPPROTO_IP) {
+#ifdef IP_PKTINFO
+			if (cmsg->cmsg_type == IP_PKTINFO) {
+				if (svc_dg_store_in_pktinfo(cmsg, xprt))
+					return 1;
+			}
 #endif
-		break;
 
-	case AF_INET6:
-#ifdef SOL_IP
-		/* Handle IPv4 PKTINFO as well on IPV6 interface */
-		if (svc_dg_store_in_pktinfo(cmsg, xprt))
-			return 1;
+#ifdef IPV6_PKTINFO
+			if (cmsg->cmsg_type == IPV6_PKTINFO) {
+				if (svc_dg_store_in6_pktinfo(cmsg, xprt))
+					return 1;
+			}
 #endif
-#ifdef SOL_IPV6
-		if (svc_dg_store_in6_pktinfo(cmsg, xprt))
-			return 1;
-#endif
-		break;
-
-	default:
-		break;
+		}
+		
 	}
 
 	return 0;

--- a/src/svc_internal.h
+++ b/src/svc_internal.h
@@ -98,10 +98,11 @@ union pktinfo_u {
  * Replaces old struct svc_dg_data by locally wrapping struct rpc_dplx_rec,
  * which wraps struct svc_xprt indexed by fd.
  */
+#define DG_NUM_PKTINFO 4 /* s/b enough space for all pktinfos in normal case*/
 struct svc_dg_xprt {
 	struct rpc_dplx_rec su_dr;	/* SVCXPRT indexed by fd */
 	struct msghdr su_msghdr;	/* msghdr received from clnt */
-	unsigned char su_cmsg[SVC_CMSG_SIZE];	/* cmsghdr received from clnt */
+	union pktinfo_u su_cmsg[DG_NUM_PKTINFO]; /* cmsghdr recv'd from clnt */
 };
 #define DG_DR(p) (opr_containerof((p), struct svc_dg_xprt, su_dr))
 #define su_data(xprt) (DG_DR(REC_XPRT(xprt)))

--- a/src/svc_internal.h
+++ b/src/svc_internal.h
@@ -101,7 +101,7 @@ union pktinfo_u {
 struct svc_dg_xprt {
 	struct rpc_dplx_rec su_dr;	/* SVCXPRT indexed by fd */
 	struct msghdr su_msghdr;	/* msghdr received from clnt */
-	unsigned char su_cmsg[SVC_CMSG_SIZE];	/* cmsghdr received from clnt */
+	union pktinfo_u su_cmsg[4];	/* cmsghdr received from clnt */
 };
 #define DG_DR(p) (opr_containerof((p), struct svc_dg_xprt, su_dr))
 #define su_data(xprt) (DG_DR(REC_XPRT(xprt)))


### PR DESCRIPTION
Prior to this change it was seen that the MSG_CTRUNC flag was set in
the data returned by recvmsg(), an indication that that the controlmsg
(i.e. pktinfo) was lost due to insufficient space. Increasing the size
of struct svc_dg_xprt by making sc_cmsg an array of pktinfo fixes this.

It was also seen that when using an IPv4 socket that two pktinfos are
recv'd: an in_pktinfo and an in6_pktinfo. (One comment I saw somewhere
said that it is related to ipv6-tunneled-over-ipv4.) In this change the
in6_pktinfo is ignored/discarded and only the in_pktinfo is saved for
later use in the reply.

Presumably an IPv6 socket receives just a single in6_pktinfo, which is
saved.

Lastly, despite a comment that seemed to imply that pktinfo is/was set
in the reply, there was no logic to actually set it; with the result
that the kernel had no hints about which source address to set in the
packet and defaulting to sending it with the lowest numeric IP address
on the NIC. This may or may not have been the correct address, i.e.
the address that the request was actually sent to. Discussions with
the knfs team confirmed that NFS clients would consider this an error.

And it was seen that the client's network stack could reject such
packets in certain circumstances, and the NFS client in failing to
receive such a reply would resend the requests (with those replies
rejected as well) before eventually failing over to sending TCP
requests as a (last ditch) attempt to resolve the mount.