### PR TITLE
Change xdrproc_t to only 2 parameters

### DIFF
--- a/ntirpc/rpc/xdr.h
+++ b/ntirpc/rpc/xdr.h
@@ -251,7 +251,7 @@ xdr_tail_update(XDR *xdrs)
  * to be decoded.  If this pointer is 0, then the type routines should
  * allocate dynamic storage of the appropriate size and return it.
  */
-typedef bool(*xdrproc_t) (XDR *, void *, unsigned int);
+typedef bool(*xdrproc_t) (XDR *, void *);
 
 /*
  * Operations defined on a XDR handle
@@ -643,7 +643,7 @@ xdr_putbool(XDR *xdrs, bool_t boolv)
 __BEGIN_DECLS
 extern XDR xdr_free_null_stream;
 
-extern bool xdr_void(void);
+extern bool xdr_void(XDR *, void *);
 extern bool xdr_int(XDR *, int *);
 extern bool xdr_u_int(XDR *, u_int *);
 extern bool xdr_long(XDR *, long *);
@@ -665,7 +665,7 @@ __END_DECLS
 static inline bool
 xdr_nfree(xdrproc_t proc, void *objp)
 {
-	return (*proc) (&xdr_free_null_stream, objp, 0);
+	return (*proc) (&xdr_free_null_stream, objp);
 }
 
 /*

--- a/ntirpc/rpc/xdr_inline.h
+++ b/ntirpc/rpc/xdr_inline.h
@@ -708,13 +708,13 @@ xdr_union(XDR *xdrs,
 	 */
 	for (; choices->proc != NULL_xdrproc_t; choices++) {
 		if (choices->value == dscm)
-			return ((*(choices->proc)) (xdrs, unp, 0));
+			return ((*(choices->proc)) (xdrs, unp));
 	}
 
 	/*
 	 * no match - execute the default xdr routine if there is one
 	 */
-	return ((dfault == NULL_xdrproc_t) ? false : (*dfault) (xdrs, unp, 0));
+	return ((dfault == NULL_xdrproc_t) ? false : (*dfault) (xdrs, unp));
 }
 #define inline_xdr_union xdr_union
 
@@ -734,7 +734,7 @@ xdr_vector(XDR *xdrs, char *basep, u_int nelem, u_int selem,
 	u_int i = 0;
 
 	for (; i < nelem; i++) {
-		if (!(*xdr_elem) (xdrs, target, 0))
+		if (!(*xdr_elem) (xdrs, target))
 			return (false);
 		target += selem;
 	}
@@ -795,7 +795,7 @@ xdr_array_decode(XDR *xdrs, char **cpp, u_int *sizep, u_int maxsize,
 		*cpp = target = (char*) mem_zalloc(size * selem);
 
 	for (; (i < size) && stat; i++) {
-		stat = (*xdr_elem) (xdrs, target, 0);
+		stat = (*xdr_elem) (xdrs, target);
 		target += selem;
 	}
 
@@ -832,7 +832,7 @@ xdr_array_encode(XDR *xdrs, char **cpp, u_int *sizep, u_int maxsize,
 		return (false);
 
 	for (; (i < size) && stat; i++) {
-		stat = (*xdr_elem) (xdrs, target, 0);
+		stat = (*xdr_elem) (xdrs, target);
 		target += selem;
 	}
 
@@ -856,7 +856,7 @@ xdr_array_free(XDR *xdrs, char **cpp, u_int *sizep, u_int maxsize,
 	}
 
 	for (; (i < size) && stat; i++) {
-		stat = (*xdr_elem) (xdrs, target, 0);
+		stat = (*xdr_elem) (xdrs, target);
 		target += selem;
 	}
 

--- a/src/auth_gss.c
+++ b/src/auth_gss.c
@@ -629,7 +629,7 @@ authgss_wrap(AUTH *auth, XDR *xdrs, xdrproc_t xdr_func, void *xdr_ptr)
 		: "unknown");
 
 	if (!gd->established || gd->sec.svc == RPCSEC_GSS_SVC_NONE)
-		return ((*xdr_func) (xdrs, xdr_ptr, 0));
+		return ((*xdr_func) (xdrs, xdr_ptr));
 
 	return (xdr_rpc_gss_wrap
 		(xdrs, xdr_func, xdr_ptr, gd->ctx, gd->sec.qop, gd->sec.svc,
@@ -644,7 +644,7 @@ authgss_unwrap(AUTH *auth, XDR *xdrs, xdrproc_t xdr_func, void *xdr_ptr)
 	__warnx(TIRPC_DEBUG_FLAG_RPCSEC_GSS, "%s()", __func__);
 
 	if (!gd->established || gd->sec.svc == RPCSEC_GSS_SVC_NONE)
-		return ((*xdr_func) (xdrs, xdr_ptr, 0));
+		return ((*xdr_func) (xdrs, xdr_ptr));
 
 	return (xdr_rpc_gss_unwrap
 		(xdrs, xdr_func, xdr_ptr, gd->ctx, gd->sec.qop, gd->sec.svc,

--- a/src/auth_none.c
+++ b/src/auth_none.c
@@ -175,7 +175,7 @@ static void authnone_destroy_dummy(AUTH *auth)
 static bool
 authnone_wrap(AUTH *auth, XDR *xdrs, xdrproc_t xfunc, void *xwhere)
 {
-	return ((*xfunc) (xdrs, xwhere, 0));
+	return ((*xfunc) (xdrs, xwhere));
 }
 
 static struct auth_ops *

--- a/src/auth_unix.c
+++ b/src/auth_unix.c
@@ -336,7 +336,7 @@ marshal_new_auth(AUTH *auth)
 static bool
 authunix_wrap(AUTH *auth, XDR *xdrs, xdrproc_t xfunc, void *xwhere)
 {
-	return ((*xfunc) (xdrs, xwhere, 0));
+	return ((*xfunc) (xdrs, xwhere));
 }
 
 static struct auth_ops *

--- a/src/authgss_prot.c
+++ b/src/authgss_prot.c
@@ -274,7 +274,7 @@ xdr_rpc_gss_wrap(XDR *xdrs, xdrproc_t xdr_func, void *xdr_ptr,
 	 * If it's a vector, the response has been marshalled into a new
 	 * buffer so that we will be able to insert any header.
 	 */
-	if (!XDR_PUTUINT32(xdrs, seq) || !(*xdr_func) (xdrs, xdr_ptr, 0)) {
+	if (!XDR_PUTUINT32(xdrs, seq) || !(*xdr_func) (xdrs, xdr_ptr)) {
 		__warnx(TIRPC_DEBUG_FLAG_RPCSEC_GSS,
 			"%s() could not enocde rpc_gss_data_t",
 			__func__);
@@ -1025,7 +1025,7 @@ xdr_rpc_gss_unwrap(XDR *xdrs, xdrproc_t xdr_func, void *xdr_ptr,
 
 	/* Decode rpc_gss_data_t (sequence number + arguments). */
 	xdr_stat = (XDR_GETUINT32(usexdrs, &seq_num)
-		    && (*xdr_func) (usexdrs, xdr_ptr, 0));
+		    && (*xdr_func) (usexdrs, xdr_ptr));
 
 	if (usexdrs == &tmpxdrs) {
 		/* If it's the tmpxdrs, then destroy the xdrmem we created. */

--- a/src/clnt_bcast.c
+++ b/src/clnt_bcast.c
@@ -630,7 +630,7 @@ rpc_broadcast_exp(rpcprog_t prog,	/* program number */
 			xdrs->x_op = XDR_FREE;
 			msg.RPCM_ack.ar_results.proc = (xdrproc_t) xdr_void;
 			(void)xdr_replymsg(xdrs, &msg);
-			(void)(*xresults) (xdrs, resultsp, 0);
+			(void)(*xresults) (xdrs, resultsp);
 			XDR_DESTROY(xdrs);
 			if (done) {
 				stat = RPC_SUCCESS;

--- a/src/clnt_raw.c
+++ b/src/clnt_raw.c
@@ -151,7 +151,7 @@ clnt_raw_call(struct clnt_req *cc)
 	if ((!XDR_PUTBYTES(xdrs, cx->cx_mcallc, cx->cx_mpos))
 	    || (!XDR_PUTUINT32(xdrs, cc->cc_proc))
 	    || (!AUTH_MARSHALL(cc->cc_auth, xdrs))
-	    || (!(*cc->cc_call.proc) (xdrs, cc->cc_call.where, 0))) {
+	    || (!(*cc->cc_call.proc) (xdrs, cc->cc_call.where))) {
 		/* error case */
 		mutex_unlock(&clnt->cl_lock);
 		__warnx(TIRPC_DEBUG_FLAG_CLNT_RAW,

--- a/src/pmap_rmt.c
+++ b/src/pmap_rmt.c
@@ -75,7 +75,7 @@ xdr_rmtcall_args(XDR *xdrs, struct rmtcallargs *cap)
 		if (!xdr_uint32_t(xdrs, &(cap->arglen)))
 			return (false);
 		argposition = XDR_GETPOS(xdrs);
-		if (!(*(cap->xdr_args)) (xdrs, cap->args_ptr, 0))
+		if (!(*(cap->xdr_args)) (xdrs, cap->args_ptr))
 			return (false);
 		position = XDR_GETPOS(xdrs);
 		cap->arglen = position - argposition;
@@ -100,7 +100,7 @@ xdr_rmtcallres(XDR *xdrs, struct rmtcallres *crp)
 
 	if (xdr_rpcport(xdrs, &crp->port)
 	 && xdr_uint32_t(xdrs, &crp->resultslen)) {
-		return ((*(crp->xdr_results)) (xdrs, crp->results_ptr, 0));
+		return ((*(crp->xdr_results)) (xdrs, crp->results_ptr));
 	}
 	return (false);
 }

--- a/src/rpc_prot.c
+++ b/src/rpc_prot.c
@@ -86,7 +86,7 @@ xdr_naccepted_reply(XDR *xdrs, struct accepted_reply *ar)
 	switch (ar->ar_stat) {
 
 	case SUCCESS:
-		return ((*(ar->ar_results.proc)) (xdrs, ar->ar_results.where, 0));
+		return ((*(ar->ar_results.proc)) (xdrs, ar->ar_results.where));
 
 	case PROG_MISMATCH:
 		if (!inline_xdr_u_int32_t(xdrs, &(ar->ar_vers.low)))

--- a/src/rpcb_prot.c
+++ b/src/rpcb_prot.c
@@ -257,7 +257,7 @@ xdr_rpcb_rmtcallargs(XDR *xdrs, struct rpcb_rmtcallargs *p)
 		return (false);
 	}
 	argposition = XDR_GETPOS(xdrs);
-	if (!(*objp->xdr_args) (xdrs, objp->args.args_val, 0)) {
+	if (!(*objp->xdr_args) (xdrs, objp->args.args_val)) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s:%u ERROR args_val",
 			__func__, __LINE__);
@@ -292,7 +292,7 @@ xdr_rpcb_rmtcallres(XDR *xdrs, struct rpcb_rmtcallres *p)
 		return (false);
 	if (!xdr_uint32_t(xdrs, &objp->results.results_len))
 		return (false);
-	dummy = (*(objp->xdr_res)) (xdrs, objp->results.results_val, 0);
+	dummy = (*(objp->xdr_res)) (xdrs, objp->results.results_val);
 	return (dummy);
 }
 

--- a/src/svc_auth_none.c
+++ b/src/svc_auth_none.c
@@ -43,14 +43,14 @@ static bool
 svcauth_none_wrap(struct svc_req *req, XDR *xdrs)
 {
 	return ((*req->rq_msg.RPCM_ack.ar_results.proc)
-		(xdrs, req->rq_msg.RPCM_ack.ar_results.where, 0));
+		(xdrs, req->rq_msg.RPCM_ack.ar_results.where));
 }
 
 static bool
 svcauth_none_unwrap(struct svc_req *req)
 {
 	return ((*req->rq_msg.rm_xdr.proc)
-		(req->rq_xdrs, req->rq_msg.rm_xdr.where, 0));
+		(req->rq_xdrs, req->rq_msg.rm_xdr.where));
 }
 
 static bool
@@ -59,7 +59,7 @@ svcauth_none_checksum(struct svc_req *req)
 	XDR *xdrs = req->rq_xdrs;
 
 	SVC_CHECKSUM(req, xdrs->x_data, xdr_size_inline(xdrs));
-	return ((*req->rq_msg.rm_xdr.proc) (xdrs, req->rq_msg.rm_xdr.where, 0));
+	return ((*req->rq_msg.rm_xdr.proc) (xdrs, req->rq_msg.rm_xdr.where));
 }
 
 static bool

--- a/src/xdr.c
+++ b/src/xdr.c
@@ -70,7 +70,7 @@ XDR xdr_free_null_stream = {
  * XDR nothing
  */
 bool
-xdr_void(void)
+xdr_void(XDR *xdrs, void *unused)
 {
 	return (true);
 }

--- a/src/xdr_reference.c
+++ b/src/xdr_reference.c
@@ -84,7 +84,7 @@ xdr_reference(XDR *xdrs, void **pp,	/* the pointer to work on */
 			break;
 		}
 
-	stat = (*proc) (xdrs, loc, 0);
+	stat = (*proc) (xdrs, loc);
 
 	if (xdrs->x_op == XDR_FREE) {
 		mem_free(loc, size);


### PR DESCRIPTION
The third parameter is always called with 0.

All the called functions, which have been cast to xdrproc_t only
take two parameters. Passing the extra 0 doesn't hurt anything but
could be a point of confusion and is extraneous code.

Also, add 2 dummy parameters to xdr_void which is the single function
cast to xdrproc_t that doesn't take two parameters.

Signed-off-by: Frank S. Filz <ffilzlnx@mindspring.com>