### PR TITLE
Take a XPRT ref when hooking events

### DIFF
--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -496,6 +496,9 @@ svc_dg_unlink_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 	if (!xprt->xp_parent) {
 		/* only original parent is registered */
 		svc_rqst_xprt_unregister(xprt, flags);
+	} else {
+		/* Still need to unhook it */
+		svc_rqst_unhook(xprt);
 	}
 }
 

--- a/src/svc_internal.h
+++ b/src/svc_internal.h
@@ -173,5 +173,6 @@ int svc_rqst_xprt_register(SVCXPRT *, SVCXPRT *);
 void svc_rqst_xprt_unregister(SVCXPRT *, uint32_t);
 int svc_rqst_evchan_write(SVCXPRT *, struct xdr_ioq *, bool);
 void svc_rqst_xprt_send_complete(SVCXPRT *);
+void svc_rqst_unhook(SVCXPRT *);
 
 #endif				/* TIRPC_SVC_INTERNAL_H */

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -515,8 +515,13 @@ svc_vc_rendezvous(SVCXPRT *xprt)
 		SVC_DESTROY(newxprt);
 		/* Was never added to epoll */
 		SVC_RELEASE(newxprt, SVC_RELEASE_FLAG_NONE);
+		SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 		return (XPRT_DESTROYED);
 	}
+
+	/* We're not using a ref for the hook anymore, since epoll doesn't store
+	 * the transport pointer.  Drop the extra ref here. */
+	SVC_RELEASE(newxprt, SVC_RELEASE_FLAG_NONE);
 	return (XPRT_IDLE);
 }
 

--- a/src/svc_xprt.c
+++ b/src/svc_xprt.c
@@ -209,13 +209,14 @@ svc_xprt_lookup(int fd, svc_xprt_setup_t setup)
 	rpc_dplx_rli(rec);
 	xp_flags = atomic_clear_uint16_t_bits(&xprt->xp_flags,
 					      SVC_XPRT_FLAG_INITIAL);
+	rpc_dplx_rui(rec);
+
 	if (!(xp_flags & SVC_XPRT_FLAG_DESTROYED)) {
 		/* do not return destroyed xprts */
 		return (xprt);
 	}
 
 	/* unlock before release permits releasing here after destroy */
-	rpc_dplx_rui(rec);
 	SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 	return (NULL);
 }
@@ -391,9 +392,9 @@ void
 svc_xprt_trace(SVCXPRT *xprt, const char *func, const char *tag, const int line)
 {
 	__warnx(TIRPC_DEBUG_FLAG_REFCNT,
-		"%s() %p fd %d xp_refcnt %" PRId32
+		"%s() %p fd %d fd_send %d xp_refcnt %" PRId32
 		" af %u port %u @%s:%d",
-		func, xprt, xprt->xp_fd, xprt->xp_refcnt,
+		func, xprt, xprt->xp_fd, xprt->xp_fd_send, xprt->xp_refcnt,
 		xprt->xp_remote.ss.ss_family,
 		__rpc_address_port(&xprt->xp_remote),
 		tag, line);


### PR DESCRIPTION
The epoll loop needs a ref on the XPRT, so that it stays alive while in
epoll().  svc_rqst_rearm_events_locked() takes a ref, but the initial
svc_rqst_hook_events() does not.  This means that, if the XPRT times
out, the cleanup will drop a ref, and the epoll loop will drop a ref,
causing one to many refs to be dropped.  This leaves the client
potentially with a dangling ref.

Take the ref for the epoll loop when initially hooking the events.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>