### PR TITLE
Fixed mount hang issue on z/OS nfs client.

### DIFF
--- a/src/svc_auth_gss.c
+++ b/src/svc_auth_gss.c
@@ -531,7 +531,6 @@ _svcauth_gss(struct svc_req *req, bool *no_dispatch)
 		}
 
 		if (gr.gr_major == GSS_S_COMPLETE) {
-			gd->established = true;
 			(void)authgss_ctx_hash_set(gd);
 		}
 
@@ -554,6 +553,7 @@ _svcauth_gss(struct svc_req *req, bool *no_dispatch)
 		}
 
 		if (gr.gr_major == GSS_S_COMPLETE) {
+			gd->established = true;
 			/* krb5 pac -- try all that apply */
 			gss_buffer_desc attr, display_buffer;
 


### PR DESCRIPTION
Fixed regression caused by commit id
5a02a88- Fixing the race condition when caching GSS contexts

Signed-off-by: Prabhu Murugesan <prabhu.murugeshan@ibm.com>