### PR TITLE
ntirpc: use __THROW attribute in {set,end}rpcent

### DIFF
--- a/ntirpc/rpc/rpcent.h
+++ b/ntirpc/rpc/rpcent.h
@@ -67,7 +67,12 @@ extern struct rpcent *getrpcbynumber(int);
 extern struct rpcent *getrpcent(void);
 #endif
 
+#ifdef __THROW
+extern void setrpcent(int) __THROW;
+extern void endrpcent(void) __THROW;
+#else
 extern void setrpcent(int);
 extern void endrpcent(void);
+#endif
 __END_DECLS
 #endif				/* !_RPC_CENT_H */


### PR DESCRIPTION
Modern glibc headers use the __THROW attribute for setrpcent and endrpcent. When compiled against C++ code, the absence of this attribute in ntirpc code causes compilation error due to declarations mismatch ("has a different exception specifier").

Signed-off-by: Shachar Sharon <ssharon@redhat.com>