### PR TITLE
work_pool: Fix for efficient scheduling.

### DIFF
--- a/ntirpc/rpc/work_pool.h
+++ b/ntirpc/rpc/work_pool.h
@@ -72,6 +72,7 @@ struct work_pool_thread {
 	char worker_name[16];
 	pthread_t pt;
 	uint32_t worker_index;
+	bool wakeup;
 };
 
 typedef void (*work_pool_fun_t) (struct work_pool_entry *);

--- a/src/svc.c
+++ b/src/svc.c
@@ -184,7 +184,7 @@ svc_init(svc_init_params *params)
 	if (__svc_params->ioq.thrd_max < params->ioq_thrd_max)
 		__svc_params->ioq.thrd_max = params->ioq_thrd_max;
 
-	work_pool_params.thrd_min = __svc_params->ioq.thrd_min + channels;
+	work_pool_params.thrd_min = __svc_params->ioq.thrd_min;
 	work_pool_params.thrd_max = __svc_params->ioq.thrd_max;
 	if (work_pool_params.thrd_max < work_pool_params.thrd_min)
 		work_pool_params.thrd_max = work_pool_params.thrd_min;

--- a/src/svc.c
+++ b/src/svc.c
@@ -186,8 +186,13 @@ svc_init(svc_init_params *params)
 
 	work_pool_params.thrd_min = __svc_params->ioq.thrd_min;
 	work_pool_params.thrd_max = __svc_params->ioq.thrd_max;
-	if (work_pool_params.thrd_max < work_pool_params.thrd_min)
-		work_pool_params.thrd_max = work_pool_params.thrd_min;
+	/*
+	 * thrd_max should > channels.
+	 */
+	if (work_pool_params.thrd_max < (work_pool_params.thrd_min +
+	    channels))
+		work_pool_params.thrd_max = work_pool_params.thrd_min +
+					    channels;
 
 	if (work_pool_init(&svc_work_pool, "svc_", &work_pool_params)) {
 		mutex_unlock(&__svc_params->mtx);


### PR DESCRIPTION
Separate out work queue and worker queue.
Always submit work to the work queue and wakeup available
work thread.
Each work thread will always check for entry in work queue,
so that it can pickup next work without scheduling.
Reduce the number of idle thread count, less number of threads
helps in less scheduling overhead.

With this fix we can get good numbers for low latency workloads like
cached reads due to less threads and less scheduling.
I got > 80% performance improvement with 8k random cached reads.
IO bound workload will use more threads as before and they are not
impacted.