### PR TITLE
Define a presumed UIO_MAXIOV value as needed

### DIFF
--- a/src/svc.c
+++ b/src/svc.c
@@ -86,7 +86,7 @@
 #ifdef IOV_MAX
 int __svc_maxiov = IOV_MAX;
 #else
-int __svc_maxiov = 1024; /* UIO_MAXIOV value from sys/uio.h */
+int __svc_maxiov = PRESUMED_UIO_MAXIOV;
 #endif
 int __svc_maxrec = RPC_MAXDATA_LEGACY;
 

--- a/src/svc_internal.h
+++ b/src/svc_internal.h
@@ -37,6 +37,13 @@
 extern int __svc_maxiov;
 extern int __svc_maxrec;
 
+#if defined(UIO_MAXIOV)
+# define PRESUMED_UIO_MAXIOV UIO_MAXIOV
+#else
+/* On macOS, the non-kernel sys/uio.h header does not define UIO_MAXIOV. */
+# define PRESUMED_UIO_MAXIOV 1024
+#endif
+
 /* threading fdsets around is annoying */
 struct svc_params {
 	mutex_t mtx;

--- a/src/svc_ioq.c
+++ b/src/svc_ioq.c
@@ -197,9 +197,9 @@ svc_ioq_flushv(SVCXPRT *xprt, struct xdr_ioq *xioq)
 			break;
 		}
 
-		if (iov_count + frag_needed > UIO_MAXIOV) {
+		if (iov_count + frag_needed > PRESUMED_UIO_MAXIOV) {
 			/* sendmsg can only take UIO_MAXIOV iovecs */
-			iov_count = UIO_MAXIOV - frag_needed;
+			iov_count = PRESUMED_UIO_MAXIOV - frag_needed;
 		}
 
 		/* Convert the xdr_vio to an iovec */


### PR DESCRIPTION
This PR contains macOS-specific support code. I don't believe this library supports macOS in particular, so this is something new. I plan to make other macOS-specific PRs in the coming weeks.

My colleagues and I (added to CC) will support our contributions for such specialized functionality going forward in case needed. We are doing similar work on NFS-Ganesha - see thread: https://lists.nfs-ganesha.org/archives/list/devel@lists.nfs-ganesha.org/thread/JFRLHI2SOMOYNZPZNNJJFP36BJD57DDU/

---

Do not use UIO_MAXIOV directly except in one place, in order to
accommodate macOS, which only defines it in the kernel version of
sys/uio.h.

Define an adapter value which is portable between platforms as long as
svc_internal.h is included.

An alternative solution would be to define UIO_MAXIOV ourselves if it is
missing.  I chose against this since it is somewhat obfuscated, but I am
not strongly attached to this style.

Signed-off-by: Matthew DeVore <matvore@google.com>