### PR TITLE
authgss_prot: silence false-positive clang warning

### DIFF
--- a/src/authgss_prot.c
+++ b/src/authgss_prot.c
@@ -305,7 +305,7 @@ xdr_rpc_gss_wrap(XDR *xdrs, xdrproc_t xdr_func, void *xdr_ptr,
 			xv_count = data_count + 2;
 			gv_count = data_count + 1;
 			after_data = data_count;
-		} else if (svc == RPCSEC_GSS_SVC_PRIVACY) {
+		} else /* svc == RPCSEC_GSS_SVC_PRIVACY */ {
 			/* Add header, padding, and trailer for the wrap */
 			xv_count = data_count + 3;
 			gv_count = data_count + 3;


### PR DESCRIPTION
clang complains about uninitialized use of xv/gv_count variables because
there is no final else clause, even if we do check that svc is either of
these types at the start of the function.
Silence false positive by skipping the last "always-true" check