### PR TITLE
Fix xdr_rpc_gss_wrap

### DIFF
--- a/src/authgss_prot.c
+++ b/src/authgss_prot.c
@@ -268,7 +268,7 @@ xdr_rpc_gss_wrap(XDR *xdrs, xdrproc_t xdr_func, void *xdr_ptr,
 	 * If it's privacy, and NEWBUF is supported (because xdrs is a vector)
 	 * then NEWBUF will have allocated the new buffer.
 	 */
-	vector = (svc == RPCSEC_GSS_SVC_INTEGRITY);
+	vector = (svc == RPCSEC_GSS_SVC_INTEGRITY) || XDR_NEWBUF(xdrs);
 
 	/* Marshal rpc_gss_data_t (sequence number + arguments).
 	 * If it's a vector, the response has been marshalled into a new


### PR DESCRIPTION
Revert part of 02b87a2842e497af5c094b4ad3951a6b69671e98. Due to the
change, some krb5p requests would contain results from uninitialized
memory, rather than the expected response.