### PR TITLE
Change RPCSEC_GSS window size to 256

### DIFF
--- a/ntirpc/rpc/gss_internal.h
+++ b/ntirpc/rpc/gss_internal.h
@@ -68,6 +68,8 @@ typedef gss_union_ctx_id_desc *gss_union_ctx_id_t;
 #define SVC_RPC_GSS_FLAG_NONE    0x0000
 #define SVC_RPC_GSS_FLAG_MSPAC   0x0001
 
+#define GSS_SEQ_WIN     256
+
 struct svc_rpc_gss_data {
 	struct opr_rbtree_node node_k;
 	 TAILQ_ENTRY(svc_rpc_gss_data) lru_q;
@@ -82,10 +84,8 @@ struct svc_rpc_gss_data {
 	gss_ctx_id_t ctx;	/* context id */
 	struct rpc_gss_sec sec;	/* security triple */
 	gss_buffer_desc cname;	/* GSS client name */
-	u_int seq;
-	u_int win;
-	u_int seqlast;
-	uint32_t seqmask;
+	int8_t win[GSS_SEQ_WIN/CHAR_BIT];
+	int seqlast;
 	gss_name_t client_name;
 	gss_buffer_desc checksum;
 	struct {

--- a/src/svc_auth_gss.c
+++ b/src/svc_auth_gss.c
@@ -42,6 +42,7 @@
 #include <rpc/svc_auth.h>
 #include <rpc/gss_internal.h>
 #include <misc/portable.h>
+#include <assert.h>
 
 static struct svc_auth_ops svc_auth_gss_ops;
 
@@ -230,13 +231,12 @@ svcauth_gss_accept_sec_context(struct svc_req *req,
 	/* ANDROS: change for debugging linux kernel version...
 	   gr->gr_win = 0x00000005;
 	 */
-	gr->gr_win = sizeof(gd->seqmask) * 8;
+	gr->gr_win = GSS_SEQ_WIN;
 
 	/* Save client info. */
 	gd->sec.mech = mech;
 	gd->sec.qop = GSS_C_QOP_DEFAULT;
 	gd->sec.svc = gc->gc_svc;
-	gd->win = gr->gr_win;
 
 	if (time_rec == GSS_C_INDEFINITE) time_rec = INDEF_EXPIRE;
 	if (time_rec > 10) time_rec -= 5;
@@ -385,6 +385,63 @@ svcauth_gss_nextverf(struct svc_req *req, struct svc_rpc_gss_data *gd,
 	return (true);
 }
 
+static bool
+gss_check_seq_num_valid(struct svc_rpc_gss_data *gd, int seq_num)
+{
+	int bit_to_clear;
+	__warnx(TIRPC_DEBUG_FLAG_RPCSEC_GSS,
+		"seq %d seqlast %d diff %d bit# %d",
+		seq_num, gd->seqlast, seq_num - gd->seqlast,
+		seq_num % GSS_SEQ_WIN);
+
+	/* According to rfc2203, sequence numbers should be less than:
+	 * MAXSEQ 0x80000000.
+	 */
+	if (seq_num < 0)
+		return false;
+
+	/* If the sequence number is greater than the max we have seen
+	 * previously, we accept it and move the seqlast and window forward.
+	 */
+	if (seq_num >= (gd->seqlast + GSS_SEQ_WIN)) {
+		memset(gd->win, 0, sizeof(gd->win));
+		gd->seqlast = seq_num;
+		setbit(gd->win, seq_num % GSS_SEQ_WIN);
+		return true;
+	}
+	if (seq_num > gd->seqlast) {
+		gd->seqlast++;
+		while (gd->seqlast < seq_num) {
+			bit_to_clear = gd->seqlast % GSS_SEQ_WIN;
+			if (!(bit_to_clear % CHAR_BIT) == 0 &&
+			    (gd->seqlast + CHAR_BIT) <= seq_num) {
+				gd->win[bit_to_clear/CHAR_BIT] = '\0';
+				gd->seqlast += CHAR_BIT;
+			} else {
+				clrbit(gd->win, gd->seqlast % GSS_SEQ_WIN);
+				gd->seqlast++;
+			}
+		}
+		assert(gd->seqlast == seq_num);
+		setbit(gd->win, seq_num % GSS_SEQ_WIN);
+		return true;
+	}
+
+	/* if seq_num falls below the window size, drop the request */
+	if (seq_num <= gd->seqlast - GSS_SEQ_WIN) {
+		return false;
+	}
+
+	/* if we have already seen the seq_num, drop the request */
+	if (isset(gd->win, seq_num % GSS_SEQ_WIN)) {
+		return false;
+	}
+
+	/* seq num is within valid window, mark it as seen and accept */
+	setbit(gd->win, seq_num % GSS_SEQ_WIN);
+	return true;
+}
+
 enum auth_stat
 _svcauth_gss(struct svc_req *req, bool *no_dispatch)
 {
@@ -393,7 +450,7 @@ _svcauth_gss(struct svc_req *req, bool *no_dispatch)
 	struct svc_rpc_gss_data *gd = NULL;
 	struct rpc_gss_cred *gc = NULL;
 	struct rpc_gss_init_res gr;
-	int call_stat, offset;
+	int call_stat;
 	OM_uint32 min_stat;
 	enum auth_stat rc = AUTH_OK;
 
@@ -480,19 +537,9 @@ _svcauth_gss(struct svc_req *req, bool *no_dispatch)
 			 goto gd_free;
 		}
 
-		/* XXX implied serialization?  or just fudging?  advance if
-		 * greater? */
-		offset = gd->seqlast - gc->gc_seq;
-		if (offset < 0) {
-			gd->seqlast = gc->gc_seq;
-			offset = 0 - offset;
-			gd->seqmask <<= offset;
-			offset = 0;
-		} else if (offset >= gd->win || (gd->seqmask & (1 << offset))) {
-			*no_dispatch = true;
+		*no_dispatch = !gss_check_seq_num_valid(gd, gc->gc_seq);
+		if (*no_dispatch)
 			goto gd_free;
-		}
-		gd->seqmask |= (1 << offset);	/* XXX harmless */
 
 		req->rq_ap1 = (void *)(uintptr_t) gc->gc_seq; /* GCC casts */
 		req->rq_clntname = (char *) gd->client_name;


### PR DESCRIPTION
The current RPCSEC_GSS window size is 32, which is too small and results
in frequent out of sequence errors when client sends multiple requests
in parallel. This can result in auth failures as metioned in this thread:
https://lists.nfs-ganesha.org/archives/list/devel@lists.nfs-ganesha.org/thread/JSADKLKF3GKNCKPFV5NYEJ3ML3YU7UN7/

Changing the window size to 256, along with reducing the value of
tcp_max_slot_table_entries (at client side) mitigates the issue to
a large extent.