### PR TITLE
Remove unused `max` macro

### DIFF
--- a/ntirpc/misc/portable.h
+++ b/ntirpc/misc/portable.h
@@ -66,10 +66,6 @@ void warnx(const char *fmt, ...);
 #define CLOCK_MONOTONIC_FAST CLOCK_MONOTONIC
 #endif
 
-#ifndef max
-#define max(a, b) (a > b ? a : b)
-#endif
-
 #if !defined(CACHE_LINE_SIZE)
 #if defined(__PPC64__)
 #define CACHE_LINE_SIZE 128


### PR DESCRIPTION
This conflicts with symbols in the C++ standard library, e.g
std::numeric_limits<>::max. I was going to rename it to be more
distinct, but it's not used here or in NFS Ganesha, so it can be
deleted.

Signed-off-by: Matthew DeVore <matvore@google.com>