### PR TITLE
xdr: Fix uio reference for xdrmem ops.

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -42,6 +42,9 @@
 #ifndef _TIRPC_SVC_H
 #define _TIRPC_SVC_H
 
+#ifdef USE_RPC_RDMA
+#include <assert.h>
+#endif
 #include <sys/cdefs.h>
 #include <rpc/rpc_msg.h>
 #include <rpc/types.h>
@@ -142,6 +145,13 @@ typedef struct svc_init_params {
 	u_int gss_max_idle_gen;
 	u_int gss_max_gc;
 	uint32_t channels;
+
+#if defined(_USE_NFS_RDMA) || defined(USE_RPC_RDMA)
+	uint32_t nfs_rdma_port; //Shared with Ganesha
+	bool enable_rdma_dump;
+	uint32_t max_rdma_connections;
+#endif
+
 	int32_t idle_timeout;
 	uint32_t thr_stack_size;
 } svc_init_params;
@@ -271,6 +281,11 @@ struct svc_xprt {
 	void *xp_u1;		/* client user data */
 	void *xp_u2;		/* client user data */
 
+#if defined(_USE_NFS_RDMA) || defined(USE_RPC_RDMA)
+	bool xp_rdma;		/* True if this xprt is RDMA enabled.
+				 * Shared with Ganesha */
+#endif
+
 	struct rpc_address xp_local;	/* local address, length, port */
 	struct rpc_address xp_remote;	/* remote address, length, port */
 	struct rpc_address xp_proxy;	/* proxy address, length, port */
@@ -338,6 +353,11 @@ struct svc_req {
 	void *rq_u1;		/* user data */
 	void *rq_u2;		/* user data */
 	uint64_t rq_cksum;
+
+#if defined(_USE_NFS_RDMA) || defined(USE_RPC_RDMA)
+	int data_chunk_length;	/* Shared with Ganesha */
+	uint8_t *data_chunk;	/* Shared with Ganesha */
+#endif
 
 	/* Moved in N TI-RPC */
 	struct SVCAUTH *rq_auth;	/* auth handle */

--- a/ntirpc/rpc/xdr_ioq.h
+++ b/ntirpc/rpc/xdr_ioq.h
@@ -34,9 +34,23 @@
 #include <rpc/work_pool.h>
 #include <rpc/xdr.h>
 
+#ifdef USE_RPC_RDMA
+typedef enum xdr_ioq_uv_type {
+	UV_DATA = 1,
+	UV_HDR
+} xdr_ioq_uv_type_t;
+#endif
+
 struct xdr_ioq_uv
 {
 	struct poolq_entry uvq;
+
+#ifdef USE_RPC_RDMA
+	bool_t rdma_uv; /* Flag to identifu uv used for RDMA */
+	struct xdr_vio rdma_v; /* Used to reset v after UIO_REFER */
+	struct xdr_uio rdma_u; /* Used to reset u after UIO_REFER */
+	xdr_ioq_uv_type_t uv_type;
+#endif
 
 	/* spliced buffers, if any */
 	struct xdr_uio u;
@@ -84,7 +98,6 @@ struct xdr_ioq {
 	struct work_pool_entry ioq_wpe;
 	struct poolq_entry ioq_s;	/* segment of stream */
 	pthread_cond_t ioq_cond;
-
 	struct poolq_head *ioq_pool;
 	struct xdr_ioq_uv_head ioq_uv;	/* header/vectors */
 
@@ -92,6 +105,11 @@ struct xdr_ioq {
 	uint32_t write_start; /* Position to start write at */
 	int frag_hdr_bytes_sent; /* Indicates a fragment header has been sent */
 	bool has_blocked;
+
+#ifdef USE_RPC_RDMA
+	bool rdma_ioq;
+#endif
+
 	struct rpc_dplx_rec *rec;
 };
 
@@ -132,4 +150,20 @@ extern void xdr_ioq_destroy_pool(struct poolq_head *ioqh);
 
 extern const struct xdr_ops xdr_ioq_ops;
 
+#ifdef USE_RPC_RDMA
+extern const struct xdr_ops xdr_ioq_ops_rdma;
+extern void xdr_rdma_ioq_uv_release(struct xdr_ioq_uv *uv);
+extern void xdr_rdma_ioq_release(struct poolq_head *ioqh, bool xioq_recycle,
+    struct xdr_ioq *xioq);
+extern struct poolq_entry *xdr_rdma_ioq_uv_fetch(struct xdr_ioq *xioq,
+					     struct poolq_head *ioqh,
+					     char *comment,
+					     u_int count,
+					     u_int ioq_flags);
+extern struct poolq_entry *xdr_rdma_ioq_uv_fetch_nothing(struct xdr_ioq *xioq,
+						     struct poolq_head *ioqh,
+						     char *comment,
+						     u_int count,
+						     u_int ioq_flags);
+#endif
 #endif				/* XDR_IOQ_H */

--- a/src/rpc_dplx_internal.h
+++ b/src/rpc_dplx_internal.h
@@ -78,6 +78,10 @@ struct rpc_dplx_rec {
 
 	size_t maxrec;
 	long pagesz;
+#ifdef USE_RPC_RDMA
+	u_int recvsz_hdr;
+	u_int sendsz_hdr;
+#endif
 	u_int recvsz;
 	u_int sendsz;
 	uint32_t call_xid;		/**< current call xid */

--- a/src/svc.c
+++ b/src/svc.c
@@ -130,6 +130,12 @@ svc_init(svc_init_params *params)
 	struct work_pool_params work_pool_params = {0,};
 	uint32_t channels = params->channels ? params->channels : 8;
 
+#ifdef USE_RPC_RDMA
+	__svc_params->nfs_rdma_port = params->nfs_rdma_port;
+	__svc_params->enable_rdma_dump = params->enable_rdma_dump;
+#endif
+
+
 	mutex_lock(&__svc_params->mtx);
 	if (__svc_params->initialized) {
 		__warnx(TIRPC_DEBUG_FLAG_WARN,
@@ -232,6 +238,7 @@ svc_init(svc_init_params *params)
 
 #ifdef USE_RPC_RDMA
 	rpc_rdma_internals_init();
+	__svc_params->max_rdma_connections = params->max_rdma_connections;
 #endif
 
 	__svc_params->initialized = true;

--- a/src/svc_internal.h
+++ b/src/svc_internal.h
@@ -82,6 +82,13 @@ struct svc_params {
 	u_long flags;
 	u_int max_connections;
 	int32_t idle_timeout;
+
+#ifdef USE_RPC_RDMA
+	uint32_t nfs_rdma_port;
+	bool enable_rdma_dump;
+	u_int max_rdma_connections;
+#endif
+
 };
 
 enum xprt_stat svc_request(SVCXPRT *xprt, XDR *xdrs);

--- a/src/svc_rdma.c
+++ b/src/svc_rdma.c
@@ -59,6 +59,8 @@
 #include "rpc_rdma.h"
 #include <rpc/svc_rqst.h>
 #include <rpc/svc_auth.h>
+#include <rpc/svc_rpc_forward.h>
+#include <rpc/svc_io_pool.h>
 
 static void svc_rdma_ops(SVCXPRT *);
 
@@ -70,6 +72,10 @@ svc_rdma_rendezvous(SVCXPRT *xprt)
 {
 	struct sockaddr_storage *ss;
 	RDMAXPRT *req_xd = RDMA_DR(REC_XPRT(xprt));
+
+	__warnx(TIRPC_DEBUG_FLAG_EVENT,
+		"Entering %s:%u", __func__, __LINE__);
+
 	RDMAXPRT *xd = rpc_rdma_accept_wait(req_xd,
 					    __svc_params->idle_timeout);
 
@@ -80,23 +86,36 @@ svc_rdma_rendezvous(SVCXPRT *xprt)
 		return (XPRT_DIED);
 	}
 
-	xd->sm_dr.xprt.xp_flags = SVC_XPRT_FLAG_CLOSE
-				| SVC_XPRT_FLAG_INITIAL
+	/* We don't manage socket fd for rdma */
+	xd->sm_dr.xprt.xp_flags = SVC_XPRT_FLAG_INITIAL
 				| SVC_XPRT_FLAG_INITIALIZED;
-	/* fixme: put something here, but make it not work on fd operations. */
-	xd->sm_dr.xprt.xp_fd = -1;
 
 	ss = (struct sockaddr_storage *)rdma_get_local_addr(xd->cm_id);
 	__rpc_address_setup(&xd->sm_dr.xprt.xp_local);
-	memcpy(&xd->sm_dr.xprt.xp_local.nb.buf, ss,
+	memcpy(xd->sm_dr.xprt.xp_local.nb.buf, ss,
 		xd->sm_dr.xprt.xp_local.nb.len);
 
 	ss = (struct sockaddr_storage *)rdma_get_peer_addr(xd->cm_id);
 	__rpc_address_setup(&xd->sm_dr.xprt.xp_remote);
-	memcpy(&xd->sm_dr.xprt.xp_remote.nb.buf, ss,
+	memcpy(xd->sm_dr.xprt.xp_remote.nb.buf, ss,
 		xd->sm_dr.xprt.xp_remote.nb.len);
 
+	xd->sm_dr.xprt.xp_ip = gsh_malloc(SOCK_NAME_MAX);
+	convert_sockaddr_to_ipname(ss, xd->sm_dr.xprt.xp_ip,
+				   SOCK_NAME_MAX);
+
+	__warnx(TIRPC_DEBUG_FLAG_EVENT,
+		"%s:%u local %p remote %p xprt %p xp_ip %s", __func__, __LINE__,
+		&xd->sm_dr.xprt.xp_local.nb, &xd->sm_dr.xprt.xp_remote.nb,
+		&xd->sm_dr.xprt, xd->sm_dr.xprt.xp_ip);
+
 	svc_rdma_ops(&xd->sm_dr.xprt);
+	xd->sm_dr.recvsz = req_xd->sm_dr.recvsz;
+	xd->sm_dr.sendsz = req_xd->sm_dr.sendsz;
+	xd->sm_dr.pagesz = req_xd->sm_dr.pagesz;
+
+	xd->sm_dr.recvsz_hdr = req_xd->sm_dr.recvsz_hdr;
+	xd->sm_dr.sendsz_hdr = req_xd->sm_dr.sendsz_hdr;
 
 	if (xdr_rdma_create(xd)) {
 		SVC_DESTROY(&xd->sm_dr.xprt);
@@ -108,13 +127,55 @@ svc_rdma_rendezvous(SVCXPRT *xprt)
 		return (XPRT_DESTROYED);
 	}
 
+	XPRT_TRACE(&xd->sm_dr.xprt, __func__, __func__, __LINE__);
 	SVC_REF(xprt, SVC_REF_FLAG_NONE);
 	xd->sm_dr.xprt.xp_parent = xprt;
+
+	svc_vc_add_xprt_thrds(&xd->sm_dr.xprt);
+	int retval = 0;
+
 	if (xprt->xp_dispatch.rendezvous_cb(&xd->sm_dr.xprt)
-	 || svc_rqst_xprt_register(&xd->sm_dr.xprt, xprt)) {
-		SVC_DESTROY(&xd->sm_dr.xprt);
+	 || ((retval = svc_rqst_xprt_register(&xd->sm_dr.xprt, xprt)) != 0)) {
+		__warnx(TIRPC_DEBUG_FLAG_WARN,
+			"%s:%u ERROR (return %d)",
+			__func__, __LINE__, retval);
+		/* svc_rqst_xprt_register fails at epoll_ctl, as xp_fd is -1.
+		 * That case returns bad descriptor error, hence ignoring it */
+		if (retval != EBADF) {
+			SVC_DESTROY(&xd->sm_dr.xprt);
+			SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
+			return (XPRT_DESTROYED);
+		}
+	}
+
+	/* RDMA xprts do not have a valid FD but identified with QPs, But for
+	 * bookkeeping the clients we will use the FD of RDMA event channel here
+	 */
+	xd->sm_dr.xprt.xp_fd = xd->event_channel->fd;
+	xd->sm_dr.xprt.start_time = time(NULL);
+
+	if (svc_rdma_add_xprt(xprt)) {
+		__warnx(TIRPC_DEBUG_FLAG_WARN,
+			"%s:%u svc_rdma_add_xprt failed (xprt %p)",
+			__func__, __LINE__, xprt);
 		return (XPRT_DESTROYED);
 	}
+
+	__warnx(TIRPC_DEBUG_FLAG_EVENT,
+		"%s:%u New RDMA client connected xprt %p, xp_fd %d, "
+		"qp_num %d, xp_fd %d is_rdma_enabled %d to local port %d "
+		"from IP %s remote port %d client_conn %d ref %d epoll %#04x",
+		__func__, __LINE__,
+		&xd->sm_dr.xprt, xd->sm_dr.xprt.xp_fd, xd->qp->qp_num,
+		xd->sm_dr.xprt.xp_fd, xd->sm_dr.xprt.xp_rdma,
+		xd->sm_dr.xprt.xp_local.nb.buf ?
+		svc_get_port(xd->sm_dr.xprt.xp_local.nb.buf) : 0,
+		xd->sm_dr.xprt.xp_ip,
+		xd->sm_dr.xprt.xp_remote.nb.buf ?
+		svc_get_port(xd->sm_dr.xprt.xp_remote.nb.buf) : 0,
+		xd->sm_dr.xprt.client_conn,
+		xd->sm_dr.xprt.xp_refcnt, xd->sm_dr.xprt.xp_flags);
+
 	return (XPRT_IDLE);
 }
 
@@ -136,10 +197,11 @@ svc_rdma_stat(SVCXPRT *xprt)
 static enum xprt_stat
 svc_rdma_decode(struct svc_req *req)
 {
+	/* We used xdrs from sendq */
 	XDR *xdrs = req->rq_xdrs;
-	struct xdr_ioq *holdq = XIOQ(xdrs);
+	struct xdr_ioq *recvq = XIOQ(xdrs);
 	struct rpc_rdma_cbc *cbc =
-		opr_containerof(holdq, struct rpc_rdma_cbc, holdq);
+		opr_containerof(recvq, struct rpc_rdma_cbc, recvq);
 
 	__warnx(TIRPC_DEBUG_FLAG_SVC_RDMA,
 		"%s() xprt %p req %p cbc %p incoming xdr %p\n",
@@ -151,6 +213,12 @@ svc_rdma_decode(struct svc_req *req)
 			__func__);
 		return (XPRT_DIED);
 	}
+
+	req->data_chunk = cbc->data_chunk_uv->v.vio_head;
+	req->data_chunk_length = ioquv_size(cbc->data_chunk_uv);
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: xdata %p req %p data chunk %p",
+		__func__, xdrs->x_data, req, req->data_chunk);
 
 	xdrs->x_op = XDR_DECODE;
 	/* No need, already positioned to beginning ...
@@ -168,6 +236,9 @@ svc_rdma_decode(struct svc_req *req)
 	/* the checksum */
 	req->rq_cksum = 0;
 
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: post decode req %p data chunk %p",
+		__func__, xdrs->x_data, req, req->data_chunk);
+
 	return (req->rq_xprt->xp_dispatch.process_cb(req));
 }
 
@@ -175,20 +246,23 @@ static enum xprt_stat
 svc_rdma_reply(struct svc_req *req)
 {
 	XDR *xdrs = req->rq_xdrs;
-	struct xdr_ioq *holdq = XIOQ(xdrs);
+	struct xdr_ioq *recvq = XIOQ(xdrs);
 	struct rpc_rdma_cbc *cbc =
-		opr_containerof(holdq, struct rpc_rdma_cbc, holdq);
+		opr_containerof(recvq, struct rpc_rdma_cbc, recvq);
 
 	__warnx(TIRPC_DEBUG_FLAG_SVC_RDMA,
 		"%s() xprt %p req %p cbc %p outgoing xdr %p\n",
 		__func__, req->rq_xprt, req, cbc, xdrs);
 
-	if (!xdr_rdma_svc_reply(cbc, 0)){
+	xdrs = cbc->sendq.xdrs;
+
+	if (!xdr_rdma_svc_reply(cbc, 0, req->data_chunk_length ? 1 : 0)){
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s: xdr_rdma_svc_reply failed (will set dead)",
 			__func__);
 		return (XPRT_DIED);
 	}
+
 	xdrs->x_op = XDR_ENCODE;
 
 	if (!xdr_reply_encode(xdrs, &req->rq_msg)) {
@@ -210,7 +284,7 @@ svc_rdma_reply(struct svc_req *req)
 	}
 	xdr_tail_update(xdrs);
 
-	if (!xdr_rdma_svc_flushout(cbc)){
+	if (!xdr_rdma_svc_flushout(cbc, req->data_chunk_length ? 1 : 0)){
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s: flushout failed (will set dead)",
 			__func__);
@@ -221,8 +295,16 @@ svc_rdma_reply(struct svc_req *req)
 }
 
 static void
+svc_rdma_unlink(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
+{
+	svc_rqst_xprt_unregister(xprt, flags);
+}
+
+static void
 svc_rdma_destroy(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 {
+	/* Fix me need to fix this code ENG-649415 */
+	return;
 	RDMAXPRT *xd = RDMA_DR(REC_XPRT(xprt));
 
 	__warnx(TIRPC_DEBUG_FLAG_REFCNT,
@@ -236,6 +318,9 @@ svc_rdma_destroy(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 		/* call free hook */
 		xprt->xp_ops->xp_free_user_data(xprt);
 	}
+	if (xprt->xp_ip)
+		gsh_free(xprt->xp_ip);
+
 	if (xprt->xp_parent)
 		SVC_RELEASE(xprt->xp_parent, SVC_RELEASE_FLAG_NONE);
 	rpc_rdma_destroy(xd);
@@ -299,6 +384,7 @@ svc_rdma_ops(SVCXPRT *xprt)
 		ops.xp_reply = svc_rdma_reply;
 		ops.xp_checksum = NULL;		/* not used */
 		ops.xp_unref_user_data = NULL;	/* no default */
+		ops.xp_unlink = svc_rdma_unlink;
 		ops.xp_destroy = svc_rdma_destroy,
 		ops.xp_control = svc_rdma_control;
 		ops.xp_free_user_data = NULL;	/* no default */

--- a/src/svc_xprt.c
+++ b/src/svc_xprt.c
@@ -66,6 +66,11 @@ struct svc_xprt_fd {
 	mutex_t lock;
 	struct rbtree_x xt;
 	uint32_t connections;
+
+#ifdef USE_RPC_RDMA
+	uint32_t rdma_connections;
+#endif
+
 };
 
 static struct svc_xprt_fd svc_xprt_fd = {
@@ -242,7 +247,14 @@ svc_xprt_clear(SVCXPRT *xprt)
 		/* if another thread passes test during svc_xprt_shutdown(),
 		 * this lock (and generation test) prevents repeats.
 		 */
+#ifdef USE_RPC_RDMA
+		if (xprt->xp_rdma)
+			atomic_dec_uint32_t(&svc_xprt_fd.rdma_connections);
+		else
+			atomic_dec_uint32_t(&svc_xprt_fd.connections);
+#else
 		atomic_dec_uint32_t(&svc_xprt_fd.connections);
+#endif
 
 		uint16_t xp_flags = atomic_postclear_uint16_t_bits(
 			&xprt->xp_flags, SVC_XPRT_TREE_LOCKED);
@@ -413,6 +425,65 @@ svc_xprt_shutdown(void)
 	mem_free(svc_xprt_fd.xt.tree,
 		 SVC_XPRT_PARTITIONS * sizeof(struct rbtree_x_part));
 }
+
+#ifdef USE_RPC_RDMA
+int
+svc_rdma_add_xprt(SVCXPRT *xprt) {
+	struct rpc_dplx_rec sk;
+	struct rpc_dplx_rec *rec;
+	struct rbtree_x_part *t;
+	struct opr_rbtree_node *nv;
+
+	RDMAXPRT *xd = RDMA_DR(REC_XPRT(xprt));
+
+	sk.xprt.xp_fd = xd->sm_dr.xprt.xp_fd;
+	sk.xprt.xp_rdma = xd->sm_dr.xprt.xp_rdma;
+	t = rbtx_partition_of_scalar(&svc_xprt_fd.xt, sk.xprt.xp_fd);
+
+	rwlock_wrlock(&t->lock);
+	nv = opr_rbtree_lookup(&t->t, &sk.fd_node);
+	if (!nv) {
+		if (atomic_fetch_uint32_t(&svc_xprt_fd.rdma_connections)
+			>= __svc_params->max_rdma_connections) {
+			rwlock_unlock(&t->lock);
+			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				"%s: fd %d ip %s max_rdma_connections %u exceeded\n",
+				__func__, sk.xprt.xp_fd, xd->sm_dr.xprt.xp_ip,
+				__svc_params->max_rdma_connections);
+			__svc_params->raise_alert(MAX_CLIENT_CONNECTION_ALERT,
+				xd->sm_dr.xprt.xp_ip);
+			SVC_DESTROY(&xd->sm_dr.xprt);
+			SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
+			return -1;
+		}
+		atomic_inc_uint32_t(&svc_xprt_fd.rdma_connections);
+
+		/* Get ref */
+		SVC_REF(&xd->sm_dr.xprt, SVC_REF_FLAG_NONE);
+
+		rec = REC_XPRT(&xd->sm_dr.xprt);
+		rpc_dplx_rli(rec);
+		if (opr_rbtree_insert(&t->t, &rec->fd_node)) {
+			/* cant happen */
+			__warnx(TIRPC_DEBUG_FLAG_LOCK,
+				"%s: collision inserting in locked rbtree partition",
+				__func__);
+
+			atomic_dec_uint32_t(&svc_xprt_fd.rdma_connections);
+			rpc_dplx_rui(rec);
+			rwlock_unlock(&t->lock);
+			SVC_RELEASE(&xd->sm_dr.xprt, SVC_RELEASE_FLAG_NONE);
+			SVC_DESTROY(&xd->sm_dr.xprt);
+			SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
+			return -1;
+		}
+		rpc_dplx_rui(rec);
+		SVC_RELEASE(&xd->sm_dr.xprt, SVC_RELEASE_FLAG_NONE);
+	}
+	rwlock_unlock(&t->lock);
+	return 0;
+}
+#endif
 
 void
 svc_xprt_trace(SVCXPRT *xprt, const char *func, const char *tag, const int line)

--- a/src/svc_xprt.h
+++ b/src/svc_xprt.h
@@ -32,6 +32,10 @@
 #include <misc/portable.h>
 #include <misc/rbtree_x.h>
 
+#ifdef USE_RPC_RDMA
+#include "rpc_rdma.h"
+#endif
+
 /**
  * @file svc_xprt.h
  * @contributeur William Allen Simpson <bill@cohortfs.com>
@@ -65,4 +69,7 @@ int svc_xprt_foreach(svc_xprt_each_func_t, void *);
 void svc_xprt_dump_xprts(const char *);
 void svc_xprt_shutdown(void);
 
+#ifdef USE_RPC_RDMA
+int svc_rdma_add_xprt(SVCXPRT *xprt);
+#endif
 #endif				/* TIRPC_SVC_XPRT_H */

--- a/src/xdr_ioq.c
+++ b/src/xdr_ioq.c
@@ -50,7 +50,10 @@
 #include <intrinsic.h>
 #include <misc/abstract_atomic.h>
 #include "rpc_com.h"
-
+#include "gsh_rpc.h"
+#ifdef USE_RPC_RDMA
+#include "rpc_rdma.h"
+#endif
 #include <rpc/xdr_ioq.h>
 
 #define VREC_MAXBUFS 24
@@ -186,6 +189,130 @@ xdr_ioq_uv_recycle(struct poolq_head *ioqh, struct poolq_entry *have)
 
 	pthread_mutex_unlock(&ioqh->qmutex);
 }
+
+#ifdef USE_RPC_RDMA
+
+struct poolq_entry *
+xdr_rdma_ioq_uv_fetch(struct xdr_ioq *xioq, struct poolq_head *ioqh,
+		 char *comment, u_int count, u_int ioq_flags)
+{
+	struct poolq_entry *have = NULL;
+	RDMAXPRT *xd = NULL;
+
+	if (xioq->rdma_ioq) {
+		xd = xioq->xdrs[0].x_lib[1];
+	}
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR,
+		"%s() %u %s xd %p",
+		__func__, count, comment, xd);
+
+	pthread_mutex_lock(&ioqh->qmutex);
+
+	while (1) {
+		/* positive for buffer(s) */
+		have = TAILQ_FIRST(&ioqh->qh);
+		__warnx(TIRPC_DEBUG_FLAG_XDR,
+			"%s() %u %s xioq %p %d ioqh %p %d have %p",
+			__func__, count, comment, xioq, xioq->ioq_uv.uvqh.qcount,
+			ioqh, ioqh->qcount, have);
+		if (have) {
+			TAILQ_REMOVE(&ioqh->qh, have, q);
+
+			/* added directly to the queue.
+			 * this lock is needed for context header queues,
+			 * but is not a burden on uncontested data queues.
+			 */
+			pthread_mutex_lock(&xioq->ioq_uv.uvqh.qmutex);
+			(xioq->ioq_uv.uvqh.qcount)++;
+			__warnx(TIRPC_DEBUG_FLAG_XDR, "ioq_track xdr_ioq_uv_fetch insert have %p to q %p", have, xioq);
+			TAILQ_INSERT_TAIL(&xioq->ioq_uv.uvqh.qh, have, q);
+			pthread_mutex_unlock(&xioq->ioq_uv.uvqh.qmutex);
+			ioqh->qcount--;
+			count--;
+			if(count == 0)
+				break;
+		} else {
+			if (xd) {
+				pthread_mutex_unlock(&ioqh->qmutex);
+				if (ioqh == &xd->inbufs_data.uvqh) {
+					xdr_rdma_add_inbufs_data(xd);
+				}
+				if (ioqh == &xd->outbufs_data.uvqh) {
+					xdr_rdma_add_outbufs_data(xd);
+				}
+
+				if (ioqh == &xd->inbufs_hdr.uvqh) {
+					xdr_rdma_add_inbufs_hdr(xd);
+				}
+				if (ioqh == &xd->outbufs_hdr.uvqh) {
+					xdr_rdma_add_outbufs_hdr(xd);
+				}
+				pthread_mutex_lock(&ioqh->qmutex);
+			}
+		}
+	}
+
+	pthread_mutex_unlock(&ioqh->qmutex);
+	return have;
+}
+
+struct poolq_entry *
+xdr_rdma_ioq_uv_fetch_nothing(struct xdr_ioq *xioq, struct poolq_head *ioqh,
+			 char *comment, u_int count, u_int ioq_flags)
+{
+	return NULL;
+}
+
+static inline void
+xdr_rdma_ioq_uv_recycle(struct poolq_head *ioqh, struct poolq_entry *have)
+{
+	pthread_mutex_lock(&ioqh->qmutex);
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s() ioq_track Reccycle ioqh %p %d have %p",
+		__func__, ioqh, ioqh->qcount, have);
+
+	TAILQ_INSERT_TAIL(&ioqh->qh, have, q);
+	ioqh->qcount++;
+
+	pthread_mutex_unlock(&ioqh->qmutex);
+}
+
+void
+xdr_rdma_ioq_uv_release(struct xdr_ioq_uv *uv)
+{
+	uv->u.uio_references = 1;	/* keeping one */
+	xdr_rdma_ioq_uv_recycle(uv->u.uio_p1, &uv->uvq);
+}
+
+void
+xdr_rdma_ioq_release(struct poolq_head *ioqh, bool xioq_recycle,
+    struct xdr_ioq *xioq)
+{
+	struct poolq_entry *have = TAILQ_FIRST(&ioqh->qh);
+
+	/* release queued buffers */
+	while (have) {
+		struct poolq_entry *next = TAILQ_NEXT(have, q);
+
+		assert(xioq->rdma_ioq);
+
+		__warnx(TIRPC_DEBUG_FLAG_XDR, "xdr_rdma_ioq_release ioqh %p %d xioq %p have %p",
+			ioqh, ioqh->qcount, xioq, have);
+
+		TAILQ_REMOVE(&ioqh->qh, have, q);
+		(ioqh->qcount)--;
+
+		xdr_rdma_ioq_uv_release(IOQ_(have));
+		have = next;
+	}
+	assert(ioqh->qcount == 0);
+	/* Recycle cbc */
+	if (xioq && xioq->ioq_pool && xioq_recycle)
+		xdr_rdma_ioq_uv_recycle(xioq->ioq_pool, &xioq->ioq_s);
+}
+
+#endif
 
 void
 xdr_ioq_uv_release(struct xdr_ioq_uv *uv)
@@ -489,6 +616,83 @@ xdr_ioq_getbytes(XDR *xdrs, char *addr, u_int len)
 	return (true);
 }
 
+#ifdef USE_RPC_RDMA
+
+static void
+xdr_ioq_destroy_internal_rdma(XDR *xdrs)
+{
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: no op for rdma",
+	    __func__);
+}
+
+static bool
+xdr_ioq_getbytes_rdma(XDR *xdrs, char *addr, u_int len)
+{
+	struct xdr_ioq_uv *uv;
+	ssize_t delta;
+
+	struct xdr_ioq *xioq = XIOQ(xdrs);
+	XDR orig_xdr;
+	int restore_xdr = 0;
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: xdata %p xioq %p rdma %d",
+	    __func__, xdrs->x_data, xioq, xioq->rdma_ioq);
+
+	/* Check if we are getting rdma_write bytes, we could have some
+	 * header part to get next compound, so restore hdr xdr at end */
+	if (xioq->rdma_ioq &&
+	    (len > ((uintptr_t)xdrs->x_v.vio_tail - (uintptr_t)xdrs->x_data))) {
+
+		__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: rdma_write len %u hdr delta %u",
+		    __func__, len, ((uintptr_t)xdrs->x_v.vio_tail -
+		    (uintptr_t)xdrs->x_data));
+
+		memcpy(&orig_xdr, xdrs, sizeof(XDR));
+		uv = xdr_ioq_uv_advance(XIOQ(xdrs));
+		if (!uv) {
+			__warnx(TIRPC_DEBUG_FLAG_XDR, "%s NULL uv", __func__);
+			return (false);
+		}
+		xdr_ioq_uv_update(XIOQ(xdrs), uv);
+		restore_xdr = 1;
+	}
+
+	while (len > 0
+		&& XIOQ(xdrs)->ioq_uv.pcount < XIOQ(xdrs)->ioq_uv.uvqh.qcount) {
+		delta = (uintptr_t)xdrs->x_v.vio_tail
+			- (uintptr_t)xdrs->x_data;
+
+		if (unlikely(delta > len)) {
+			delta = len;
+		} else if (unlikely(!delta)) {
+			/* advance fill pointer */
+			uv = xdr_ioq_uv_advance(XIOQ(xdrs));
+			if (!uv) {
+				return (false);
+			}
+			xdr_ioq_uv_update(XIOQ(xdrs), uv);
+			continue;
+		}
+		memcpy(addr, xdrs->x_data, delta);
+		xdrs->x_data += delta;
+		addr += delta;
+		len -= delta;
+	}
+
+	if (restore_xdr) {
+		__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: rdma_write restore xdr hdr",
+		    __func__);
+		memcpy(xdrs, &orig_xdr, sizeof(XDR));
+	}
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: xdata %p xioq %p rdma %d",
+	    __func__, xdrs->x_data, xioq, xioq->rdma_ioq);
+
+	/* assert(len == 0); */
+	return (true);
+}
+
+#endif
+
 static bool
 xdr_ioq_putbytes(XDR *xdrs, const char *addr, u_int len)
 {
@@ -768,6 +972,10 @@ xdr_ioq_destroy(struct xdr_ioq *xioq, size_t qsize)
 	__warnx(TIRPC_DEBUG_FLAG_XDR,
 		"%s() xioq %p",
 		__func__, xioq);
+
+#ifdef USE_RPC_RDMA
+	assert(!xioq->rdma_ioq);
+#endif
 
 	xdr_ioq_release(&xioq->ioq_uv.uvqh);
 
@@ -1263,6 +1471,24 @@ const struct xdr_ops xdr_ioq_ops = {
 	xdr_ioq_getpos,
 	xdr_ioq_setpos,
 	xdr_ioq_destroy_internal,
+	xdr_ioq_control,
+	xdr_ioq_getbufs,
+	xdr_ioq_putbufs,
+	xdr_ioq_newbuf,		/* x_newbuf */
+	xdr_ioq_iovcount,	/* x_iovcount */
+	xdr_ioq_fillbufs,	/* x_fillbufs */
+	xdr_ioq_allochdrs,	/* x_allochdrs */
+};
+
+
+const struct xdr_ops xdr_ioq_ops_rdma = {
+	xdr_ioq_getunit,
+	xdr_ioq_putunit,
+	xdr_ioq_getbytes_rdma,
+	xdr_ioq_putbytes,
+	xdr_ioq_getpos,
+	xdr_ioq_setpos,
+	xdr_ioq_destroy_internal_rdma,
 	xdr_ioq_control,
 	xdr_ioq_getbufs,
 	xdr_ioq_putbufs,

--- a/src/xdr_rdma.c
+++ b/src/xdr_rdma.c
@@ -55,7 +55,6 @@
  * they are rarely checked.
  */
 
-#define CALLQ_SIZE (2)
 #define RFC5666_BUFFER_SIZE (1024)
 #define RPCRDMA_VERSION (1)
 
@@ -71,6 +70,9 @@
 static void
 rpcrdma_dump_msg(struct xdr_ioq_uv *data, char *comment, uint32_t xid)
 {
+	if (!__svc_params->enable_rdma_dump)
+		return;
+
 	char *buffer;
 	uint8_t *datum = data->v.vio_head;
 	int sized = ioquv_length(data);
@@ -185,77 +187,6 @@ struct rdma_msg {
 	} rdma_body;
 };
 
-/***********************************/
-/****** Utilities for buffers ******/
-/***********************************/
-
-static void
-xdr_rdma_chunk_in(struct poolq_entry *have, u_int k, u_int m, u_int sized)
-{
-	/* final buffer limited to truncated length */
-	IOQ_(have)->v.vio_head = IOQ_(have)->v.vio_base;
-	IOQ_(have)->v.vio_tail = (char *)IOQ_(have)->v.vio_base + m;
-	IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base + sized;
-
-	while (0 < --k && NULL != (have = TAILQ_PREV(have, poolq_head_s, q))) {
-		/* restore defaults after previous usage */
-		IOQ_(have)->v.vio_head = IOQ_(have)->v.vio_base;
-		IOQ_(have)->v.vio_tail =
-		IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base + sized;
-	}
-}
-
-static void
-xdr_rdma_chunk_out(struct poolq_entry *have, u_int k, u_int m, u_int sized)
-{
-	/* final buffer limited to truncated length */
-	IOQ_(have)->v.vio_head =
-	IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
-	IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base + m;
-
-	while (0 < --k && NULL != (have = TAILQ_PREV(have, poolq_head_s, q))) {
-		/* restore defaults after previous usage */
-		IOQ_(have)->v.vio_head =
-		IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
-		IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base + sized;
-	}
-}
-
-static uint32_t
-xdr_rdma_chunk_fetch(struct xdr_ioq *xioq, struct poolq_head *ioqh,
-		     char *comment, u_int length, u_int sized, u_int max_sge,
-		     void (*setup)(struct poolq_entry *, u_int, u_int, u_int))
-{
-	struct poolq_entry *have;
-	uint32_t k = length / sized;
-	uint32_t m = length % sized;
-
-	if (m) {
-		/* need fractional buffer */
-		k++;
-	} else {
-		/* have full-sized buffer */
-		m = sized;
-	}
-
-	/* ensure never asking for more buffers than allowed */
-	if (k > max_sge) {
-		__warnx(TIRPC_DEBUG_FLAG_XDR,
-			"%s() requested chunk %" PRIu32
-			" is too long (%" PRIu32 ">%" PRIu32 ")",
-			__func__, length, k, max_sge);
-		k = max_sge;
-		m = sized;
-	}
-
-	/* ensure we can get all of our buffers without deadlock
-	 * (wait for them all to be appended)
-	 */
-	have = xdr_ioq_uv_fetch(xioq, ioqh, comment, k, IOQ_FLAG_NONE);
-	(*setup)(have, k, m, sized);
-	return k;
-}
-
 /***********************/
 /****** Callbacks ******/
 /***********************/
@@ -265,66 +196,44 @@ xdr_rdma_chunk_fetch(struct xdr_ioq *xioq, struct poolq_head *ioqh,
 static int
 xdr_rdma_respond_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
 {
-	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+	__warnx(TIRPC_DEBUG_FLAG_XDR,
 		"%s() %p[%u] cbc %p\n",
 		__func__, xprt, xprt->state, cbc);
 
-	mutex_lock(&xprt->sm_dr.ioq.ioq_uv.uvqh.qmutex);
-	TAILQ_REMOVE(&xprt->sm_dr.ioq.ioq_uv.uvqh.qh, &cbc->workq.ioq_s, q);
-	(xprt->sm_dr.ioq.ioq_uv.uvqh.qcount)--;
-	mutex_unlock(&xprt->sm_dr.ioq.ioq_uv.uvqh.qmutex);
+	pthread_mutex_lock(&cbc->cb_done_mutex);
+	cbc_release_it(cbc);
+	pthread_cond_signal(&cbc->cb_done);
+	pthread_mutex_unlock(&cbc->cb_done_mutex);
 
-	xdr_ioq_destroy(&cbc->workq, sizeof(*cbc));
 	return (0);
 }
 
 static int
 xdr_rdma_destroy_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
 {
-	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+	__warnx(TIRPC_DEBUG_FLAG_XDR,
 		"%s() %p[%u] cbc %p\n",
 		__func__, xprt, xprt->state, cbc);
 
-	mutex_lock(&xprt->sm_dr.ioq.ioq_uv.uvqh.qmutex);
-	TAILQ_REMOVE(&xprt->sm_dr.ioq.ioq_uv.uvqh.qh, &cbc->workq.ioq_s, q);
-	(xprt->sm_dr.ioq.ioq_uv.uvqh.qcount)--;
-	mutex_unlock(&xprt->sm_dr.ioq.ioq_uv.uvqh.qmutex);
+	pthread_mutex_lock(&cbc->cb_done_mutex);
+	cbc_release_it(cbc);
+	pthread_cond_signal(&cbc->cb_done);
+	pthread_mutex_unlock(&cbc->cb_done_mutex);
 
-	xdr_ioq_destroy(&cbc->workq, sizeof(*cbc));
 	return (0);
 }
 
-/**
- * xdr_rdma_wait_callback: send/recv callback that just unlocks a mutex.
- *
- */
 static int
-xdr_rdma_wait_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
+xdr_rdma_destroy_callback_recv(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
 {
-	mutex_t *lock = cbc->callback_arg;
-
-	__warnx(TIRPC_DEBUG_FLAG_ERROR,
-		"%s() %p[%u] cbc %p\n",
+	__warnx(TIRPC_DEBUG_FLAG_XDR,
+		"Error in recv callback %s() %p[%u] cbc %p\n",
 		__func__, xprt, xprt->state, cbc);
 
-	mutex_unlock(lock);
-	return (0);
-}
+	cbc->cbc_flags = CBC_FLAG_RELEASE;
+	/* Release senital ref */
+	cbc_release_it(cbc);
 
-/**
- * xdr_rdma_warn_callback: send/recv callback that just unlocks a mutex.
- *
- */
-static int
-xdr_rdma_warn_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
-{
-	mutex_t *lock = cbc->callback_arg;
-
-	__warnx(TIRPC_DEBUG_FLAG_ERROR,
-		"%s() %p[%u] cbc %p\n",
-		__func__, xprt, xprt->state, cbc);
-
-	mutex_unlock(lock);
 	return (0);
 }
 
@@ -335,9 +244,13 @@ xdr_rdma_warn_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
 static int
 xdr_rdma_wrap_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
 {
-	XDR *xdrs = cbc->holdq.xdrs;
-
-	return (int)svc_request(&xprt->sm_dr.xprt, xdrs);
+	/* Use xdrs from recvq in context */
+	XDR *xdrs = cbc->recvq.xdrs;
+	int ret = (int)svc_request(&xprt->sm_dr.xprt, xdrs);
+	cbc->cbc_flags = CBC_FLAG_RELEASE;
+	/* Release senital ref */
+	cbc_release_it(cbc);
+	return ret;
 }
 
 /***********************************/
@@ -362,7 +275,7 @@ xdr_rdma_wrap_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
 static int
 xdr_rdma_post_recv_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge)
 {
-	struct poolq_entry *have = TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh);
+	struct poolq_entry *have = TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh);
 	int i = 0;
 	int ret;
 
@@ -394,8 +307,8 @@ xdr_rdma_post_recv_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge)
 
 		if (!mr) {
 			__warnx(TIRPC_DEBUG_FLAG_ERROR,
-				"%s() Missing mr: Not requesting.",
-				__func__);
+				"%s() Missing mr: Not requesting addr %p",
+				__func__, IOQ_(have)->v.vio_head);
 			return EINVAL;
 		}
 
@@ -448,8 +361,9 @@ static int
 xdr_rdma_post_recv_cb(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge)
 {
 	cbc->positive_cb = xdr_rdma_wrap_callback;
-	cbc->negative_cb = xdr_rdma_destroy_callback;
+	cbc->negative_cb = xdr_rdma_destroy_callback_recv;
 	cbc->callback_arg = NULL;
+	cbc->call_inline = 0;
 	return xdr_rdma_post_recv_n(xprt, cbc, sge);
 }
 
@@ -473,7 +387,8 @@ static int
 xdr_rdma_post_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 		     struct xdr_rdma_segment *rs, enum ibv_wr_opcode opcode)
 {
-	struct poolq_entry *have = TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh);
+	struct poolq_entry *have = cbc->have;
+
 	uint32_t totalsize = 0;
 	int i = 0;
 	int ret;
@@ -502,7 +417,9 @@ xdr_rdma_post_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 	// opcode-specific checks:
 	switch (opcode) {
 	case IBV_WR_RDMA_WRITE:
+		//__warnx(TIRPC_DEBUG_FLAG_ERROR, "IBV_WR_RDMA_WRITE");
 	case IBV_WR_RDMA_READ:
+		 //__warnx(TIRPC_DEBUG_FLAG_ERROR, "IBV_WR_RDMA_READ");
 		if (!rs) {
 			__warnx(TIRPC_DEBUG_FLAG_ERROR,
 				"%s() Cannot do rdma without a remote location!",
@@ -511,7 +428,9 @@ xdr_rdma_post_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 		}
 		break;
 	case IBV_WR_SEND:
+		//__warnx(TIRPC_DEBUG_FLAG_ERROR, "IBV_WR_SEND");
 	case IBV_WR_SEND_WITH_IMM:
+		//__warnx(TIRPC_DEBUG_FLAG_ERROR, "IBV_WR_SEND_WITH_IMM");
 		break;
 	default:
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -526,9 +445,8 @@ xdr_rdma_post_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 
 		if (!length) {
 			__warnx(TIRPC_DEBUG_FLAG_XDR,
-				"%s() Empty buffer: Not sending.",
+				"%s() Empty buffer: sending.",
 				__func__);
-			break;
 		}
 		if (!mr) {
 			__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -579,12 +497,25 @@ xdr_rdma_post_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 	ret = ibv_post_send(xprt->qp, &cbc->wr.wwr, &xprt->bad_send_wr);
 	if (ret) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
-			"%s() %p[%u] cbc %p ibv_post_send failed: %s (%d)",
-			__func__, xprt, xprt->state, cbc, strerror(ret), ret);
+			"%s() %p[%u] cbc %p ibv_post_send failed: %s (%d), "
+			"num sge %d imm_data %d",
+			__func__, xprt, xprt->state, cbc, strerror(ret), ret,
+			cbc->wr.wwr.num_sge, cbc->wr.wwr.imm_data);
 		return ret; // FIXME np_uerror(ret)
 	}
 
 	return 0;
+}
+
+static inline int
+xdr_rdma_wait_cb_done_locked(struct rpc_rdma_cbc *cbc)
+{
+	struct timespec ts;
+	ts.tv_sec = time(NULL) + 60;
+	ts.tv_nsec = 0;
+	return pthread_cond_timedwait(&cbc->cb_done,
+		    &cbc->cb_done_mutex, &ts);
+
 }
 
 /**
@@ -599,114 +530,68 @@ xdr_rdma_post_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 static inline int
 xdr_rdma_post_send_cb(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge)
 {
+	int ret;
+
 	cbc->positive_cb = xdr_rdma_respond_callback;
 	cbc->negative_cb = xdr_rdma_destroy_callback;
-	cbc->callback_arg = cbc;
-	return xdr_rdma_post_send_n(xprt, cbc, sge, NULL, IBV_WR_SEND);
-}
+	cbc->callback_arg = NULL;
+	cbc->call_inline = 1;
 
-#ifdef UNUSED
-/**
- * Post a receive chunk and waits for _that one and not any other_ to be filled.
- * Generally a bad idea to use that one unless only that one is used.
- *
- * @param[IN] xprt
- * @param[INOUT] cbc	CallBack Context xdr_ioq and xdr_ioq_uv(s)
- *
- * @return 0 on success, the value of errno on error
- */
-static int
-xdr_rdma_wait_recv_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc)
-{
-	mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
-	int ret;
+	pthread_mutex_lock(&cbc->cb_done_mutex);
 
-	cbc->positive_cb = xdr_rdma_wait_callback;
-	cbc->negative_cb = xdr_rdma_warn_callback;
-	cbc->callback_arg = &lock;
+	cbc_ref_it(cbc);
 
-	mutex_lock(&lock);
-	ret = xdr_rdma_post_recv_n(xprt, cbc);
-
-	if (!ret) {
-		mutex_lock(&lock);
-		mutex_unlock(&lock);
-	}
-	mutex_destroy(&lock);
-
-	return ret;
-}
-
-/**
- * Post a send chunk and waits for that one to be completely sent
- * @param[IN] xprt
- * @param[IN] cbc	CallBack Context xdr_ioq and xdr_ioq_uv(s)
- * @param[IN] sge	scatter/gather elements to send
- *
- * @return 0 on success, the value of errno on error
- */
-static int
-xdr_rdma_wait_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge)
-{
-	mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
-	int ret;
-
-	cbc->positive_cb = xdr_rdma_wait_callback;
-	cbc->negative_cb = xdr_rdma_warn_callback;
-	cbc->callback_arg = &lock;
-
-	mutex_lock(&lock);
 	ret = xdr_rdma_post_send_n(xprt, cbc, sge, NULL, IBV_WR_SEND);
 
-	if (!ret) {
-		mutex_lock(&lock);
-		mutex_unlock(&lock);
+	if (ret) {
+		/* Assuming there won't be callback */
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: failed ret %d err %d "
+			" xprt %p cbc %p", __func__, ret, errno, xprt, cbc);
+		cbc_release_it(cbc);
+	} else {
+		ret = xdr_rdma_wait_cb_done_locked(cbc);
+		if (ret == ETIMEDOUT) {
+			__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: Failed to get callback cbc %p "
+				"refs %d", __func__, cbc, cbc->refcnt);
+		}
 	}
-	mutex_destroy(&lock);
+
+	pthread_mutex_unlock(&cbc->cb_done_mutex);
 
 	return ret;
 }
-
-static inline int
-xdr_rdma_post_read_cb(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
-		      struct xdr_rdma_segment *rs)
-{
-	cbc->positive_cb = xdr_rdma_respond_callback;
-	cbc->negative_cb = xdr_rdma_destroy_callback;
-	cbc->callback_arg = cbc;
-	return xdr_rdma_post_send_n(xprt, cbc, sge, rs, IBV_WR_RDMA_READ);
-}
-
-static inline int
-xdr_rdma_post_write_cb(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
-		       struct xdr_rdma_segment *rs)
-{
-	cbc->positive_cb = xdr_rdma_respond_callback;
-	cbc->negative_cb = xdr_rdma_destroy_callback;
-	cbc->callback_arg = cbc;
-	return xdr_rdma_post_send_n(xprt, cbc, sge, rs, IBV_WR_RDMA_WRITE);
-}
-#endif /* UNUSED */
 
 static int
 xdr_rdma_wait_read_cb(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 		     struct xdr_rdma_segment *rs)
 {
-	mutex_t lock = MUTEX_INITIALIZER;
 	int ret;
 
-	cbc->positive_cb = xdr_rdma_wait_callback;
-	cbc->negative_cb = xdr_rdma_warn_callback;
-	cbc->callback_arg = &lock;
+	cbc->positive_cb = xdr_rdma_respond_callback;
+	cbc->negative_cb = xdr_rdma_destroy_callback;
+	cbc->callback_arg = NULL;
+	cbc->call_inline = 1;
 
-	mutex_lock(&lock);
+	pthread_mutex_lock(&cbc->cb_done_mutex);
+
+	cbc_ref_it(cbc);
+
 	ret = xdr_rdma_post_send_n(xprt, cbc, sge, rs, IBV_WR_RDMA_READ);
 
-	if (!ret) {
-		mutex_lock(&lock);
-		mutex_unlock(&lock);
+	if (ret) {
+		/* Assuming there won't be callback */
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: failed ret %d err %d "
+			" xprt %p cbc %p", __func__, ret, errno, xprt, cbc);
+		cbc_release_it(cbc);
+	} else {
+		ret = xdr_rdma_wait_cb_done_locked(cbc);
+		if (ret == ETIMEDOUT) {
+			__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: Failed to get callback cbc %p "
+				"refs %d", __func__, cbc, cbc->refcnt);
+		}
 	}
-	mutex_destroy(&lock);
+
+	pthread_mutex_unlock(&cbc->cb_done_mutex);
 
 	return ret;
 }
@@ -715,21 +600,33 @@ static int
 xdr_rdma_wait_write_cb(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 		      struct xdr_rdma_segment *rs)
 {
-	mutex_t lock = MUTEX_INITIALIZER;
 	int ret;
 
-	cbc->positive_cb = xdr_rdma_wait_callback;
-	cbc->negative_cb = xdr_rdma_warn_callback;
-	cbc->callback_arg = &lock;
+	cbc->positive_cb = xdr_rdma_respond_callback;
+	cbc->negative_cb = xdr_rdma_destroy_callback;
+	cbc->callback_arg = NULL;
+	cbc->call_inline = 1;
 
-	mutex_lock(&lock);
+	pthread_mutex_lock(&cbc->cb_done_mutex);
+
+	cbc_ref_it(cbc);
+
 	ret = xdr_rdma_post_send_n(xprt, cbc, sge, rs, IBV_WR_RDMA_WRITE);
 
-	if (!ret) {
-		mutex_lock(&lock);
-		mutex_unlock(&lock);
+	if (ret) {
+		/* Assuming there won't be callback */
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: failed ret %d err %d "
+			" xprt %p cbc %p", __func__, ret, errno, xprt, cbc);
+		cbc_release_it(cbc);
+	} else {
+		ret = xdr_rdma_wait_cb_done_locked(cbc);
+		if (ret == ETIMEDOUT) {
+			__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: Failed to get callback cbc %p "
+				"refs %d", __func__, cbc, cbc->refcnt);
+		}
 	}
-	mutex_destroy(&lock);
+
+	pthread_mutex_unlock(&cbc->cb_done_mutex);
 
 	return ret;
 }
@@ -747,16 +644,20 @@ typedef struct xdr_write_list wl_t;
 static inline void
 xdr_rdma_skip_read_list(uint32_t **pptr)
 {
+	uint32_t *ptr1 = *pptr;
 	while (rl(*pptr)->present) {
 		*pptr += sizeof(struct xdr_read_list)
 			 / sizeof(**pptr);
 	}
 	(*pptr)++;
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: ptr1 %p ptr2 %p diff %d", __func__, ptr1, *pptr, (*pptr) - ptr1);
 }
 
 static inline void
 xdr_rdma_skip_write_list(uint32_t **pptr)
 {
+	uint32_t *ptr1 = *pptr;
 	if (wl(*pptr)->present) {
 		*pptr += (sizeof(struct xdr_write_list)
 			  + sizeof(struct xdr_write_chunk)
@@ -764,11 +665,13 @@ xdr_rdma_skip_write_list(uint32_t **pptr)
 			 / sizeof(**pptr);
 	}
 	(*pptr)++;
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: ptr1 %p ptr2 %p diff %d", __func__, ptr1, *pptr, (*pptr) - ptr1);
 }
 
 static inline void
 xdr_rdma_skip_reply_array(uint32_t **pptr)
 {
+	uint32_t *ptr1 = *pptr;
 	if (wl(*pptr)->present) {
 		*pptr += (sizeof(struct xdr_write_list)
 			  + sizeof(struct xdr_write_chunk)
@@ -777,6 +680,7 @@ xdr_rdma_skip_reply_array(uint32_t **pptr)
 	} else {
 		(*pptr)++;
 	}
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: ptr1 %p ptr2 %p diff %d", __func__, ptr1, *pptr, (*pptr) - ptr1);
 }
 
 static inline uint32_t *
@@ -891,22 +795,49 @@ xdr_rdma_encode_reply_header(struct svcxprt_rdma *xprt,
 void
 xdr_rdma_callq(RDMAXPRT *xd)
 {
+	/* Get context buf from cbqh and add to sm_dr
+	 * rpc_rdma_allocate->xdr_ioq_setup(&xd->sm_dr.ioq);
+	 * Check if we have credits availabled from cbqh
+	 * rpc_rdma_setup_cbq
+	 * rc = rpc_rdma_setup_cbq(&xd->cbqh,
+	 * xd->xa->rq_depth + xd->xa->sq_depth, xd->xa->credits);
+	 * Remove from cbqh and add to sm_dr.ioq */
+
 	struct poolq_entry *have =
-		xdr_ioq_uv_fetch(&xd->sm_dr.ioq, &xd->cbqh,
+		xdr_rdma_ioq_uv_fetch(&xd->sm_dr.ioq, &xd->cbqh,
 				 "callq context", 1, IOQ_FLAG_NONE);
 	struct rpc_rdma_cbc *cbc = (struct rpc_rdma_cbc *)(_IOQ(have));
 
-	have = xdr_ioq_uv_fetch(&cbc->workq, &xd->inbufs.uvqh,
+	cbc->recvq.xdrs[0].x_lib[1] =
+	cbc->sendq.xdrs[0].x_lib[1] =
+	cbc->dataq.xdrs[0].x_lib[1] =
+	cbc->freeq.xdrs[0].x_lib[1] = xd;
+
+	/* Get recv buf from ibufs abd add to context recvq
+	 * Remove from inbufs and add to cbc recvq */
+	have = xdr_rdma_ioq_uv_fetch(&cbc->recvq, &xd->inbufs_hdr.uvqh,
 				"callq buffer", 1, IOQ_FLAG_NONE);
 
 	/* input positions */
 	IOQ_(have)->v.vio_head = IOQ_(have)->v.vio_base;
 	IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_wrap;
 	IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base
-			       + xd->sm_dr.recvsz;
+			       + xd->sm_dr.recvsz_hdr;
 
-	cbc->workq.xdrs[0].x_lib[1] =
-	cbc->holdq.xdrs[0].x_lib[1] = xd;
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc %p recvq %p %d sendq %p %d xd %p",
+		__func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount, &cbc->sendq,
+		cbc->sendq.ioq_uv.uvqh.qcount, xd);
+
+	cbc->call_inline = 0;
+	cbc->data_chunk_uv = NULL;
+	cbc->refcnt = 1; // Senital ref
+	cbc->cbc_flags = CBC_FLAG_NONE;
+	cbc->non_registered_buf = NULL;
+	cbc->non_registered_buf_len = 0;
+
+	pthread_mutex_lock(&xd->cbclist.qmutex);
+	TAILQ_INSERT_TAIL(&xd->cbclist.qh, &cbc->cbc_list, q);
+	pthread_mutex_unlock(&xd->cbclist.qmutex);
 
 	xdr_rdma_post_recv_cb(xd, cbc, 1);
 }
@@ -926,10 +857,15 @@ xdr_rdma_destroy(RDMAXPRT *xd)
 	xdr_ioq_destroy_pool(&xd->sm_dr.ioq.ioq_uv.uvqh);
 
 	/* must be after queues, xdr_ioq_destroy() moves them here */
-	xdr_ioq_release(&xd->inbufs.uvqh);
-	poolq_head_destroy(&xd->inbufs.uvqh);
-	xdr_ioq_release(&xd->outbufs.uvqh);
-	poolq_head_destroy(&xd->outbufs.uvqh);
+	xdr_ioq_release(&xd->inbufs_hdr.uvqh);
+	poolq_head_destroy(&xd->inbufs_hdr.uvqh);
+	xdr_ioq_release(&xd->outbufs_hdr.uvqh);
+	poolq_head_destroy(&xd->outbufs_hdr.uvqh);
+
+	xdr_ioq_release(&xd->inbufs_data.uvqh);
+	poolq_head_destroy(&xd->inbufs_data.uvqh);
+	xdr_ioq_release(&xd->outbufs_data.uvqh);
+	poolq_head_destroy(&xd->outbufs_data.uvqh);
 
 	/* must be after pools */
 	if (xd->buffer_aligned) {
@@ -941,6 +877,218 @@ xdr_rdma_destroy(RDMAXPRT *xd)
 	xd->sm_dr.ioq.xdrs[0].x_lib[1] = NULL;
 }
 
+static uint8_t *
+xdr_rdma_add_bufs(RDMAXPRT *xd, struct ibv_mr *mr,
+    struct xdr_ioq_uv_head *uv_head, xdr_ioq_uv_type_t buf_type,
+    uint32_t buf_size, uint32_t buf_count, uint8_t *b_addr)
+{
+
+	/* Each pre-allocated buffer has a corresponding xdr_ioq_uv,
+	 * stored on the pool queues.
+	 */
+
+	pthread_mutex_lock(&uv_head->uvqh.qmutex);
+
+	for (int qcount = 0;
+	     qcount < buf_count;
+	     qcount++) {
+		struct xdr_ioq_uv *data = xdr_ioq_uv_create(0, UIO_FLAG_BUFQ);
+		data->rdma_uv = 1;
+
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
+			"%s() recvbuf at %p base %p",
+			__func__, data, b_addr);
+
+		data->v.vio_base =
+		data->v.vio_head =
+		data->v.vio_tail = b_addr;
+		data->v.vio_wrap = (char *)b_addr + buf_size;
+		data->rdma_v = data->v;
+		data->u.uio_p1 = &uv_head->uvqh;
+		data->u.uio_p2 = mr;
+		data->rdma_u = data->u;
+		data->uv_type = buf_type;
+		TAILQ_INSERT_TAIL(&uv_head->uvqh.qh, &data->uvq, q);
+		uv_head->uvqh.qcount++;
+
+		b_addr += buf_size;
+	}
+
+	pthread_mutex_unlock(&uv_head->uvqh.qmutex);
+
+	return b_addr;
+}
+
+static void
+xdr_rdma_update_extra_bufs(RDMAXPRT *xd, struct ibv_mr *mr, uint32_t buffer_total,
+    uint8_t *buffer_aligned, rpc_extra_io_buf_type_t type)
+{
+
+	pthread_mutex_lock(&xd->extra_bufs.qmutex);
+
+	struct rpc_extra_io_bufs *io_buf =
+	    mem_zalloc(sizeof(struct rpc_extra_io_bufs));
+	io_buf->mr = mr;
+	io_buf->buffer_total = buffer_total;
+	io_buf->buffer_aligned = buffer_aligned;
+	io_buf->type = type;
+
+	TAILQ_INSERT_TAIL(&xd->extra_bufs.qh, &io_buf->q, q);
+
+	xd->extra_bufs_count++;
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() extra bufs count %u io_buf %p xd %p",
+		__func__, xd->extra_bufs_count, io_buf, xd);
+
+	pthread_mutex_unlock(&xd->extra_bufs.qmutex);
+}
+
+static struct ibv_mr *
+xdr_rdma_reg_mr(RDMAXPRT *xd, uint8_t *buffer_aligned, uint32_t buffer_total)
+{
+	return ibv_reg_mr(xd->pd->pd, buffer_aligned, buffer_total,
+			    IBV_ACCESS_LOCAL_WRITE |
+			    IBV_ACCESS_REMOTE_WRITE |
+			    IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC);
+}
+
+int
+xdr_rdma_add_outbufs_hdr(RDMAXPRT *xd)
+{
+	uint8_t *b;
+	int hdr_qdepth = RDMA_HDR_CHUNKS;
+	uint32_t buffer_total = xd->sm_dr.sendsz_hdr * hdr_qdepth;
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_total  %llu, sendsz %llu sq %llu xd %p pagesz %llu",
+		__func__, buffer_total, xd->sm_dr.sendsz_hdr, hdr_qdepth,
+		xd, xd->sm_dr.pagesz);
+
+	uint8_t *buffer_aligned = mem_aligned(xd->sm_dr.pagesz, buffer_total);
+	memset(buffer_aligned, 0, buffer_total);
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_aligned at %p proptection domain %p xd %p",
+		__func__, buffer_aligned, xd->pd->pd, xd);
+
+	struct ibv_mr *mr = xdr_rdma_reg_mr(xd, buffer_aligned, buffer_total);
+
+	assert(mr);
+
+	b = buffer_aligned;
+
+	xdr_rdma_add_bufs(xd, mr, &xd->outbufs_hdr, UV_HDR,
+	    xd->sm_dr.sendsz_hdr, hdr_qdepth, b);
+
+	xdr_rdma_update_extra_bufs(xd, mr, buffer_total, buffer_aligned,
+	    IO_OUTBUF);
+
+	return 0;
+}
+
+int
+xdr_rdma_add_outbufs_data(RDMAXPRT *xd)
+{
+	uint8_t *b;
+	int data_qdepth = RDMA_DATA_CHUNKS;
+	uint32_t buffer_total = xd->sm_dr.sendsz * data_qdepth;
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_total  %llu, sendsz %llu sq %llu xd %p pagesz %llu",
+		__func__, buffer_total, xd->sm_dr.sendsz, data_qdepth,
+		xd, xd->sm_dr.pagesz);
+
+	uint8_t *buffer_aligned = mem_aligned(xd->sm_dr.pagesz, buffer_total);
+	memset(buffer_aligned, 0, buffer_total);
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_aligned at %p proptection domain %p xd %p",
+		__func__, buffer_aligned, xd->pd->pd, xd);
+
+	struct ibv_mr *mr = xdr_rdma_reg_mr(xd, buffer_aligned, buffer_total);
+
+	assert(mr);
+
+	b = buffer_aligned;
+
+	xdr_rdma_add_bufs(xd, mr, &xd->outbufs_data, UV_DATA,
+	    xd->sm_dr.sendsz, data_qdepth, b);
+
+	xdr_rdma_update_extra_bufs(xd, mr, buffer_total, buffer_aligned,
+	    IO_OUTBUF);
+
+	return 0;
+}
+
+int
+xdr_rdma_add_inbufs_hdr(RDMAXPRT *xd)
+{
+	uint8_t *b;
+	int hdr_qdepth = RDMA_HDR_CHUNKS;
+	uint32_t buffer_total = xd->sm_dr.recvsz_hdr * hdr_qdepth;
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_total  %llu, recvsz %llu rq %llu xd %p pagesz %llu",
+		__func__, buffer_total, xd->sm_dr.recvsz_hdr, hdr_qdepth,
+		xd, xd->sm_dr.pagesz);
+
+	uint8_t *buffer_aligned = mem_aligned(xd->sm_dr.pagesz, buffer_total);
+	memset(buffer_aligned, 0, buffer_total);
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_aligned at %p proptection domain %p xd %p",
+		__func__, buffer_aligned, xd->pd->pd, xd);
+
+	struct ibv_mr *mr = xdr_rdma_reg_mr(xd, buffer_aligned, buffer_total);
+
+	assert(mr);
+
+	b = buffer_aligned;
+
+	xdr_rdma_add_bufs(xd, mr, &xd->inbufs_hdr, UV_HDR,
+	    xd->sm_dr.recvsz_hdr, hdr_qdepth, b);
+
+	xdr_rdma_update_extra_bufs(xd, mr, buffer_total, buffer_aligned,
+	    IO_INBUF);
+
+	return 0;
+}
+
+int
+xdr_rdma_add_inbufs_data(RDMAXPRT *xd)
+{
+	uint8_t *b;
+	int data_qdepth = RDMA_DATA_CHUNKS;
+	uint32_t buffer_total = xd->sm_dr.recvsz * data_qdepth;
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_total  %llu, recvsz %llu rq %llu xd %p pagesz %llu",
+		__func__, buffer_total, xd->sm_dr.recvsz, data_qdepth,
+		xd, xd->sm_dr.pagesz);
+
+	uint8_t *buffer_aligned = mem_aligned(xd->sm_dr.pagesz, buffer_total);
+	memset(buffer_aligned, 0, buffer_total);
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_aligned at %p proptection domain %p xd %p",
+		__func__, buffer_aligned, xd->pd->pd, xd);
+
+	struct ibv_mr *mr = xdr_rdma_reg_mr(xd, buffer_aligned, buffer_total);
+
+	assert(mr);
+
+	b = buffer_aligned;
+
+	xdr_rdma_add_bufs(xd, mr, &xd->inbufs_data, UV_DATA,
+	    xd->sm_dr.recvsz, data_qdepth, b);
+
+	xdr_rdma_update_extra_bufs(xd, mr, buffer_total, buffer_aligned,
+	    IO_INBUF);
+
+	return 0;
+}
+
 /*
  * initializes a stream descriptor for a memory buffer.
  *
@@ -950,6 +1098,8 @@ int
 xdr_rdma_create(RDMAXPRT *xd)
 {
 	uint8_t *b;
+	int data_qdepth = RDMA_DATA_CHUNKS;
+	int hdr_qdepth = RDMA_HDR_CHUNKS;
 
 	if (!xd->pd || !xd->pd->pd) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -964,69 +1114,85 @@ xdr_rdma_create(RDMAXPRT *xd)
 	 * more than one buffer can be chained to one ioq_uv head,
 	 * but never need more ioq_uv heads than buffers.
 	 */
-	xd->buffer_total = xd->sm_dr.recvsz * xd->xa->rq_depth
-			 + xd->sm_dr.sendsz * xd->xa->sq_depth;
+	size_t total_hdr_sz = RDMA_HDR_CHUNK_SZ * (RDMA_HDR_CHUNKS * 2);
+	size_t tirpc_buff_total = xd->sm_dr.recvsz * data_qdepth
+				  + xd->sm_dr.sendsz * data_qdepth;
+
+	xd->buffer_total = tirpc_buff_total + total_hdr_sz;
+
+	__warnx(TIRPC_DEBUG_FLAG_EVENT,
+		"%s() buffer_total %llu(%llu + %llu), xd %p pagesz %llu "
+		"recvsz data %llu hdr %llu rq %llu "
+		"sendsz data %llu hdr %llu sq %llu",
+		__func__, xd->buffer_total,
+		tirpc_buff_total, total_hdr_sz, xd, xd->sm_dr.pagesz,
+		xd->sm_dr.recvsz, xd->sm_dr.recvsz_hdr, data_qdepth,
+		xd->sm_dr.sendsz, xd->sm_dr.sendsz_hdr, data_qdepth);
 
 	xd->buffer_aligned = mem_aligned(xd->sm_dr.pagesz, xd->buffer_total);
+	memset(xd->buffer_aligned, 0, xd->buffer_total);
 
-	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
-		"%s() buffer_aligned at %p",
-		__func__, xd->buffer_aligned);
+	__warnx(TIRPC_DEBUG_FLAG_EVENT,
+		"%s() buffer_aligned at %p protection domain %p xd %p",
+		__func__, xd->buffer_aligned, xd->pd->pd, xd);
 
-	/* register it in two chunks for read and write??? */
-	xd->mr = ibv_reg_mr(xd->pd->pd, xd->buffer_aligned, xd->buffer_total,
-			    IBV_ACCESS_LOCAL_WRITE |
-			    IBV_ACCESS_REMOTE_WRITE |
-			    IBV_ACCESS_REMOTE_READ);
+	xd->mr = xdr_rdma_reg_mr(xd, xd->buffer_aligned,
+	    xd->buffer_total);
 
-	poolq_head_setup(&xd->inbufs.uvqh);
-	xd->inbufs.min_bsize = xd->sm_dr.pagesz;
-	xd->inbufs.max_bsize = xd->sm_dr.recvsz;
+	assert(xd->mr);
 
-	poolq_head_setup(&xd->outbufs.uvqh);
-	xd->outbufs.min_bsize = xd->sm_dr.pagesz;
-	xd->outbufs.max_bsize = xd->sm_dr.sendsz;
+	xd->sm_dr.xprt.xp_rdma = true;
 
-	/* Each pre-allocated buffer has a corresponding xdr_ioq_uv,
-	 * stored on the pool queues.
-	 */
+	poolq_head_setup(&xd->inbufs_data.uvqh);
+	xd->inbufs_data.min_bsize = xd->sm_dr.pagesz;
+	xd->inbufs_data.max_bsize = xd->sm_dr.recvsz;
+
+	poolq_head_setup(&xd->outbufs_data.uvqh);
+	xd->outbufs_data.min_bsize = xd->sm_dr.pagesz;
+	xd->outbufs_data.max_bsize = xd->sm_dr.sendsz;
+
+	poolq_head_setup(&xd->inbufs_hdr.uvqh);
+	xd->inbufs_hdr.min_bsize = xd->sm_dr.pagesz;
+	xd->inbufs_hdr.max_bsize = xd->sm_dr.recvsz_hdr;
+
+	poolq_head_setup(&xd->outbufs_hdr.uvqh);
+	xd->outbufs_hdr.min_bsize = xd->sm_dr.pagesz;
+	xd->outbufs_hdr.max_bsize = xd->sm_dr.sendsz_hdr;
+
 	b = xd->buffer_aligned;
 
-	for (xd->inbufs.uvqh.qcount = 0;
-	     xd->inbufs.uvqh.qcount < xd->xa->rq_depth;
-	     xd->inbufs.uvqh.qcount++) {
-		struct xdr_ioq_uv *data = xdr_ioq_uv_create(0, UIO_FLAG_BUFQ);
+	b = xdr_rdma_add_bufs(xd, xd->mr, &xd->inbufs_data, UV_DATA,
+	    xd->sm_dr.recvsz, data_qdepth, b);
 
-		data->v.vio_base =
-		data->v.vio_head =
-		data->v.vio_tail = b;
-		data->v.vio_wrap = (char *)b + xd->sm_dr.recvsz;
-		data->u.uio_p1 = &xd->inbufs.uvqh;
-		data->u.uio_p2 = xd->mr;
-		TAILQ_INSERT_TAIL(&xd->inbufs.uvqh.qh, &data->uvq, q);
+	b = xdr_rdma_add_bufs(xd, xd->mr, &xd->outbufs_data, UV_DATA,
+	    xd->sm_dr.sendsz, data_qdepth, b);
 
-		b += xd->sm_dr.recvsz;
-	}
+	b = xdr_rdma_add_bufs(xd, xd->mr, &xd->inbufs_hdr, UV_HDR,
+	    xd->sm_dr.recvsz_hdr, hdr_qdepth, b);
 
-	for (xd->outbufs.uvqh.qcount = 0;
-	     xd->outbufs.uvqh.qcount < xd->xa->sq_depth;
-	     xd->outbufs.uvqh.qcount++) {
-		struct xdr_ioq_uv *data = xdr_ioq_uv_create(0, UIO_FLAG_BUFQ);
+	b = xdr_rdma_add_bufs(xd, xd->mr, &xd->outbufs_hdr, UV_HDR,
+	    xd->sm_dr.sendsz_hdr, hdr_qdepth, b);
 
-		data->v.vio_base =
-		data->v.vio_head =
-		data->v.vio_tail = b;
-		data->v.vio_wrap = (char *)b + xd->sm_dr.sendsz;
-		data->u.uio_p1 = &xd->outbufs.uvqh;
-		data->u.uio_p2 = xd->mr;
-		TAILQ_INSERT_TAIL(&xd->outbufs.uvqh.qh, &data->uvq, q);
+	TAILQ_INIT(&xd->extra_bufs.qh);
+	pthread_mutex_init(&xd->extra_bufs.qmutex, NULL);
+	xd->extra_bufs_count = 0;
 
-		b += xd->sm_dr.sendsz;
-	}
+	int callq_size = (RDMA_HDR_CHUNKS / 4);
 
-	while (xd->sm_dr.ioq.ioq_uv.uvqh.qcount < CALLQ_SIZE) {
+	__warnx(TIRPC_DEBUG_FLAG_EVENT, "callq size %d", callq_size);
+
+	TAILQ_INIT(&xd->cbclist.qh);
+	pthread_mutex_init(&xd->cbclist.qmutex, NULL);
+
+	while (xd->sm_dr.ioq.ioq_uv.uvqh.qcount < callq_size) {
+		/* Post 2 buffers to do first recvs
+		 * callback will be done on recv which should rearam again */
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
+			"%s() qcount %d callq size %d",
+			__func__, xd->sm_dr.ioq.ioq_uv.uvqh.qcount);
 		xdr_rdma_callq(xd);
 	}
+
 	return 0;
 }
 
@@ -1034,7 +1200,7 @@ xdr_rdma_create(RDMAXPRT *xd)
  *
  * Client prepares for a reply
  *
- * potential output buffers are queued in workq.
+ * potential output buffers are queued in recvq.
  *
  * @param[IN] xdrs	cm_data
  *
@@ -1057,7 +1223,7 @@ xdr_rdma_clnt_reply(XDR *xdrs, u_int32_t xid)
 	}
 	xprt = x_xprt(xdrs);
 
-	work_uv = IOQ_(TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh));
+	work_uv = IOQ_(TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh));
 	rpcrdma_dump_msg(work_uv, "creply head", htonl(xid));
 
 	reply_array = (wl_t *)xdr_rdma_get_reply_array(work_uv->v.vio_head);
@@ -1077,7 +1243,7 @@ xdr_rdma_clnt_reply(XDR *xdrs, u_int32_t xid)
 			 * failing if no match. add a zero timeout
 			 * when implemented
 			 */
-			have = xdr_ioq_uv_fetch(&cbc->holdq, &xprt->inbufs.uvqh,
+			have = xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xprt->inbufs_data.uvqh,
 				"creply body", 1, IOQ_FLAG_NONE);
 			rpcrdma_dump_msg(IOQ_(have), "creply body", ntohl(xid));
 
@@ -1088,7 +1254,7 @@ xdr_rdma_clnt_reply(XDR *xdrs, u_int32_t xid)
 		}
 	}
 
-	xdr_ioq_reset(&cbc->holdq, 0);
+	xdr_ioq_reset(&cbc->sendq, 0);
 	return (true);
 }
 
@@ -1100,7 +1266,7 @@ xdr_rdma_clnt_reply(XDR *xdrs, u_int32_t xid)
  * but clones call rdma header in place for future use.
  *
  * @param[IN] cbc	incoming request
- *			call request is in workq
+ *			call request is in recvq
  *
  * called by svc_rdma_recv()
  */
@@ -1109,8 +1275,8 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 {
 	RDMAXPRT *xprt;
 	struct rdma_msg *cmsg;
-	uint32_t k;
 	uint32_t l;
+
 
 	if (!cbc) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -1118,14 +1284,26 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 			__func__);
 		return (false);
 	}
-	xprt = x_xprt(cbc->workq.xdrs);
+	/* Both sendq and recvq (xdrs)->x_lib[1] points to xprt */
+	xprt = x_xprt(cbc->recvq.xdrs);
 
-	/* free old buffers (should do nothing) */
-	xdr_ioq_release(&cbc->holdq.ioq_uv.uvqh);
+        __warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc %p recvq %p %d sendq %p %d "
+		"dataq %p %d xd %p",
+                __func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount, &cbc->sendq,
+                cbc->sendq.ioq_uv.uvqh.qcount, &cbc->dataq, cbc->dataq.ioq_uv.uvqh.qcount,
+		xprt);
+
+	/* recvq will have request header part */
+	assert(cbc->recvq.ioq_uv.uvqh.qcount == 1);
+	assert(cbc->sendq.ioq_uv.uvqh.qcount == 0);
+	assert(cbc->dataq.ioq_uv.uvqh.qcount == 0);
+	assert(cbc->freeq.ioq_uv.uvqh.qcount == 0);
+
+	/* rearm for next recv */
 	xdr_rdma_callq(xprt);
 
-	cbc->call_uv = IOQ_(TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh));
-	(cbc->call_uv->u.uio_references)++;
+	/* Get inbuf from recvq */
+	cbc->call_uv = IOQ_(TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh));
 	cbc->call_head = cbc->call_uv->v.vio_head;
 	cmsg = m_(cbc->call_head);
 	rpcrdma_dump_msg(cbc->call_uv, "call", cmsg->rdma_xid);
@@ -1138,8 +1316,8 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 			"%s() rdma_vers %" PRIu32 "?",
 			__func__, ntohl(cmsg->rdma_vers));
 		xdr_rdma_encode_error(cbc->call_uv, RDMA_ERR_VERS);
+		cbc->have = TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh);
 		xdr_rdma_post_send_cb(xprt, cbc, 1);
-		xdr_ioq_uv_release(cbc->call_uv);
 		return (false);
 	}
 
@@ -1152,13 +1330,18 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 			"%s() rdma_type %" PRIu32 "?",
 			__func__, ntohl(cmsg->rdma_type));
 		xdr_rdma_encode_error(cbc->call_uv, RDMA_ERR_BADHEADER);
+		cbc->have = TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh);
 		xdr_rdma_post_send_cb(xprt, cbc, 1);
-		xdr_ioq_uv_release(cbc->call_uv);
 		return (false);
 	}
 
 	/* locate NFS/RDMA (RFC-5666) chunk positions */
 	cbc->read_chunk = xdr_rdma_get_read_list(cmsg);
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s:%d read chunk %p present %u position %u",
+		__func__, __LINE__, cbc->read_chunk, rl(cbc->read_chunk)->present,
+		rl(cbc->read_chunk)->position);
+
 	cbc->write_chunk = (wl_t *)cbc->read_chunk;
 	xdr_rdma_skip_read_list((uint32_t **)&cbc->write_chunk);
 	cbc->reply_chunk = cbc->write_chunk;
@@ -1166,38 +1349,136 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 	cbc->call_data = cbc->reply_chunk;
 	xdr_rdma_skip_reply_array((uint32_t **)&cbc->call_data);
 
-	/* swap calling message from workq to holdq */
-	TAILQ_CONCAT(&cbc->holdq.ioq_uv.uvqh.qh, &cbc->workq.ioq_uv.uvqh.qh, q);
-	cbc->holdq.ioq_uv.uvqh.qcount = cbc->workq.ioq_uv.uvqh.qcount;
-	cbc->workq.ioq_uv.uvqh.qcount = 0;
+	struct xdr_write_list *reply_array = (wl_t *)cbc->reply_chunk;
+	int data_chunk = 0;
+	if (reply_array->present == 0) {
+		reply_array = (wl_t *)cbc->write_chunk;
+		if (reply_array->present)
+			data_chunk = 1;
+	} else {
+		data_chunk = 1;
+	}
 
-	/* skip past the header for the calling buffer */
-	xdr_ioq_reset(&cbc->holdq, ((uintptr_t)cbc->call_data
+	/* Allocate data buffer for read/readdir */
+	if (data_chunk) {
+		struct xdr_ioq_uv *data_chunk_uv = IOQ_(xdr_rdma_ioq_uv_fetch(&cbc->dataq,
+		    &xprt->outbufs_data.uvqh,
+		    "sreply head", 1, IOQ_FLAG_NONE));
+
+		/* entry was already added directly to the queue */
+		data_chunk_uv->v.vio_head = data_chunk_uv->v.vio_tail =
+		    data_chunk_uv->v.vio_base;
+		/* tail adjusted below */
+		data_chunk_uv->v.vio_wrap = (char *)data_chunk_uv->v.vio_base +
+		    xprt->sm_dr.sendsz;
+
+		cbc->data_chunk_uv = data_chunk_uv;
+		__warnx(TIRPC_DEBUG_FLAG_XDR, "data_chunk_uv data %p cbc %p",
+		    data_chunk_uv, cbc);
+	} else {
+		/* For read/readdir without reply/write list, we should not need
+		 * big buffer */
+		struct xdr_ioq_uv *data_chunk_uv = IOQ_(xdr_rdma_ioq_uv_fetch(&cbc->dataq,
+		    &xprt->outbufs_hdr.uvqh,
+		    "sreply head", 1, IOQ_FLAG_NONE));
+
+		/* entry was already added directly to the queue */
+		data_chunk_uv->v.vio_head = data_chunk_uv->v.vio_tail =
+		    data_chunk_uv->v.vio_base;
+		/* tail adjusted below */
+		data_chunk_uv->v.vio_wrap = (char *)data_chunk_uv->v.vio_base +
+		    xprt->sm_dr.sendsz_hdr;
+
+		cbc->data_chunk_uv = data_chunk_uv;
+		__warnx(TIRPC_DEBUG_FLAG_XDR, "data_chunk_uv hdr %p cbc %p",
+		    data_chunk_uv, cbc);
+	}
+
+
+	/* skip past the header for the calling buffer
+	 * xdr_ioq_reset->xdr_ioq_uv_reset set the xdrs point to buf
+	 * Set xdr in sendq for decoding.
+	 * xioq->xdrs[0].x_data = uv->v.vio_head; */
+	xdr_ioq_reset(&cbc->recvq, ((uintptr_t)cbc->call_data
 				  - (uintptr_t)cmsg));
 
-	while (rl(cbc->read_chunk)->present != 0
-	    && rl(cbc->read_chunk)->position == 0) {
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s read chunk %p present %u "
+		"position %u reply chunk %p reply chunk present %d write "
+		"chunk %p write chunk present %d",
+		__func__, cbc->read_chunk, rl(cbc->read_chunk)->present,
+		rl(cbc->read_chunk)->position, cbc->reply_chunk,
+		wl(cbc->reply_chunk)->present, cbc->write_chunk,
+		wl(cbc->write_chunk)->present);
+
+	pthread_mutex_lock(&cbc->recvq.ioq_uv.uvqh.qmutex);
+	TAILQ_REMOVE(&cbc->recvq.ioq_uv.uvqh.qh, &cbc->call_uv->uvq, q);
+	(cbc->recvq.ioq_uv.uvqh.qcount)--;
+	pthread_mutex_unlock(&cbc->recvq.ioq_uv.uvqh.qmutex);
+
+	assert(cbc->recvq.ioq_uv.uvqh.qcount == 0);
+
+	while (rl(cbc->read_chunk)->present) {
 		l = ntohl(rl(cbc->read_chunk)->target.length);
-		k = xdr_rdma_chunk_fetch(&cbc->workq, &xprt->inbufs.uvqh,
-					 "call chunk", l,
-					 xprt->sm_dr.recvsz,
-					 xprt->xa->max_recv_sge,
-					 xdr_rdma_chunk_in);
 
-		xdr_rdma_wait_read_cb(xprt, cbc, k, &rl(cbc->read_chunk)->target);
-		rpcrdma_dump_msg(IOQ_(TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh)),
-				 "call chunk", cmsg->rdma_xid);
+		__warnx(TIRPC_DEBUG_FLAG_XDR,
+			"%s() length %u",
+			__func__, l);
 
-		/* concatenate any additional buffers after the calling message,
-		 * faking there is more call data in the calling buffer.
-		 */
-		TAILQ_CONCAT(&cbc->holdq.ioq_uv.uvqh.qh,
-			     &cbc->workq.ioq_uv.uvqh.qh, q);
-		cbc->holdq.ioq_uv.uvqh.qcount += cbc->workq.ioq_uv.uvqh.qcount;
-		cbc->workq.ioq_uv.uvqh.qcount = 0;
+		assert(l <= xprt->sm_dr.recvsz);
+
+		struct xdr_ioq_uv *data_chunk_uv = IOQ_(xdr_rdma_ioq_uv_fetch(&cbc->recvq,
+		    &xprt->inbufs_data.uvqh,
+		    "sreply head", 1, IOQ_FLAG_NONE));
+
+		/* entry was already added directly to the queue */
+		data_chunk_uv->v.vio_head = data_chunk_uv->v.vio_tail =
+		    data_chunk_uv->v.vio_base;
+		/* tail adjusted below */
+		data_chunk_uv->v.vio_wrap = (char *)data_chunk_uv->v.vio_base + l;
+
+		data_chunk_uv->v.vio_tail = data_chunk_uv->v.vio_head + l;
+
+		cbc->have = TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh);
+		xdr_rdma_wait_read_cb(xprt, cbc, 1, &rl(cbc->read_chunk)->target);
+
+		pthread_mutex_lock(&cbc->recvq.ioq_uv.uvqh.qmutex);
+		pthread_mutex_lock(&cbc->freeq.ioq_uv.uvqh.qmutex);
+
+		TAILQ_CONCAT(&cbc->freeq.ioq_uv.uvqh.qh, &cbc->recvq.ioq_uv.uvqh.qh, q);
+		cbc->freeq.ioq_uv.uvqh.qcount += cbc->recvq.ioq_uv.uvqh.qcount;
+		cbc->recvq.ioq_uv.uvqh.qcount = 0;
+
+		pthread_mutex_unlock(&cbc->freeq.ioq_uv.uvqh.qmutex);
+		pthread_mutex_unlock(&cbc->recvq.ioq_uv.uvqh.qmutex);
+
 		cbc->read_chunk = (char *)cbc->read_chunk
 						+ sizeof(struct xdr_read_list);
 	}
+
+	pthread_mutex_lock(&cbc->recvq.ioq_uv.uvqh.qmutex);
+	pthread_mutex_lock(&cbc->freeq.ioq_uv.uvqh.qmutex);
+
+	TAILQ_CONCAT(&cbc->recvq.ioq_uv.uvqh.qh, &cbc->freeq.ioq_uv.uvqh.qh, q);
+	cbc->recvq.ioq_uv.uvqh.qcount += cbc->freeq.ioq_uv.uvqh.qcount;
+	cbc->freeq.ioq_uv.uvqh.qcount = 0;
+
+	TAILQ_INSERT_HEAD(&cbc->recvq.ioq_uv.uvqh.qh, &cbc->call_uv->uvq, q);
+	(cbc->recvq.ioq_uv.uvqh.qcount)++;
+
+	/* Now recvq = req_header buf + rdma_read data bufs
+	 * We use recvq xdrs for decoding */
+
+	pthread_mutex_unlock(&cbc->freeq.ioq_uv.uvqh.qmutex);
+	pthread_mutex_unlock(&cbc->recvq.ioq_uv.uvqh.qmutex);
+
+	rpcrdma_dump_msg(IOQ_(TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh)),
+			 "call chunk", cmsg->rdma_xid);
+
+        __warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc %p recvq %p %d "
+		"sendq %p %d freeq %p %d xd %p ",
+                __func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount, &cbc->sendq,
+                cbc->sendq.ioq_uv.uvqh.qcount, &cbc->freeq,
+		cbc->freeq.ioq_uv.uvqh.qcount, xprt);
 
 	return (true);
 }
@@ -1206,19 +1487,22 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
  *
  * Server prepares for a reply
  *
- * potential output buffers are queued in workq.
+ * potential output buffers are queued in recvq.
  *
  * @param[IN] cbc	incoming request
- *			call request is in holdq
+ *			call request is in sendq
  *
  * called by svc_rdma_reply()
  */
 bool
-xdr_rdma_svc_reply(struct rpc_rdma_cbc *cbc, u_int32_t xid)
+xdr_rdma_svc_reply(struct rpc_rdma_cbc *cbc, u_int32_t xid,
+    bool rdma_buf_used)
 {
 	RDMAXPRT *xprt;
 	struct xdr_write_list *reply_array;
 	struct poolq_entry *have;
+	int allocate_header = 0;
+	int write_chunk = 0;
 
 	if (!cbc) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -1226,33 +1510,60 @@ xdr_rdma_svc_reply(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 			__func__);
 		return (false);
 	}
-	xprt = x_xprt(cbc->workq.xdrs);
+	xprt = x_xprt(cbc->recvq.xdrs);
 
-	/* free call buffers (head will be retained) */
-	xdr_ioq_release(&cbc->holdq.ioq_uv.uvqh);
+        __warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc %p recvq %p %d sendq %p %d xd %p",
+                __func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount, &cbc->sendq,
+                cbc->sendq.ioq_uv.uvqh.qcount, xprt);
 
 	reply_array = (wl_t *)cbc->reply_chunk;
+	 /* For write_chuks we need to allocate seperate buffer for
+	 * RPC header */
+	if (reply_array->present == 0) {
+		reply_array = (wl_t *)cbc->write_chunk;
+		if (reply_array->present)
+			write_chunk = 1;
+	}
+
 	if (reply_array->present == 0) {
 		/* no reply array to write, replying inline and hope it works
 		 * (OK on RPC/RDMA Read)
 		 */
-		have = xdr_ioq_uv_fetch(&cbc->holdq, &xprt->outbufs.uvqh,
+
+		__warnx(TIRPC_DEBUG_FLAG_XDR,
+			"%s() no reply array to write, replying inline and hope it works",
+			__func__);
+
+		have = xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xprt->outbufs_hdr.uvqh,
 					"sreply buffer", 1, IOQ_FLAG_NONE);
 
 		/* buffer is limited size */
 		IOQ_(have)->v.vio_head =
 		IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
 		IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base
-					+ RFC5666_BUFFER_SIZE;
+					+ xprt->sm_dr.sendsz_hdr;
 
+		/* Should be only set for read and readdir */
+		if (rdma_buf_used) {
+			have = xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xprt->outbufs_hdr.uvqh,
+						"sreply buffer", 1, IOQ_FLAG_NONE);
+
+			/* buffer is limited size */
+			IOQ_(have)->v.vio_head =
+			IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
+			IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base
+						+ xprt->sm_dr.sendsz_hdr;
+		}
 		/* make room at head for RDMA header */
-		xdr_ioq_reset(&cbc->holdq, (uintptr_t)cbc->call_data
-				  - (uintptr_t)cbc->write_chunk
-				  + offsetof(struct rdma_msg, rdma_body));
+		xdr_ioq_reset(&cbc->sendq, 0);
 	} else {
 		uint32_t i;
 		uint32_t l;
 		uint32_t n = ntohl(reply_array->elements);
+
+		__warnx(TIRPC_DEBUG_FLAG_XDR,
+			"%s() reply array to write n %u ",
+			__func__, n);
 
 		if (!n) {
 			__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -1261,20 +1572,58 @@ xdr_rdma_svc_reply(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 			return (false);
 		}
 
+		allocate_header = 1;
+
+		if (allocate_header) {
+			have = xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xprt->outbufs_hdr.uvqh,
+					"sreply buffer", 1, IOQ_FLAG_NONE);
+
+
+			/* buffer is limited size */
+			IOQ_(have)->v.vio_head =
+			IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
+			IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base
+					+ xprt->sm_dr.sendsz_hdr;
+			/* make room at head for RDMA header */
+			xdr_ioq_reset(&cbc->sendq, 0);
+		}
+
 		/* fetch all reply chunks in advance to avoid deadlock
 		 * (there may be more than one)
 		 */
 		for (i = 0; i < n; i++) {
 			l = ntohl(reply_array->entry[i].target.length);
-			xdr_rdma_chunk_fetch(&cbc->holdq, &xprt->outbufs.uvqh,
-					     "sreply chunk", l,
-					     xprt->sm_dr.sendsz,
-					     xprt->xa->max_send_sge,
-					     xdr_rdma_chunk_out);
-		}
+			if (write_chunk) {
+				/* For write_list we get buffer from protocol,
+				 * we need buffer to refer it */
+				have = xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xprt->outbufs_hdr.uvqh,
+				    "sreply buffer", 1, IOQ_FLAG_NONE);
 
-		xdr_ioq_reset(&cbc->holdq, 0);
+				/* buffer is limited size */
+				IOQ_(have)->v.vio_head =
+				IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
+				IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base
+					+ xprt->sm_dr.sendsz_hdr;
+			} else {
+				/* For reply_list we copy from protocol buffer so allocate bigger
+				 * chunk */
+				assert(l <= xprt->sm_dr.sendsz);
+				have = xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xprt->outbufs_data.uvqh,
+				    "sreply buffer", 1, IOQ_FLAG_NONE);
+
+				/* buffer is limited size */
+				IOQ_(have)->v.vio_head =
+				IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
+				IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base + l;
+			}
+		}
+		if (!allocate_header)
+			xdr_ioq_reset(&cbc->sendq, 0);
 	}
+
+        __warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc %p recvq %p %d sendq %p %d xd %p",
+                __func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount, &cbc->sendq,
+                cbc->sendq.ioq_uv.uvqh.qcount, xprt);
 
 	return (true);
 }
@@ -1282,7 +1631,7 @@ xdr_rdma_svc_reply(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 /** xdr_rdma_clnt_flushout
  *
  * @param[IN] cbc	combined callback context
- *			call request is in holdq
+ *			call request is in sendq
  *
  * @return true is message sent, false otherwise
  *
@@ -1294,7 +1643,7 @@ xdr_rdma_clnt_flushout(struct rpc_rdma_cbc *cbc)
 /* FIXME: decide how many buffers we use in argument!!!!!! */
 #define num_chunks (xd->xa->credits - 1)
 
-	RDMAXPRT *xd = x_xprt(cbc->workq.xdrs);
+	RDMAXPRT *xd = x_xprt(cbc->recvq.xdrs);
 	struct rpc_msg *msg;
 	struct rdma_msg *rmsg;
 	struct xdr_write_list *w_array;
@@ -1303,9 +1652,9 @@ xdr_rdma_clnt_flushout(struct rpc_rdma_cbc *cbc)
 	struct poolq_entry *have;
 	int i = 0;
 
-	hold_uv = IOQ_(TAILQ_FIRST(&cbc->holdq.ioq_uv.uvqh.qh));
+	hold_uv = IOQ_(TAILQ_FIRST(&cbc->sendq.ioq_uv.uvqh.qh));
 	msg = (struct rpc_msg *)(hold_uv->v.vio_head);
-	xdr_tail_update(cbc->workq.xdrs);
+	xdr_tail_update(cbc->recvq.xdrs);
 
 	switch(ntohl(msg->rm_direction)) {
 	    case CALL:
@@ -1323,12 +1672,12 @@ xdr_rdma_clnt_flushout(struct rpc_rdma_cbc *cbc)
 		return (false);
 	}
 
-	cbc->workq.ioq_uv.uvq_fetch = xdr_ioq_uv_fetch_nothing;
+	cbc->recvq.ioq_uv.uvq_fetch = xdr_rdma_ioq_uv_fetch_nothing;
 
-	head_uv = IOQ_(xdr_ioq_uv_fetch(&cbc->workq, &xd->outbufs.uvqh,
+	head_uv = IOQ_(xdr_rdma_ioq_uv_fetch(&cbc->recvq, &xd->outbufs_data.uvqh,
 					"c_head buffer", 1, IOQ_FLAG_NONE));
 
-	(void)xdr_ioq_uv_fetch(&cbc->holdq, &xd->inbufs.uvqh,
+	(void)xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xd->inbufs_data.uvqh,
 				"call buffers", num_chunks, IOQ_FLAG_NONE);
 
 	rmsg = m_(head_uv->v.vio_head);
@@ -1346,7 +1695,7 @@ xdr_rdma_clnt_flushout(struct rpc_rdma_cbc *cbc)
 	w_array->present = htonl(1);
 	w_array->elements = htonl(num_chunks);
 
-	TAILQ_FOREACH(have, &cbc->holdq.ioq_uv.uvqh.qh, q) {
+	TAILQ_FOREACH(have, &cbc->sendq.ioq_uv.uvqh.qh, q) {
 		struct xdr_rdma_segment *w_seg =
 			&w_array->entry[i++].target;
 		uint32_t length = ioquv_length(IOQ_(have));
@@ -1375,7 +1724,7 @@ xdr_rdma_clnt_flushout(struct rpc_rdma_cbc *cbc)
  * called by svc_rdma_reply()
  */
 bool
-xdr_rdma_svc_flushout(struct rpc_rdma_cbc *cbc)
+xdr_rdma_svc_flushout(struct rpc_rdma_cbc *cbc, bool rdma_buf_used)
 {
 	RDMAXPRT *xprt;
 	struct rpc_msg *msg;
@@ -1383,8 +1732,13 @@ xdr_rdma_svc_flushout(struct rpc_rdma_cbc *cbc)
 	struct rdma_msg *rmsg;
 	struct xdr_write_list *w_array;
 	struct xdr_write_list *reply_array;
-	struct xdr_ioq_uv *head_uv;
-	struct xdr_ioq_uv *work_uv;
+	struct xdr_ioq_uv *rdma_head_uv;
+	struct xdr_ioq_uv *work_uv, *nfs_header_uv;
+	struct xdr_ioq_uv *first_send_buf_uv = NULL;
+	int write_chunk = 0, add_nfs_header = 1;
+	struct xdr_uio  *uio_refer = NULL;
+	uint8_t *rdma_buf_addr = NULL, *non_registered_buf = NULL;
+	int rdma_buf_len = 0, non_registered_buf_len = 0;
 
 	if (!cbc) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -1392,14 +1746,26 @@ xdr_rdma_svc_flushout(struct rpc_rdma_cbc *cbc)
 			__func__);
 		return (false);
 	}
-	xprt = x_xprt(cbc->workq.xdrs);
+	xprt = x_xprt(cbc->recvq.xdrs);
 
-	/* swap reply body from holdq to workq */
-	TAILQ_CONCAT(&cbc->workq.ioq_uv.uvqh.qh, &cbc->holdq.ioq_uv.uvqh.qh, q);
-	cbc->workq.ioq_uv.uvqh.qcount = cbc->holdq.ioq_uv.uvqh.qcount;
-	cbc->holdq.ioq_uv.uvqh.qcount = 0;
+        __warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc %p recvq %p %d sendq %p %d xd %p",
+                __func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount, &cbc->sendq,
+                cbc->sendq.ioq_uv.uvqh.qcount, xprt);
 
-	work_uv = IOQ_(TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh));
+	reply_array = (wl_t *)cbc->reply_chunk;
+
+
+	if (reply_array->present == 0) {
+		reply_array = (wl_t *)cbc->write_chunk;
+		if (reply_array->present)
+			write_chunk = 1;
+	}
+
+	/* Remove NFS rpc header to send it after rdma_writes,
+	 * We allocated seperate header for nfs */
+	nfs_header_uv = IOQ_(TAILQ_FIRST(&cbc->sendq.ioq_uv.uvqh.qh));
+
+	work_uv = nfs_header_uv;
 	msg = (struct rpc_msg *)(work_uv->v.vio_head);
 	/* work_uv->v.vio_tail has been set by xdr_tail_update() */
 
@@ -1427,17 +1793,20 @@ xdr_rdma_svc_flushout(struct rpc_rdma_cbc *cbc)
 		return (false);
 	}
 
-	/* usurp the holdq for the head, move to workq later */
-	head_uv = IOQ_(xdr_ioq_uv_fetch(&cbc->holdq, &xprt->outbufs.uvqh,
+	/* usurp the sendq for the head, move to recvq later */
+	/* Allocate seperate buf to send RPCoRDMA header */
+	rdma_head_uv = IOQ_(xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xprt->outbufs_hdr.uvqh,
 					"sreply head", 1, IOQ_FLAG_NONE));
 
 	/* entry was already added directly to the queue */
-	head_uv->v.vio_head = head_uv->v.vio_base;
+	rdma_head_uv->v.vio_head = rdma_head_uv->v.vio_tail =
+	    rdma_head_uv->v.vio_base;
 	/* tail adjusted below */
-	head_uv->v.vio_wrap = (char *)head_uv->v.vio_base + xprt->sm_dr.sendsz;
+	rdma_head_uv->v.vio_wrap = (char *)rdma_head_uv->v.vio_base +
+	    xprt->sm_dr.sendsz_hdr;
 
 	/* build the header that goes with the data */
-	rmsg = m_(head_uv->v.vio_head);
+	rmsg = m_(rdma_head_uv->v.vio_head);
 	rmsg->rdma_xid = cmsg->rdma_xid;
 	rmsg->rdma_vers = cmsg->rdma_vers;
 	rmsg->rdma_credit = htonl(xprt->xa->credits);
@@ -1445,18 +1814,57 @@ xdr_rdma_svc_flushout(struct rpc_rdma_cbc *cbc)
 	/* no read, write chunks. */
 	rmsg->rdma_body.rdma_msg.rdma_reads = 0; /* htonl(0); */
 	rmsg->rdma_body.rdma_msg.rdma_writes = 0; /* htonl(0); */
+	rmsg->rdma_body.rdma_msg.rdma_reply = 0;
 
-	reply_array = (wl_t *)cbc->reply_chunk;
+	rpcrdma_dump_msg(nfs_header_uv, "sreply nfs head", msg->rm_xid);
+
+	pthread_mutex_lock(&cbc->sendq.ioq_uv.uvqh.qmutex);
+	TAILQ_REMOVE(&cbc->sendq.ioq_uv.uvqh.qh, &rdma_head_uv->uvq, q);
+	(cbc->sendq.ioq_uv.uvqh.qcount)--;
+
+	TAILQ_REMOVE(&cbc->sendq.ioq_uv.uvqh.qh, &nfs_header_uv->uvq, q);
+	(cbc->sendq.ioq_uv.uvqh.qcount)--;
+	pthread_mutex_unlock(&cbc->sendq.ioq_uv.uvqh.qmutex);
+
 	if (reply_array->present == 0) {
 		rmsg->rdma_type = htonl(RDMA_MSG);
 
 		/* no reply chunk either */
 		rmsg->rdma_body.rdma_msg.rdma_reply = 0; /* htonl(0); */
 
-		head_uv->v.vio_tail = head_uv->v.vio_head
+		rdma_head_uv->v.vio_tail = rdma_head_uv->v.vio_head
 					+ xdr_rdma_header_length(rmsg);
 
-		rpcrdma_dump_msg(head_uv, "sreply head", msg->rm_xid);
+		struct poolq_entry *have = TAILQ_FIRST(&cbc->sendq.ioq_uv.uvqh.qh);
+		if (have) {
+			/* We will do rdma_send, so if there is rdma_buf from
+			 * protocol, just copy it, for read/readdir we always
+			 * get rdma_buf even if there are no reply_array/write_array,
+			 * if there is no rdma_buf the it could be compound op with reply_buf,
+			 * So no harm in copying for metadata ops */
+
+			first_send_buf_uv  = IOQ_(have);
+			uint8_t *ptr = first_send_buf_uv->v.vio_head;
+			uint32_t len = ioquv_length(first_send_buf_uv);
+
+			assert(rdma_buf_used);
+			assert(cbc->sendq.ioq_uv.uvqh.qcount == 1);
+			assert(len <= xprt->sm_dr.sendsz_hdr);
+
+			/* If its rdma_buf from protocol we should have
+			 * UIO_FLAG_REFER set. */
+			if (first_send_buf_uv->u.uio_flags & UIO_FLAG_REFER)
+				uio_refer = first_send_buf_uv->u.uio_refer;
+
+			first_send_buf_uv->v = first_send_buf_uv->rdma_v;
+			first_send_buf_uv->u = first_send_buf_uv->rdma_u;
+
+			memcpy(first_send_buf_uv->v.vio_head, ptr,
+			    len);
+			first_send_buf_uv->v.vio_tail = first_send_buf_uv->v.vio_head + len;
+		}
+
+		rpcrdma_dump_msg(rdma_head_uv, "sreply head", msg->rm_xid);
 		rpcrdma_dump_msg(work_uv, "sreply body", msg->rm_xid);
 	} else {
 		uint32_t i = 0;
@@ -1464,70 +1872,182 @@ xdr_rdma_svc_flushout(struct rpc_rdma_cbc *cbc)
 
 		rmsg->rdma_type = htonl(RDMA_NOMSG);
 
+		struct poolq_entry *have = TAILQ_FIRST(&cbc->sendq.ioq_uv.uvqh.qh);
+		first_send_buf_uv  = IOQ_(have);
+
 		/* reply chunk */
 		w_array = (wl_t *)&rmsg->rdma_body.rdma_msg.rdma_reply;
+		if (write_chunk) {
+			w_array = (wl_t *)&rmsg->rdma_body.rdma_msg.rdma_writes;
+			rmsg->rdma_type = htonl(RDMA_MSG);
+		}
+
+		/* In case of read/readdir xdr encode xdr_putbufs will
+		 * change the uv vio buffers to point to buffser set by
+		 * protocols and UIO_FLAG_REFER will be set.
+		 * first_buf = nfs_header buf + rdma_write bufs */
+		if (rdma_buf_used) {
+			rdma_buf_addr = first_send_buf_uv->v.vio_head;
+			rdma_buf_len = ioquv_length(first_send_buf_uv);
+			if (first_send_buf_uv->u.uio_flags & UIO_FLAG_REFER)
+				uio_refer = first_send_buf_uv->u.uio_refer;
+			if (!write_chunk) {
+				non_registered_buf = mem_zalloc(rdma_buf_len +
+				    ioquv_length(nfs_header_uv));
+				cbc->non_registered_buf = non_registered_buf;
+				memcpy(non_registered_buf, nfs_header_uv->v.vio_head,
+				    ioquv_length(nfs_header_uv));
+				memcpy(non_registered_buf + ioquv_length(nfs_header_uv),
+				    rdma_buf_addr, rdma_buf_len);
+				rdma_buf_addr = non_registered_buf;
+				rdma_buf_len = rdma_buf_len + ioquv_length(nfs_header_uv);
+				non_registered_buf_len = rdma_buf_len;
+				cbc->non_registered_buf_len = non_registered_buf_len;
+				add_nfs_header = 0;
+				xdr_rdma_ioq_uv_release(nfs_header_uv);
+			}
+		} else {
+			memcpy(first_send_buf_uv->v.vio_head, nfs_header_uv->v.vio_head,
+			    ioquv_length(nfs_header_uv));
+			memcpy(first_send_buf_uv->v.vio_head + ioquv_length(nfs_header_uv),
+			    rdma_buf_addr, rdma_buf_len);
+			first_send_buf_uv->v.vio_tail = first_send_buf_uv->v.vio_head +
+			    ioquv_length(nfs_header_uv) + rdma_buf_len;
+			add_nfs_header = 0;
+			xdr_rdma_ioq_uv_release(nfs_header_uv);
+		}
+
+		__warnx(TIRPC_DEBUG_FLAG_XDR, "first_send_buf_uv %d write_chunk %d",
+			ioquv_length(first_send_buf_uv), write_chunk);
+
 		w_array->present = htonl(1);
 
+		rdma_head_uv->v.vio_tail = rdma_head_uv->v.vio_head
+					+ 64;
+
+		cbc->have = TAILQ_FIRST(&cbc->sendq.ioq_uv.uvqh.qh);
 		while (i < n) {
 			struct xdr_rdma_segment *c_seg =
 				&reply_array->entry[i].target;
 			struct xdr_rdma_segment *w_seg =
 				&w_array->entry[i++].target;
+			struct xdr_ioq_uv *send_uv = NULL;
 			uint32_t length = ntohl(c_seg->length);
-			uint32_t k = length / xprt->sm_dr.sendsz;
-			uint32_t m = length % xprt->sm_dr.sendsz;
+			uint32_t nfs_header_len = ioquv_length(nfs_header_uv);
 
-			if (m) {
-				/* need fractional buffer */
-				k++;
-			}
-
-			/* ensure never asking for more buffers than allowed */
-			if (k > xprt->xa->max_send_sge) {
-				__warnx(TIRPC_DEBUG_FLAG_XDR,
-					"%s() requested chunk %" PRIu32
-					" is too long (%" PRIu32 ">%" PRIu32 ")",
-					__func__, length, k,
-					xprt->xa->max_send_sge);
-				k = xprt->xa->max_send_sge;
-			}
+			assert(length <= xprt->sm_dr.sendsz);
 
 			*w_seg = *c_seg;
 
-			/* sometimes, back-to-back buffers could be sent
-			 * together.  releases of unused buffers and
-			 * other events eventually scramble the buffers
-			 * enough that there's no gain in efficiency.
-			 */
-			xdr_rdma_wait_write_cb(xprt, cbc, k, w_seg);
+			__warnx(TIRPC_DEBUG_FLAG_XDR,
+				"%s() requested chunk length %u offset %llx handle %x length %x"
+				" nfs_header_len %u rdma_buf_addr %p rdma_buf_len %u",
+				__func__, length, w_seg->offset, w_seg->handle, w_seg->length,
+				nfs_header_len, rdma_buf_addr, rdma_buf_len);
 
-			while (0 < k--) {
-				struct poolq_entry *have =
-					TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh);
+			send_uv  = IOQ_(cbc->have);
+			assert(send_uv->rdma_uv);
 
-				TAILQ_REMOVE(&cbc->workq.ioq_uv.uvqh.qh, have, q);
-				(cbc->workq.ioq_uv.uvqh.qcount)--;
+			if (rdma_buf_used) {
+				uint32_t write_len = (rdma_buf_len > length) ? length : rdma_buf_len;
 
-				rpcrdma_dump_msg(IOQ_(have), "sreply body",
-						 msg->rm_xid);
-				xdr_ioq_uv_release(IOQ_(have));
+				if (non_registered_buf) {
+					/* Copy allocated buffer to registered buffer */
+					send_uv->v = send_uv->rdma_v;
+					send_uv->u = send_uv->rdma_u;
+					memcpy(send_uv->v.vio_head, rdma_buf_addr,
+					    write_len);
+				} else {
+					/* If its protocol rdma buffer, we need to set uv vio addr to
+					 * point to protocol rdma buf */
+					send_uv->v.vio_head = rdma_buf_addr;
+					/* mr could be different if its extra added buffer
+					 * protocol buffer will always be from preallocate mr */
+					send_uv->u.uio_p2 = cbc->data_chunk_uv->u.uio_p2;
+				}
+				send_uv->v.vio_tail = send_uv->v.vio_head + write_len;
+				rdma_buf_addr = rdma_buf_addr + write_len;
+				rdma_buf_len = rdma_buf_len - write_len;
 			}
+
+			xdr_rdma_wait_write_cb(xprt, cbc, 1, w_seg);
+
+			rpcrdma_dump_msg(IOQ_(have), "sreply rdma write",
+					 msg->rm_xid);
+
+			/* Reset uv vio back to rdma buf, so that we don't release protocol
+			 * rdma_buf */
+			if (rdma_buf_addr) {
+				send_uv->v = send_uv->rdma_v;
+				send_uv->u = send_uv->rdma_u;
+			}
+			cbc->have = TAILQ_NEXT(cbc->have, q);
 		}
+
 		w_array->elements = htonl(i);
 
-		head_uv->v.vio_tail = head_uv->v.vio_head
+		rdma_head_uv->v.vio_tail = rdma_head_uv->v.vio_head
+						+ 64;
+		if (write_chunk) {
+			wl_t * reply_array1 = (wl_t *)xdr_rdma_get_reply_array(rdma_head_uv->v.vio_head);
+			uint32_t * iptr = (uint32_t * )reply_array1;
+			iptr--;
+			*iptr = 0;
+			reply_array1->present = 0;
+		}
+
+		assert(cbc->freeq.ioq_uv.uvqh.qcount == 0);
+
+		pthread_mutex_lock(&cbc->freeq.ioq_uv.uvqh.qmutex);
+		pthread_mutex_lock(&cbc->sendq.ioq_uv.uvqh.qmutex);
+
+		TAILQ_CONCAT(&cbc->freeq.ioq_uv.uvqh.qh, &cbc->sendq.ioq_uv.uvqh.qh, q);
+		cbc->freeq.ioq_uv.uvqh.qcount += cbc->sendq.ioq_uv.uvqh.qcount;
+		cbc->sendq.ioq_uv.uvqh.qcount = 0;
+
+		pthread_mutex_unlock(&cbc->sendq.ioq_uv.uvqh.qmutex);
+		pthread_mutex_unlock(&cbc->freeq.ioq_uv.uvqh.qmutex);
+
+		rdma_head_uv->v.vio_tail = rdma_head_uv->v.vio_head
 					+ xdr_rdma_header_length(rmsg);
-		rpcrdma_dump_msg(head_uv, "sreply head", msg->rm_xid);
+
 	}
 
-	/* actual send, callback will take care of cleanup */
-	TAILQ_REMOVE(&cbc->holdq.ioq_uv.uvqh.qh, &head_uv->uvq, q);
-	(cbc->holdq.ioq_uv.uvqh.qcount)--;
-	(cbc->workq.ioq_uv.uvqh.qcount)++;
-	TAILQ_INSERT_HEAD(&cbc->workq.ioq_uv.uvqh.qh, &head_uv->uvq, q);
-	xdr_rdma_post_send_cb(xprt, cbc, cbc->workq.ioq_uv.uvqh.qcount);
+	rpcrdma_dump_msg(rdma_head_uv, "sreply rdma head", msg->rm_xid);
+	rpcrdma_dump_msg(nfs_header_uv, "sreply nfs head", msg->rm_xid);
 
-	/* free the old inbuf we only kept for header */
-	xdr_ioq_uv_release(cbc->call_uv);
+	pthread_mutex_lock(&cbc->sendq.ioq_uv.uvqh.qmutex);
+
+	if (add_nfs_header) {
+		TAILQ_INSERT_HEAD(&cbc->sendq.ioq_uv.uvqh.qh, &nfs_header_uv->uvq, q);
+		(cbc->sendq.ioq_uv.uvqh.qcount)++;
+	}
+
+	TAILQ_INSERT_HEAD(&cbc->sendq.ioq_uv.uvqh.qh, &rdma_head_uv->uvq, q);
+	(cbc->sendq.ioq_uv.uvqh.qcount)++;
+
+	pthread_mutex_unlock(&cbc->sendq.ioq_uv.uvqh.qmutex);
+
+	/* recvq = request_header buf + rdma_read bufs */
+	/* sendq = response_header_buf + rdma_write_bufs */
+	/* dataq = protocol_buf */
+
+	assert(cbc->dataq.ioq_uv.uvqh.qcount == 1);
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s() sendq %d recvq %d", __func__,
+		cbc->sendq.ioq_uv.uvqh.qcount, cbc->recvq.ioq_uv.uvqh.qcount);
+
+	cbc->have = TAILQ_FIRST(&cbc->sendq.ioq_uv.uvqh.qh);
+	xdr_rdma_post_send_cb(xprt, cbc, cbc->sendq.ioq_uv.uvqh.qcount);
+
+	/* Release uio for read/readdir */
+	if (uio_refer) {
+		uio_refer->uio_release(uio_refer, UIO_FLAG_NONE);
+	}
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc %p recvq %p %d sendq %p %d xd %p",
+		__func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount, &cbc->sendq,
+		cbc->sendq.ioq_uv.uvqh.qcount, xprt);
+
 	return (true);
 }


### PR DESCRIPTION
We are not taking ref for uio in xdrmem_putbufs which causes leak as uio_release won't happen.

To fix memory leak reported by valigrind, while running IO on udp.

==5030== 441,058,920 (5,531,240 direct, 435,527,680 indirect) bytes in 53,185 blocks are definitely lost in loss record 439 of 439
==5030==    at 0x4C2C089: calloc (vg_replace_malloc.c:762)
==5030==    by 0x4F90773: xdr_READ3res_uio_setup (xdr_nfs23.c:825)
==5030==    by 0x4F908EE: xdr_READ3resok_encode (xdr_nfs23.c:854)
==5030==    by 0x4F909DF: xdr_READ3resok (xdr_nfs23.c:873)
==5030==    by 0x4F90AA7: xdr_READ3res (xdr_nfs23.c:895)
==5030==    by 0x52AECC5: svcauth_none_wrap (svc_auth_none.c:45)
==5030==    by 0x52B023D: svc_dg_reply (svc_dg.c:423)
==5030==    by 0x52AE231: svc_sendreply (svc.c:506)
==5030==    by 0x4E91A7E: complete_request (nfs_worker_thread.c:784)
==5030==    by 0x4E94093: nfs_rpc_process_request (nfs_worker_thread.c:1520)
==5030==    by 0x4E94669: nfs_rpc_valid_NFS (nfs_worker_thread.c:1724)
==5030==    by 0x52AFFCC: svc_dg_decode (svc_dg.c:362)

Signed-off-by: Gaurav Gangalwar <gaurav.gangalwar@nutanix.com>