### PR TITLE
Use macOS's native implementation of clock_gettime

### DIFF
--- a/ntirpc/misc/portable.h
+++ b/ntirpc/misc/portable.h
@@ -58,10 +58,8 @@ void warnx(const char *fmt, ...);
 #endif				/* !_WIN32 */
 
 #ifdef __APPLE__
-#include <sys/time.h>
-typedef unsigned int clockid_t;
-#define CLOCK_MONOTONIC_FAST 6
-extern int clock_gettime(clockid_t clock, struct timespec *ts);
+#include <time.h>
+#define CLOCK_MONOTONIC_FAST CLOCK_MONOTONIC
 #endif
 
 #ifndef max

--- a/src/portable.c
+++ b/src/portable.c
@@ -29,17 +29,6 @@
 #include <stdbool.h>
 #include <reentrant.h>
 
-#ifdef __APPLE__
-int clock_gettime(clockid_t clock, struct timespec *ts)
-{
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-	ts->tv_sec = tv.tv_sec;
-	ts->tv_nsec = tv.tv_usec * 1000UL;
-	return 0;
-}
-#endif
-
 #if defined(_WIN32)
 pthread_mutex_t clock_mtx = PTHREAD_MUTEX_INITIALIZER;
 


### PR DESCRIPTION
ASIDE: obviously we could continue to support old macOS versions as well, if desired. Let me know if that's preferred.

clock_gettime has been in macOS since 10.12 [1] (Sierra, announced mid
2016). On that version and later, the re-definition of clock_gettime
causes compile errors.

[1] https://www.manpagez.com/man/3/clock_gettime/

Signed-off-by: Matthew DeVore <matvore@google.com>