### PR TITLE
VC - RELEASE after DESTROY

### DIFF
--- a/src/clnt_vc.c
+++ b/src/clnt_vc.c
@@ -459,12 +459,14 @@ clnt_vc_destroy(CLIENT *clnt)
 	struct cx_data *cx = CX_DATA(clnt);
 
 	if (cx->cx_rec) {
-		SVC_RELEASE(&cx->cx_rec->xprt, SVC_RELEASE_FLAG_NONE);
-
 		if (clnt->cl_flags & CLNT_FLAG_LOCAL) {
 			/* Local client; destroy the xprt */
 			SVC_DESTROY(&cx->cx_rec->xprt);
 		}
+
+		/* RELEASE after DESTROY in case an error case has already
+		 * called DESTROY */
+		SVC_RELEASE(&cx->cx_rec->xprt, SVC_RELEASE_FLAG_NONE);
 	}
 	clnt_vc_data_free(CT_DATA(cx));
 }


### PR DESCRIPTION
Many error paths call DESTROY, which will unlink and drop the ref.  This
means that the final RELEASE will free, causing the DESTROY to
use-after-free.  Instead, make sure we DESTROY first.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>