### PR TITLE
Cleanup writeq if svc_ioq_flushv return -1

### DIFF
--- a/src/svc_ioq.c
+++ b/src/svc_ioq.c
@@ -353,7 +353,7 @@ void svc_ioq_write(SVCXPRT *xprt)
 				"%s: %p fd %d About to destroy - rc = %d",
 				__func__, xprt, xprt->xp_fd, rc);
 			SVC_DESTROY(xprt);
-			break;
+			/* Continue to clenaup all requests in queue */
 		} else if (rc == EWOULDBLOCK){
 			__warnx(TIRPC_DEBUG_FLAG_SVC_VC,
 				"%s: %p fd %d EWOULDBLOCK",


### PR DESCRIPTION
In svc_ioq_write for (rc < 0), we are not cleaning up writeq.
We can just continue instead of break if (rc < 0).
Its similar to how we handle errno != EWOULDBLOCK.

Signed-off-by: Gaurav Gangalwar <gaurav.gangalwar@gmail.com>