### PR TITLE
Centrally define bswap_## on non-GNU platforms

### DIFF
--- a/ntirpc/misc/portable.h
+++ b/ntirpc/misc/portable.h
@@ -77,4 +77,34 @@ void warnx(const char *fmt, ...);
 
 #define CACHE_PAD(_n) char __pad ## _n [CACHE_LINE_SIZE]
 
+/* Define bswap_## on non-GNU systems. */
+#if defined(_MSC_VER)
+
+#include <stdlib.h>
+#define bswap_16(x) _byteswap_ushort(x)
+#define bswap_32(x) _byteswap_ulong(x)
+#define bswap_64(x) _byteswap_uint64(x)
+
+#elif defined(__APPLE__)
+
+/* macOS / Darwin features */
+#include <libkern/OSByteOrder.h>
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+
+#elif defined(__FreeBSD__)
+
+#include <sys/endian.h>
+#define bswap_16(x)     bswap16((x))
+#define bswap_32(x)     bswap32((x))
+#define bswap_64(x)     bswap64((x))
+
+#else
+
+/* Must be on Linux. GNU supplies bswap_## directly. */
+#include <byteswap.h>
+
+#endif				/* bswap_## */
+
 #endif				/* NTIRPC_PORTABLE_H */

--- a/src/city.c
+++ b/src/city.c
@@ -36,6 +36,7 @@
 #include "config.h"
 #include <string.h>
 #include <misc/city.h>
+#include <misc/portable.h>
 
 static uint64 UNALIGNED_LOAD64(const char *p)
 {
@@ -57,21 +58,6 @@ static uint32 UNALIGNED_LOAD32(const char *p)
 #define uint64_in_expected_order(x) (x)
 
 #else
-
-#ifdef _MSC_VER
-#include <stdlib.h>
-#define bswap_32(x) _byteswap_ulong(x)
-#define bswap_64(x) _byteswap_uint64(x)
-
-#elif defined(__APPLE__)
-/* Mac OS X / Darwin features */
-#include <libkern/OSByteOrder.h>
-#define bswap_32(x) OSSwapInt32(x)
-#define bswap_64(x) OSSwapInt64(x)
-
-#else
-#include <byteswap.h>
-#endif
 
 #define uint32_in_expected_order(x) (bswap_32(x))
 #define uint64_in_expected_order(x) (bswap_64(x))


### PR DESCRIPTION
There is some redundancy in Ganesha's codebase around defining
portability shims for this functionality (e.g. [0] and [1]), so it would
be nice to store them in one location. This also allows more portions of
Ganesha to build on macOS, though the files will have to be updated to
include <misc/portable.h> in order to build.

[0] src/support/city.c
[1] src/FSAL/FSAL_MEM/mem_export.c

Signed-off-by: Matthew DeVore <matvore@google.com>