### PR TITLE
abstract_atomic.h: use atomics for free on macOS

### DIFF
--- a/ntirpc/misc/abstract_atomic.h
+++ b/ntirpc/misc/abstract_atomic.h
@@ -95,8 +95,6 @@
 
 #if ((ATOMIC_GCC_VERSION) >= 40700)
 #define GCC_ATOMIC_FUNCTIONS 1
-#elif defined(__APPLE__) && defined(__x86_64__)
-#include "atomic_x86_64.h"
 #elif ((ATOMIC_GCC_VERSION) >= 40100)
 #define GCC_SYNC_FUNCTIONS 1
 #else


### PR DESCRIPTION
The check for `__APPLE__` here is not serving any purpose, because:

 (a) there is a GCC-specific file passed to the linker during building,
     which is not supported by Apple's ld, so for this reason at the
     very least Apple builds are not supported (see
     src/libntirpc.map.in.cmake)

 (b) The `__sync_*` intrinsics have been supported for a long time in
     Clang, so we can just use them.

On my macOS machine with Clang version 11.0.3, ATOMIC_GCC_VERSION
evaluates to 40201 which causes GCC_SYNC_FUNCTIONS (`__sync_*`) to be
used.

I see mention of `__sync_fetch_and_add` in the Clang 3.4 documentation [1]
which is from circa 2013 [2], so I suspect this check only serves very
ancient compilers. I would like to remove the check and the
corresponding atomic_x86_64.h file from Ganesha as well.

Take advantage of these atomic intrinsics available on non-ancient Clang
and GCC compilers.

[1] https://releases.llvm.org/3.4/tools/clang/docs/LanguageExtensions.html
[2] https://releases.llvm.org/3.4/tools/clang/docs/ReleaseNotes.html
    - see footer