### PR TITLE
Update opr_containerof macro to work with clang

### DIFF
--- a/ntirpc/misc/opr.h
+++ b/ntirpc/misc/opr.h
@@ -2,6 +2,6 @@
 #define OPR_H 1
 
 #define opr_containerof(ptr, structure, member) \
-	((structure *)((char *)(ptr)-(char *)(&((structure *)NULL)->member)))
+	((structure *)((char *)(ptr)-(char *)offsetof(structure, member)))
 
 #endif				/* OPR_H */

--- a/ntirpc/misc/rbtree.h
+++ b/ntirpc/misc/rbtree.h
@@ -7,10 +7,6 @@
 #include <stdint.h>
 #include <misc/opr.h>
 
-/* from opr.h */
-#define opr_containerof(ptr, structure, member) \
-	((structure *)((char *)(ptr)-(char *)(&((structure *)NULL)->member)))
-
 struct opr_rbtree_node {
 	struct opr_rbtree_node *left;
 	struct opr_rbtree_node *right;


### PR DESCRIPTION
This code compiles with clang, but sends a SIGILL signal for access inside a NULL structure.
This unifies the container_of macros across ntirpc and NFS Ganesha.
Remove duplicate definition.