### PR TITLE
Fixed valgrind error

### DIFF
--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -399,7 +399,7 @@ svc_dg_reply(struct svc_req *req)
 	struct cmsghdr* cmsg;
 	struct iovec iov;
 	size_t slen;
-        char msg_control[sizeof(struct cmsghdr) + sizeof(struct in6_pktinfo)];
+        char msg_control[sizeof(struct cmsghdr) + sizeof(struct in6_pktinfo)] = {0};
 
 	if (!xprt->xp_remote.nb.len) {
 		__warnx(TIRPC_DEBUG_FLAG_WARN,


### PR DESCRIPTION
Fixed the following valgrind report by initializing
'buffer' to 0 in 'svc_dg_reply':

==2615== Syscall param sendmsg(msg.msg_control) points to uninitialised byte(s)
==2615==    at 0x6651C6D: ??? (in /usr/lib64/libpthread-2.17.so)
==2615==    by 0x6A8A9E1: svc_dg_reply (svc_dg.c:465)
==2615==    by 0x6A88748: svc_sendreply (svc.c:549)
==2615==    by 0x44CDF2: nfs_rpc_execute (nfs_worker_thread.c:1344)
==2615==    by 0x44D447: worker_run (nfs_worker_thread.c:1562)
==2615==    by 0x50C4FF: fridgethr_start_routine (fridgethr.c:550)
==2615==    by 0x664AE24: start_thread (in /usr/lib64/libpthread-2.17.so)
==2615==    by 0x6FC434C: clone (in /usr/lib64/libc-2.17.so)
==2615==  Address 0x1360ce08 is on thread 17's stack
==2615==  in frame #1, created by svc_dg_reply (svc_dg.c:407)

Signed-off-by: Prabhu Murugesan <prabhu.murugeshan@ibm.com>