### PR TITLE
In clnt_tli_ncreate() close FD in case client creation failed

### DIFF
--- a/src/clnt_generic.c
+++ b/src/clnt_generic.c
@@ -401,6 +401,9 @@ clnt_tli_ncreate(int fd, const struct netconfig *nconf,
 		goto err;
 	}
 
+	if (CLNT_FAILURE(cl))
+		goto err1;
+
 	if (flags & CLNT_CREATE_FLAG_CLOSE) {
 		/* We got a new FD; this makes it a local client */
 		cl->cl_flags |= CLNT_FLAG_LOCAL;


### PR DESCRIPTION
In clnt_tli_ncreate() if client creation fails then we don't
close FD and cause FD leak.
Fixed by closing FD in case of client creation failure.

Signed-off-by: Madhu Thorat <madhu.punjabi@in.ibm.com>