### PR TITLE
Define a compatability layer for macOS spinlocks

### DIFF
--- a/ntirpc/misc/macpthreads.h
+++ b/ntirpc/misc/macpthreads.h
@@ -1,0 +1,44 @@
+#ifndef NTIRPC_MACPTHREADS_H_
+#define NTIRPC_MACPTHREADS_H_
+
+#include <err.h>
+#include <os/lock.h>
+#include <pthread.h>
+#include <string.h>
+#include <sys/errno.h>
+
+typedef os_unfair_lock pthread_spinlock_t;
+
+static inline int pthread_spin_init(os_unfair_lock *sp, int pshared)
+{
+	if (pshared != PTHREAD_PROCESS_PRIVATE)
+		errx(1, "Unsupported spinlock type: %d", pshared);
+
+	memset(sp, 0, sizeof(*sp));
+	return 0;
+}
+
+static inline int pthread_spin_lock(os_unfair_lock *sp)
+{
+	os_unfair_lock_lock(sp);
+	return 0;
+}
+
+static inline int pthread_spin_trylock(os_unfair_lock *sp)
+{
+	return os_unfair_lock_trylock(sp) ? 0 : EBUSY;
+}
+
+static inline int pthread_spin_unlock(os_unfair_lock *sp)
+{
+	os_unfair_lock_unlock(sp);
+	return 0;
+}
+
+static inline int pthread_spin_destroy(os_unfair_lock *sp)
+{
+	/* Nothing to do. */
+	return 0;
+}
+
+#endif				/* NTIRPC_MACPTHREADS_H_ */

--- a/ntirpc/reentrant.h
+++ b/ntirpc/reentrant.h
@@ -40,6 +40,8 @@
 
 #if defined(_WIN32)
 #include <misc/winpthreads.h>
+#elif defined(__APPLE__)
+#include <misc/macpthreads.h>
 #else
 #include <pthread.h>
 #endif


### PR DESCRIPTION
This is the last macOS compatibility fix I require in ntirpc.