### PR TITLE
Allow for non glibc libc.

### DIFF
--- a/ntirpc/misc/event.h
+++ b/ntirpc/misc/event.h
@@ -191,10 +191,14 @@ extern int kqueue_del_filteropts(int filt);
 #include <sys/cdefs.h>
 struct timespec;
 
-__BEGIN_DECLS int kqueue(void);
+#ifdef __cplusplus
+extern "C" {
+#endif int kqueue(void);
 int kevent(int kq, const struct kevent *changelist, int nchanges,
 	   struct kevent *eventlist, int nevents,
 	   const struct timespec *timeout);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* !_KERNEL */
 #endif				/* !_TIRPC_EVENT_H_ */

--- a/ntirpc/netconfig.h
+++ b/ntirpc/netconfig.h
@@ -82,7 +82,9 @@ typedef struct {
 #define NC_ICMP		"icmp"
 
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern void *setnetconfig(void);
 extern struct netconfig *getnetconfig(void *);
 extern struct netconfig *getnetconfigent(const char *);
@@ -96,5 +98,7 @@ extern int endnetpath(void *);
 extern void nc_perror(const char *);
 extern char *nc_sperror(void);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* _NETCONFIG_H_ */

--- a/ntirpc/reentrant.h
+++ b/ntirpc/reentrant.h
@@ -53,7 +53,7 @@
 #define once_t			pthread_once_t
 
 #define thread_key_t		pthread_key_t
-#if defined(__linux__)
+#if defined(__linux__) && defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 2))
 #define MUTEX_INITIALIZER	PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP
 #else
 #define MUTEX_INITIALIZER	PTHREAD_MUTEX_INITIALIZER
@@ -69,8 +69,8 @@ mutex_init(pthread_mutex_t *m, const pthread_mutexattr_t *a
 	int rslt;
 
 	pthread_mutexattr_init(&attr);
-#if defined(__linux__)
-	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ADAPTIVE_NP);
+#if defined(__linux__) && defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 2))
+  pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ADAPTIVE_NP);
 #endif
 	rslt = pthread_mutex_init(m, &attr);
 	pthread_mutexattr_destroy(&attr);

--- a/ntirpc/rpc/auth.h
+++ b/ntirpc/rpc/auth.h
@@ -96,9 +96,13 @@ union des_block {
 	char c[8];
 };
 typedef union des_block des_block;
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern bool xdr_des_block(XDR *, des_block *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * Authentication info.  Opaque to client.
  */
@@ -219,9 +223,13 @@ static inline int auth_put(AUTH *auth)
 	((*((auth)->ah_ops->ah_unwrap))(auth, xdrs,	\
 					xfunc, xwhere))
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern struct opaque_auth _null_auth;
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * Any style authentication.  These routines can be used by any
  * authentication style that does not use the wrap/unwrap functions.
@@ -244,52 +252,72 @@ int authany_wrap(void), authany_unwrap(void);
  * int len;
  * int *aup_gids;
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern AUTH *authunix_ncreate(char *, uid_t, uid_t, int, uid_t *);
 extern AUTH *authunix_ncreate_default(void);	/* takes no parameters */
 extern AUTH *authnone_ncreate(void);	/* takes no parameters */
 extern AUTH *authnone_ncreate_dummy(void);	/* takes no parameters */
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * Netname manipulation routines.
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern int getnetname(char *);
 extern int host2netname(char *, const char *, const char *);
 extern int user2netname(char *, const uid_t, const char *);
 extern int netname2user(char *, uid_t *, gid_t *, int *, gid_t *);
 extern int netname2host(char *, char *, const int);
 extern void passwd2des(char *, char *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  *
  * These routines interface to the keyserv daemon
  *
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern int key_decryptsession(const char *, des_block *);
 extern int key_encryptsession(const char *, des_block *);
 extern int key_gendes(des_block *);
 extern int key_setsecret(const char *);
 extern int key_secretkey_is_set(void);
 extern int key_encryptsession_pk(char *, netobj *, des_block *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * Publickey routines.
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern int getpublickey(const char *, char *);
 extern int getpublicandprivatekey(char *, char *);
 extern int getsecretkey(char *, char *, char *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 struct svc_req;
 enum auth_stat _svcauth_none(struct svc_req *);
 enum auth_stat _svcauth_short(struct svc_req *);
 enum auth_stat _svcauth_unix(struct svc_req *);
 enum auth_stat _svcauth_gss(struct svc_req *, bool *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 #define AUTH_NONE 0		/* no authentication */
 #define AUTH_NULL 0		/* backward compatibility */

--- a/ntirpc/rpc/auth_gss.h
+++ b/ntirpc/rpc/auth_gss.h
@@ -108,7 +108,9 @@ struct rpc_gss_init_res {
 typedef void (*checksum_func_t) (void *priv, void *databuf, size_t length);
 
 /* Prototypes. */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 bool xdr_rpc_gss_cred(XDR *xdrs, struct rpc_gss_cred *p);
 bool xdr_rpc_gss_init_args(XDR *xdrs, gss_buffer_desc *p);
 bool xdr_rpc_gss_init_res(XDR *xdrs, struct rpc_gss_init_res *p);
@@ -128,6 +130,8 @@ bool authgss_get_private_data(AUTH *auth, struct authgss_private_data *);
 
 void gss_log_status(char *m, OM_uint32 major, OM_uint32 minor);
 void gss_log_hexdump(const u_char *buf, int len, int offset);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 #endif				/* !_TIRPC_AUTH_GSS_H */

--- a/ntirpc/rpc/auth_unix.h
+++ b/ntirpc/rpc/auth_unix.h
@@ -68,9 +68,13 @@ struct authunix_parms {
 
 #define authsys_parms authunix_parms
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern bool xdr_authunix_parms(XDR *, struct authunix_parms *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * If a response verifier has flavor AUTH_SHORT,
  * then the body of the response verifier encapsulates the following structure;

--- a/ntirpc/rpc/clnt.h
+++ b/ntirpc/rpc/clnt.h
@@ -367,7 +367,9 @@ static inline void clnt_destroy_it(CLIENT *clnt,
  * Always returns CLIENT. Must check cl_error.re_status,
  * followed by CLNT_DESTROY() as necessary.
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /*
  * Generic client creation routine. Supported protocols are those that
@@ -584,14 +586,20 @@ enum clnt_stat clnt_req_setup(struct clnt_req *, struct timespec);
 enum clnt_stat clnt_req_wait_reply(struct clnt_req *);
 int clnt_req_release(struct clnt_req *);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * Used by rpc_perror() and rpc_sperror()
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern void clnt_perrno(enum clnt_stat);	/* stderr */
 extern char *clnt_sperrno(enum clnt_stat);	/* string */
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * The simplified interface:
  * enum clnt_stat
@@ -606,13 +614,17 @@ __END_DECLS
  * void *out;
  * const char *nettype;
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern enum clnt_stat rpc_call(const char *, const rpcprog_t,
 			       const rpcvers_t, const rpcproc_t,
 			       const xdrproc_t, const void *,
 			       const xdrproc_t, void *,
 			       const char *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * RPC broadcast interface
  * The call is broadcasted to all locally connected nets.
@@ -658,7 +670,9 @@ __END_DECLS
  */
 typedef bool(*resultproc_t) (void *, ...);
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern enum clnt_stat rpc_broadcast(const rpcprog_t,
 				    const rpcvers_t,
 				    const rpcproc_t,
@@ -671,7 +685,9 @@ extern enum clnt_stat rpc_broadcast_exp(const rpcprog_t, const rpcvers_t,
 					void *, const xdrproc_t, void *,
 					const resultproc_t, const int,
 					const int, const char *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /* For backward compatibility */
 #include <rpc/tirpc_compat.h>
 #endif				/* !_TIRPC_CLNT_H_ */

--- a/ntirpc/rpc/des_crypt.h
+++ b/ntirpc/rpc/des_crypt.h
@@ -81,19 +81,31 @@
 /*
  * Cipher Block Chaining mode
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 int cbc_crypt(char *, char *, unsigned int, unsigned int, char *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * Electronic Code Book mode
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 int ecb_crypt(char *, char *, unsigned int, unsigned int);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * Set des parity for a key.
  * DES parity is odd and in the low bit of each byte
  */
-__BEGIN_DECLS void des_setparity(char *);
-__END_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif void des_setparity(char *);
+#ifdef __cplusplus
+}
+#endif
 #endif				/* _DES_DES_CRYPT_H */

--- a/ntirpc/rpc/nettype.h
+++ b/ntirpc/rpc/nettype.h
@@ -55,12 +55,16 @@
 #define	_RPC_UDP	8
 #define _RPC_VSOCK      9 /* XXX assignment */
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern void *__rpc_setconf(const char *);
 extern void __rpc_endconf(void *);
 extern struct netconfig *__rpc_getconf(void *);
 extern struct netconfig *__rpc_getconfip(const char *);
 extern struct netbuf *rpcb_find_mapped_addr(char *nettype, rpcprog_t prog,
 					    rpcvers_t vers, char *local_addr);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* !_TIRPC_NETTYPE_H */

--- a/ntirpc/rpc/pmap_prot.h
+++ b/ntirpc/rpc/pmap_prot.h
@@ -41,7 +41,9 @@
 #endif
 #include <rpc/xdr.h>
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* The following procedures are supported by the protocol:
  *
  * PMAPPROC_NULL() returns ()
@@ -100,5 +102,7 @@ struct pmaplist {
 
 extern bool xdr_pmaplist(XDR *__xdrs, struct pmaplist **__rp);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* rpc/pmap_prot.h */

--- a/ntirpc/rpc/pmap_rmt.h
+++ b/ntirpc/rpc/pmap_rmt.h
@@ -60,8 +60,12 @@ struct rmtcallres {
 	rpcport_t port;
 };
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern bool xdr_rmtcall_args(XDR *, struct rmtcallargs *);
 extern bool xdr_rmtcallres(XDR *, struct rmtcallres *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* !_RPC_PMAP_RMT_H */

--- a/ntirpc/rpc/rpc.h
+++ b/ntirpc/rpc/rpc.h
@@ -72,7 +72,9 @@
 #define UDPMSGSIZE 8800
 #endif
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern int bindresvport(int, struct sockaddr_in *);
 
 char *taddr2uaddr(const struct netconfig *, const struct netbuf *);
@@ -85,16 +87,22 @@ extern bool tirpc_control(const u_int, void *);
 extern void *__mem_alloc(size_t);
 extern void __mem_free(void *, size_t);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * The following are not exported interfaces, they are for internal library
  * and rpcbind use only. Do not use, they may change without notice.
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 int __rpc_nconf2fd(const struct netconfig *);
 int __rpc_nconf2fd_flags(const struct netconfig *, int);
 int __rpc_nconf2sockinfo(const struct netconfig *, struct __rpc_sockinfo *);
 int __rpc_fd2sockinfo(int, struct __rpc_sockinfo *);
 u_int __rpc_get_t_size(int, int, int);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* !_RPC_RPC_H */

--- a/ntirpc/rpc/rpc_com.h
+++ b/ntirpc/rpc/rpc_com.h
@@ -56,7 +56,9 @@
 	((u_int32_t)getpid() ^ (u_int32_t)(now)->tv_sec ^ \
 	 (u_int32_t)(now)->tv_usec)
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern u_int __rpc_get_a_size(int);
 extern int __rpc_dtbsize(void);
 extern int _rpc_dtablesize(void);
@@ -76,5 +78,7 @@ struct netbuf *__rpcb_findaddr(rpcprog_t, rpcvers_t, const struct netconfig *,
 bool rpc_control(int, void *);
 char *_get_next_token(char *, int);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* _RPC_RPCCOM_H */

--- a/ntirpc/rpc/rpc_msg.h
+++ b/ntirpc/rpc/rpc_msg.h
@@ -178,7 +178,9 @@ struct rpc_msg {
 #define RPCM_ack ru.RM_rmb.ru.RP_ar
 #define RPCM_rej ru.RM_rmb.ru.RP_dr
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 static inline void
 rpc_msg_init(struct rpc_msg *msg)
 {
@@ -248,7 +250,9 @@ extern bool xdr_nrejected_reply(XDR *, struct rejected_reply *);
  *  struct rpc_err *error;
  */
 extern void _seterr_reply(struct rpc_msg *, struct rpc_err *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /* For backward compatibility */
 #include <rpc/tirpc_compat.h>
 #endif				/* !_TIRPC_RPC_MSG_H */

--- a/ntirpc/rpc/rpcb_clnt.h
+++ b/ntirpc/rpc/rpcb_clnt.h
@@ -60,7 +60,9 @@
 #include <rpc/types.h>
 #include <rpc/rpcb_prot.h>
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern bool rpcb_set(const rpcprog_t, const rpcvers_t,
 		     const struct netconfig *,
 		     const struct netbuf *);
@@ -79,5 +81,7 @@ extern bool rpcb_getaddr(const rpcprog_t, const rpcvers_t,
 extern bool rpcb_gettime(const char *, time_t *);
 extern char *rpcb_taddr2uaddr(struct netconfig *, struct netbuf *);
 extern struct netbuf *rpcb_uaddr2taddr(struct netconfig *, char *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* !_RPC_RPCB_CLNT_H */

--- a/ntirpc/rpc/rpcent.h
+++ b/ntirpc/rpc/rpcent.h
@@ -45,9 +45,11 @@
 /*	#pragma ident "@(#)rpcent.h   1.13    94/04/25 SMI"	*/
 /*      @(#)rpcent.h 1.1 88/12/06 SMI   */
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* These are defined in /usr/include/rpc/netdb.h */
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || ! defined(__GLIBC__)
 struct rpcent {
 	char *r_name;		/* name of server for this rpc program */
 	char **r_aliases;	/* alias list */
@@ -69,5 +71,7 @@ extern struct rpcent *getrpcent(void);
 
 extern void setrpcent(int);
 extern void endrpcent(void);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* !_RPC_CENT_H */

--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -361,9 +361,13 @@ extern void svc_resume(struct svc_req *req);
 /*
  * Trace transport (de-)references, with remote address
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern void svc_xprt_trace(SVCXPRT *, const char *, const char *, const int);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 #define XPRT_TRACE(xprt, func, tag, line)				 \
 	if (__ntirpc_pkg_params.debug_flags & TIRPC_DEBUG_FLAG_REFCNT) { \
@@ -493,17 +497,25 @@ static inline void svc_destroy_it(SVCXPRT *xprt,
  * Service init (optional).
  */
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern struct work_pool svc_work_pool;
 
 bool svc_init(struct svc_init_params *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * Service shutdown (optional).
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 int svc_shutdown(u_long flags);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * Service registration
  *
@@ -514,11 +526,15 @@ __END_DECLS
  * const void (*dispatch)();
  * const struct netconfig *nconf;
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern bool svc_reg(SVCXPRT *, const rpcprog_t, const rpcvers_t,
 		    void (*)(struct svc_req *),
 		    const struct netconfig *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * Service un-registration
  *
@@ -526,15 +542,21 @@ __END_DECLS
  * const rpcprog_t prog;
  * const rpcvers_t vers;
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern void svc_unreg(const rpcprog_t, const rpcvers_t);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * This is used to set local and remote addresses in a way legacy
  * apps can deal with, at the same time setting up a corresponding
  * netbuf -- with no alloc/free needed.
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern u_int __rpc_address_port(struct rpc_address *);
 extern void __rpc_address_set_length(struct rpc_address *, socklen_t);
 
@@ -545,7 +567,9 @@ __rpc_address_setup(struct rpc_address *rpca)
 	rpca->nb.len =
 	rpca->nb.maxlen = sizeof(struct sockaddr_storage);
 }
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * When the service routine is called, it must first check to see if it
  * knows about the procedure;  if not, it should call svcerr_noproc
@@ -571,7 +595,9 @@ __END_DECLS
  * batched and which are not.  Warning: responding to batch calls may
  * deadlock the caller and server processes!
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern enum xprt_stat svc_sendreply(struct svc_req *);
 extern enum xprt_stat svcerr_decode(struct svc_req *);
 extern enum xprt_stat svcerr_weakauth(struct svc_req *);
@@ -582,14 +608,20 @@ extern enum xprt_stat svcerr_noprog(struct svc_req *);
 extern enum xprt_stat svcerr_systemerr(struct svc_req *);
 extern int rpc_reg(rpcprog_t, rpcvers_t, rpcproc_t, char *(*)(char *),
 		   xdrproc_t, xdrproc_t, char *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * a small program implemented by the svc_rpc implementation itself;
  * also see clnt.h for protocol numbers.
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern void rpctest_service(void);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /*
  * Socket to use on svcxxx_ncreate call to get default socket
  */
@@ -603,7 +635,9 @@ __END_DECLS
 /*
  * These are the existing service side transport implementations
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 /*
  * Transport independent svc_create routine.
  */
@@ -644,7 +678,9 @@ extern SVCXPRT *svc_tli_ncreate(const int, const struct netconfig *,
  *      const u_int sendsz;             -- max sendsize
  *      const u_int recvsz;             -- max recvsize
  */
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 /*
  * Connectionless and connectionful create routines
@@ -659,7 +695,9 @@ __END_DECLS
 #define SVC_CREATE_FLAG_XPRT_DOREG	0x80000000
 #define SVC_CREATE_FLAG_XPRT_NOREG	0x08000000
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 extern SVCXPRT *svc_vc_ncreatef(const int, const u_int, const u_int,
 				const uint32_t);
@@ -758,7 +796,9 @@ extern bool svc_validate_xprt_list(SVCXPRT *);
 
 int __rpc_get_local_uid(SVCXPRT *, uid_t *);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /* for backward compatibility */
 #include <rpc/tirpc_compat.h>
 #endif				/* !_TIRPC_SVC_H */

--- a/ntirpc/rpc/svc_auth.h
+++ b/ntirpc/rpc/svc_auth.h
@@ -75,8 +75,12 @@ typedef struct SVCAUTH {
 /*
  * Server side authenticator
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern enum auth_stat svc_auth_authenticate(struct svc_req *, bool *);
 extern int svc_auth_reg(int, enum auth_stat (*)(struct svc_req *));
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* !_RPC_SVC_AUTH_H */

--- a/ntirpc/rpc/types.h
+++ b/ntirpc/rpc/types.h
@@ -50,9 +50,6 @@
 
 #if defined(_WIN32)
 
-#define __BEGIN_DECLS
-#define __END_DECLS
-
 /* integral types */
 #ifndef _MSC_VER
 #include <_bsd_types.h>		/* XXX mingw (defines u_long) */

--- a/ntirpc/rpc/xdr.h
+++ b/ntirpc/rpc/xdr.h
@@ -640,7 +640,9 @@ xdr_putbool(XDR *xdrs, bool_t boolv)
 /*
  * These are the "generic" xdr routines.
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern XDR xdr_free_null_stream;
 
 extern bool xdr_void(XDR *, void *);
@@ -656,7 +658,9 @@ extern bool xdr_wrapstring(XDR *, char **);
 extern bool xdr_longlong_t(XDR *, quad_t *);
 extern bool xdr_u_longlong_t(XDR *, u_quad_t *);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 /*
  * Free a data structure using XDR
@@ -684,14 +688,18 @@ extern bool xdr_nnetobj(XDR *, struct netobj *);
  * These are the public routines for the various implementations of
  * xdr streams.
  */
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* XDR using memory buffers */
 extern void xdrmem_ncreate(XDR *, char *, u_int, enum xdr_op);
 
 /* intrinsic checksum (be careful) */
 extern uint64_t xdrmem_cksum(XDR *, u_int);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 /* For backward compatibility */
 #include <rpc/tirpc_compat.h>
 #endif				/* !_TIRPC_XDR_H */

--- a/src/rpc_com.h
+++ b/src/rpc_com.h
@@ -58,7 +58,9 @@
 			   (u_int32_t)((now)->tv_nsec))
 #endif				/* !__RPC_GETXID */
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern u_int __rpc_get_a_size(int);
 extern int __rpc_dtbsize(void);
 extern struct netconfig *__rpcgettp(int);
@@ -84,5 +86,7 @@ bool __rpc_control(int, void *);
 
 char *_get_next_token(char *, int);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* _TIRPC_RPCCOM_H */

--- a/src/xdr_float.c
+++ b/src/xdr_float.c
@@ -91,7 +91,12 @@ static struct sgl_limits {
 #else
 
 #if defined(__linux__)
+#if defined (__GLIBC__)
 #include <bits/endian.h>
+#else
+#include <endian.h>
+#endif
+
 #elif defined(_WIN32)
 /* XXX */
 #elif defined(__APPLE__)


### PR DESCRIPTION
Some of the headers used are glibc specific and they needed to be tuned.
Usage of __BEGIN_DECLS and __END_DECLS is not allowed even on glibc as it is a private header. Fixed it according to [1]

[1] https://wiki.musl-libc.org/faq.html#Q:-When-compiling-something-against-musl,-I-get-error-messages-about-%3Ccode%3Esys/cdefs.h%3C/code%3E