### PR TITLE
XPRT - Unregister xprt before dropping sentinal ref

### DIFF
--- a/src/rpc_rdma.c
+++ b/src/rpc_rdma.c
@@ -2207,6 +2207,12 @@ rpc_rdma_connect(RDMAXPRT *xprt)
 }
 
 static void
+rpc_rdma_unlink_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
+{
+	return;
+}
+
+static void
 rpc_rdma_destroy_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 {
 	if (xprt->xp_ops->xp_free_user_data) {
@@ -2245,6 +2251,7 @@ static struct xp_ops rpc_rdma_ops = {
 	.xp_decode = (svc_req_fun_t)abort,
 	.xp_reply = (svc_req_fun_t)abort,
 	.xp_checksum = NULL,		/* not used */
+	.xp_unlink = rpc_rdma_unlink_it,
 	.xp_destroy = rpc_rdma_destroy_it,
 	.xp_control = rpc_rdma_control,
 	.xp_free_user_data = NULL,	/* no default */

--- a/src/svc_raw.c
+++ b/src/svc_raw.c
@@ -186,6 +186,11 @@ svc_raw_reply(struct svc_req *req)
 
  /*ARGSUSED*/
 static void
+svc_raw_unlink(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
+{
+}
+
+static void
 svc_raw_destroy(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 {
 }
@@ -212,6 +217,7 @@ svc_raw_ops(SVCXPRT *xprt)
 		ops.xp_decode = svc_raw_decode;
 		ops.xp_reply = svc_raw_reply;
 		ops.xp_checksum = NULL;		/* optional */
+		ops.xp_unlink = svc_raw_unlink;
 		ops.xp_destroy = svc_raw_destroy;
 		ops.xp_control = svc_raw_control;
 		ops.xp_free_user_data = NULL;	/* no default */

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -563,14 +563,18 @@ svc_vc_destroy_task(struct work_pool_entry *wpe)
 }
 
 static void
+svc_vc_unlink_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
+{
+	svc_rqst_xprt_unregister(xprt, flags);
+}
+
+static void
 svc_vc_destroy_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 {
 	struct timespec ts = {
 		.tv_sec = 0,
 		.tv_nsec = 0,
 	};
-
-	svc_rqst_xprt_unregister(xprt, flags);
 
 	__warnx(TIRPC_DEBUG_FLAG_REFCNT,
 		"%s() %p fd %d xp_refcnt %" PRId32 " @%s:%d",
@@ -584,12 +588,6 @@ svc_vc_destroy_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 
 	REC_XPRT(xprt)->ioq.ioq_wpe.fun = svc_vc_destroy_task;
 	work_pool_submit(&svc_work_pool, &(REC_XPRT(xprt)->ioq.ioq_wpe));
-}
-
-static void
-svc_vc_destroy(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
-{
-	svc_vc_destroy_it(xprt, flags, tag, line);
 }
 
 extern mutex_t ops_lock;
@@ -981,7 +979,8 @@ svc_vc_override_ops(SVCXPRT *xprt, SVCXPRT *rendezvous)
 		ops.xp_decode = svc_vc_decode;
 		ops.xp_reply = svc_vc_reply;
 		ops.xp_checksum = svc_vc_checksum;
-		ops.xp_destroy = svc_vc_destroy;
+		ops.xp_unlink = svc_vc_unlink_it;
+		ops.xp_destroy = svc_vc_destroy_it;
 		ops.xp_control = svc_vc_control;
 		ops.xp_free_user_data = NULL;	/* no default */
 	}
@@ -1006,6 +1005,7 @@ svc_vc_rendezvous_ops(SVCXPRT *xprt)
 		ops.xp_decode = (svc_req_fun_t)abort;
 		ops.xp_reply = (svc_req_fun_t)abort;
 		ops.xp_checksum = NULL;		/* not used */
+		ops.xp_unlink = svc_vc_unlink_it;
 		ops.xp_destroy = svc_vc_destroy_it;
 		ops.xp_control = svc_vc_rendezvous_control;
 		ops.xp_free_user_data = NULL;	/* no default */


### PR DESCRIPTION
XPRTs are generally stored in some form of lookup table.  When we're
destroying the XPRT, we need to remove it from it's lookup table before
we drop the sentinal ref.  Otherwise, another thread can find it, and
increment it's ref from 0 -> 1.  This is very hard to handle in an
atomic fashion.

Add an unlink() API method, and implement it for all backends.  This
allows us to remove the XPRT from it's lookup table before we drop it's
sentinal ref.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>