### PR TITLE
CMakeLists.txt: Make libnsl optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,13 +197,14 @@ set(SYSTEM_LIBRARIES
   ${SYSTEM_LIBRARIES}
 )
 
-if (NOT BSDBASED)
+option(USE_LIBNSL "Enable NSL sockets" ON)
+if (USE_LIBNSL)
   find_package(NSL) # sockets
   set(SYSTEM_LIBRARIES
     ${SYSTEM_LIBRARIES}
     ${NSL_LIBRARY}
   )
-endif (NOT BSDBASED)
+endif (USE_LIBNSL)
 
 set(LIBNTIRPC_MAP "${PROJECT_BINARY_DIR}/src/libntirpc.map")
 # subst files (need add_custom_command for dependency, fyi)
@@ -221,6 +222,7 @@ message(STATUS)
 message(STATUS "-------------------------------------------------------")
 message(STATUS "TIRPC_EPOLL = ${TIRPC_EPOLL}")
 message(STATUS "USE_RPC_RDMA = ${USE_RPC_RDMA}")
+message(STATUS "USE_LIBNSL = ${USE_LIBNSL}")
 message(STATUS "USE_GSS = ${USE_GSS}")
 message(STATUS "USE_PROFILE = ${USE_PROFILE}")
 message(STATUS "USE_LTTNG_NTIRPC = ${USE_LTTNG_NTIRPC}")

--- a/config-h.in.cmake
+++ b/config-h.in.cmake
@@ -20,6 +20,10 @@
 #cmakedefine TIRPC_EPOLL 1
 #cmakedefine USE_RPC_RDMA 1
 #cmakedefine USE_LTTNG_NTIRPC 1
+#cmakedefine USE_LIBNSL 1
+#ifdef USE_LIBNSL
+#define YP 1
+#endif
 
 /* Package stuff */
 #define PACKAGE "libntirpc"


### PR DESCRIPTION
YP libnsl functionality is already protected by ifdef guards where necessary and there are usecases where it is not required. Add USE_LIBNSL as a build system knob. Fixes #254 

Signed-off-by: Paulo Neves <ptsneves@gmail.com>