### PR TITLE
svc_dg.c: cleanup pktinfo handling

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -273,6 +273,13 @@ struct svc_xprt {
 
 	int32_t xp_refcnt;	/* handle reference count */
 	uint16_t xp_flags;	/* flags */
+
+	union {
+		struct in_pktinfo in;
+#ifdef INET6
+		struct in6_pktinfo in6;
+#endif
+	} xp_pktinfo;
 };
 
 /* Service record used by exported search routines */

--- a/src/svc_internal.h
+++ b/src/svc_internal.h
@@ -98,10 +98,11 @@ union pktinfo_u {
  * Replaces old struct svc_dg_data by locally wrapping struct rpc_dplx_rec,
  * which wraps struct svc_xprt indexed by fd.
  */
+#define DG_NUM_PKTINFO 4 /* s/b enough space for all pktinfos in normal case*/
 struct svc_dg_xprt {
 	struct rpc_dplx_rec su_dr;	/* SVCXPRT indexed by fd */
 	struct msghdr su_msghdr;	/* msghdr received from clnt */
-	unsigned char su_cmsg[SVC_CMSG_SIZE];	/* cmsghdr received from clnt */
+	union pktinfo_u su_cmsg[DG_NUM_PKTINFO]; /* cmsghdr recv'd from clnt */
 };
 #define DG_DR(p) (opr_containerof((p), struct svc_dg_xprt, su_dr))
 #define su_data(xprt) (DG_DR(REC_XPRT(xprt)))


### PR DESCRIPTION
Prior to this change it was seen that the MSG_CTRUNC flag was set in
the data returned by recvmsg(), an indication that that the controlmsg
(i.e. pktinfo) was lost due to insufficient space. Increasing the size
of struct svc_dg_xprt by making sc_cmsg an array of pktinfo fixes this.

It was also seen that when using an IPv4 socket that two pktinfos are
recv'd: an in_pktinfo and an in6_pktinfo. (One comment I saw somewhere
said that it is related to ipv6-tunneled-over-ipv4.) In this change the
in6_pktinfo is ignored/discarded and only the in_pktinfo is saved for
later use in the reply.

Presumably an IPv6 socket receives just a single in6_pktinfo, which is
saved.

Lastly, despite a comment that seemed to imply that pktinfo is/was set
in the reply, there was no logic to actually set it; with the result
that the kernel had no hints about which source address to set in the
packet and defaulting to sending it with the lowest numeric IP address
on the NIC. This may or may not have been the correct address, i.e.
the address that the request was actually sent to. Discussions with
the knfs team confirmed that NFS clients would consider this an error.

And it was seen that the client's network stack could reject such
packets in certain circumstances, and the NFS client in failing to
receive such a reply would resend the requests (with those replies
rejected as well) before eventually failing over to sending TCP
requests as a (last ditch) attempt to resolve the mount.