### PR TITLE
Add missing includes to make headers stand-alone

### DIFF
--- a/ntirpc/misc/bsd_epoll.h
+++ b/ntirpc/misc/bsd_epoll.h
@@ -54,6 +54,8 @@
 #ifndef __BSD_EPOLL_H__
 #define __BSD_EPOLL_H__
 
+#include <stdint.h>
+
 union epoll_data {
 	int fd;
 	uint32_t u32;

--- a/ntirpc/misc/event.h
+++ b/ntirpc/misc/event.h
@@ -29,6 +29,8 @@
 #ifndef _TIRPC_EVENT_H_
 #define _TIRPC_EVENT_H_
 
+#include <sys/types.h>
+
 #define EVFILT_READ		(-1)
 #define EVFILT_WRITE		(-2)
 #define EVFILT_AIO		(-3)	/* attached to aio requests */


### PR DESCRIPTION
I have been building libntirpc with Bazel. Bazel will pass headers through the compiler without any preamble to verify they can be used alone (i.e. as the first `#include` of a source file). This patch allows using this helpful default behavior.

---

Include stdint.h for fixed-size int types like uint32_t.

Include sys/types.h for u_short and u_int.

This allows users of the header to #include it without worrying about
transitive dependencies.

Signed-off-by: Matthew DeVore <matvore@google.com>