### PR TITLE
ntirpc: Build with Modern C

### DIFF
--- a/src/authgss_hash.c
+++ b/src/authgss_hash.c
@@ -116,7 +116,7 @@ svc_rpc_gss_cmpf(const struct opr_rbtree_node *lhs,
 }
 
 static void
-authgss_hash_init()
+authgss_hash_init(void)
 {
 	int ix, code = 0;
 

--- a/src/authgss_prot.c
+++ b/src/authgss_prot.c
@@ -177,7 +177,7 @@ gss_log_error(char *m, OM_uint32 maj_stat, OM_uint32 min_stat)
 {
 	OM_uint32 min;
 	gss_buffer_desc msg1, msg2;
-	int msg_ctx = 0;
+	unsigned int msg_ctx = 0;
 
 	gss_display_status(&min, maj_stat, GSS_C_GSS_CODE, GSS_C_NULL_OID,
 			   &msg_ctx, &msg1);

--- a/src/svc_xprt.c
+++ b/src/svc_xprt.c
@@ -350,7 +350,7 @@ svc_xprt_dump_xprts(const char *tag)
 }
 
 void
-svc_xprt_shutdown()
+svc_xprt_shutdown(void)
 {
 	struct rbtree_x_part *t;
 	struct opr_rbtree_node *n;

--- a/src/svc_xprt.h
+++ b/src/svc_xprt.h
@@ -63,6 +63,6 @@ typedef bool(*svc_xprt_each_func_t) (SVCXPRT *, void *);
 int svc_xprt_foreach(svc_xprt_each_func_t, void *);
 
 void svc_xprt_dump_xprts(const char *);
-void svc_xprt_shutdown();
+void svc_xprt_shutdown(void);
 
 #endif				/* TIRPC_SVC_XPRT_H */

--- a/tests/rpcping.c
+++ b/tests/rpcping.c
@@ -213,7 +213,7 @@ free_request(struct svc_req *req, enum xprt_stat stat)
 	free(req);
 }
 
-static void usage()
+static void usage(void)
 {
 	printf("Usage: rpcping <raw|rdma|tcp|udp> <host> [--rpcbind] [--count=<n>] [--threads=<n>] [--workers=<n>] [--port=<n>] [--program=<n>] [--version=<n>] [--procedure=<n>]\n");
 }


### PR DESCRIPTION
GCC and Clang communities are hinting that in versions 14 and 16 respectively that they will deprecate or disable legacy C89 features, e.g. K&R1 style function definitions, among others.

In parallel, Fedora is going to start enforcing C99 as the minimum, expected to land in F40. (I.e. around Spring 2024 IIRC.)

Currently Fedora is recommending that use of -Werror=implicit-int, -Werror=implicit-function-declaration, -Werror=int-conversion, -Werror=strict-prototypes, and -Werror=old-style-definition a set of options to build with in the mean time to clean up code.

Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>