### PR TITLE
Implement HA Proxy V2 Protocol

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -254,6 +254,7 @@ struct svc_xprt {
 
 	struct rpc_address xp_local;	/* local address, length, port */
 	struct rpc_address xp_remote;	/* remote address, length, port */
+	struct rpc_address xp_proxy;	/* proxy address, length, port */
 
 #if defined(HAVE_BLKIN)
 	/* blkin tracing */

--- a/src/haproxy.h
+++ b/src/haproxy.h
@@ -1,0 +1,125 @@
+/*
+ * include/haproxy/connection-t.h
+ * This file describes the connection struct and associated constants.
+ *
+ * Copyright (C) 2000-2014 Willy Tarreau - w@1wt.eu
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, version 2.1
+ * exclusively.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* NOTE: This file is extracted from the haproxy project at:
+ *       https://github.com/haproxy/haproxy.git
+ *
+ * Specifically, parts of this file: include/haproxy/connection-t.h
+ */
+
+/* proxy protocol v2 definitions */
+#define PP2_SIGNATURE        "\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A"
+#define PP2_SIG_UINT32       0x0d0a0d0a
+#define PP2_SIG_UINT32_2     0x000d0a51
+#define PP2_SIG_UINT32_3     0x5549540a
+#define PP2_SIGNATURE_LEN    12
+#define PP2_HEADER_LEN       16
+
+/* ver_cmd byte */
+#define PP2_CMD_LOCAL        0x00
+#define PP2_CMD_PROXY        0x01
+#define PP2_CMD_MASK         0x0F
+
+#define PP2_VERSION          0x20
+#define PP2_VERSION_MASK     0xF0
+
+#define PP2_VERSION2_CMD_LOCAL (PP2_CMD_LOCAL | PP2_VERSION)
+#define PP2_VERSIOB2_CMD_PROXY (PP2_CMD_PROXY | PP2_VERSION)
+
+/* fam byte */
+#define PP2_TRANS_UNSPEC     0x00
+#define PP2_TRANS_STREAM     0x01
+#define PP2_TRANS_DGRAM      0x02
+#define PP2_TRANS_MASK       0x0F
+
+#define PP2_FAM_UNSPEC       0x00
+#define PP2_FAM_INET         0x10
+#define PP2_FAM_INET6        0x20
+#define PP2_FAM_UNIX         0x30
+#define PP2_FAM_MASK         0xF0
+
+#define PP2_TRANS_STREAM_FAM_INET (PP2_TRANS_STREAM | PP2_FAM_INET)
+#define PP2_TRANS_STREAM_FAM_INET6 (PP2_TRANS_STREAM | PP2_FAM_INET6)
+
+#define PP2_ADDR_LEN_UNSPEC  (0)
+#define PP2_ADDR_LEN_INET    (4 + 4 + 2 + 2)
+#define PP2_ADDR_LEN_INET6   (16 + 16 + 2 + 2)
+#define PP2_ADDR_LEN_UNIX    (108 + 108)
+
+#define PP2_HDR_LEN_UNSPEC   (PP2_HEADER_LEN + PP2_ADDR_LEN_UNSPEC)
+#define PP2_HDR_LEN_INET     (PP2_HEADER_LEN + PP2_ADDR_LEN_INET)
+#define PP2_HDR_LEN_INET6    (PP2_HEADER_LEN + PP2_ADDR_LEN_INET6)
+#define PP2_HDR_LEN_UNIX     (PP2_HEADER_LEN + PP2_ADDR_LEN_UNIX)
+
+#define PP2_TYPE_ALPN           0x01
+#define PP2_TYPE_AUTHORITY      0x02
+#define PP2_TYPE_CRC32C         0x03
+#define PP2_TYPE_NOOP           0x04
+#define PP2_TYPE_UNIQUE_ID      0x05
+#define PP2_TYPE_SSL            0x20
+#define PP2_SUBTYPE_SSL_VERSION 0x21
+#define PP2_SUBTYPE_SSL_CN      0x22
+#define PP2_SUBTYPE_SSL_CIPHER  0x23
+#define PP2_SUBTYPE_SSL_SIG_ALG 0x24
+#define PP2_SUBTYPE_SSL_KEY_ALG 0x25
+#define PP2_TYPE_NETNS          0x30
+
+#define PP2_CLIENT_SSL           0x01
+#define PP2_CLIENT_CERT_CONN     0x02
+#define PP2_CLIENT_CERT_SESS     0x04
+
+/* Max length of the authority TLV */
+#define PP2_AUTHORITY_MAX 255
+
+#define TLV_HEADER_SIZE      3
+
+struct proxy_header_part {
+	uint8_t ver_cmd;   /* protocol version and command */
+	uint8_t fam;       /* protocol family and transport */
+	uint16_t len;      /* number of following bytes part of the header */
+};
+
+union proxy_addr { 
+	struct {   /* for TCP/UDP over IPv4, len = 12 */
+		uint32_t src_addr;
+		uint32_t dst_addr;
+		uint16_t src_port;
+		uint16_t dst_port;
+	} ip4;
+	struct {   /* for TCP/UDP over IPv6, len = 36 */
+		uint8_t  src_addr[16];
+		uint8_t  dst_addr[16];
+		uint16_t src_port;
+		uint16_t dst_port;
+	} ip6;
+	struct {   /* for AF_UNIX sockets, len = 216 */
+		uint8_t src_addr[108];
+		uint8_t dst_addr[108];
+	} unx;
+};
+
+struct proxy_hdr_v2 {
+	uint8_t sig[12];   /* hex 0D 0A 0D 0A 00 0D 0A 51 55 49 54 0A */
+	struct proxy_header_part header_part;
+	union proxy_addr addr;
+};
+
+enum xprt_stat recv_haproxy_header(SVCXPRT *xprt);

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -79,6 +79,7 @@
 #include "svc_xprt.h"
 #include "rpc_dplx_internal.h"
 #include "svc_ioq.h"
+#include "haproxy.h"
 
 static void svc_vc_rendezvous_ops(SVCXPRT *);
 static void svc_vc_override_ops(SVCXPRT *, SVCXPRT *);
@@ -672,6 +673,7 @@ svc_vc_recv(SVCXPRT *xprt)
 	ssize_t rlen;
 	u_int flags;
 	int code;
+	bool hap_again = false;
 
 #ifdef USE_LTTNG_NTIRPC
 	tracepoint(xprt, funcin, __func__, __LINE__, xprt);
@@ -691,14 +693,17 @@ svc_vc_recv(SVCXPRT *xprt)
 	}
 
 	if (!xd->sx_fbtbc) {
+again:
+
 		rlen = recv(xprt->xp_fd, &xd->sx_fbtbc, BYTES_PER_XDR_UNIT,
-			    MSG_WAITALL);
+			    hap_again ? MSG_DONTWAIT : MSG_WAITALL);
 
 		if (unlikely(rlen < 0)) {
 			code = errno;
 
 			if (code == EAGAIN || code == EWOULDBLOCK) {
-				__warnx(TIRPC_DEBUG_FLAG_WARN,
+				__warnx(hap_again ? TIRPC_DEBUG_FLAG_SVC_VC
+						  : TIRPC_DEBUG_FLAG_WARN,
 					"%s: %p fd %d recv errno %d (try again)",
 					"svc_vc_wait", xprt, xprt->xp_fd, code);
 				if (unlikely(svc_rqst_rearm_events(
@@ -741,6 +746,134 @@ svc_vc_recv(SVCXPRT *xprt)
 		}
 
 		xd->sx_fbtbc = (int32_t)ntohl((long)xd->sx_fbtbc);
+
+		__warnx(TIRPC_DEBUG_FLAG_SVC_VC,
+			"sx_fbtbc = %08x", (int)xd->sx_fbtbc);
+
+		if (xd->sx_fbtbc == PP2_SIG_UINT32) {
+			/* HA Proxy V2? */
+			uint32_t rest[2];
+			struct proxy_header_part s;
+			union proxy_addr *pa;
+
+			rlen = recv(xprt->xp_fd, rest, sizeof(rest),
+				    MSG_WAITALL);
+			if (rlen != sizeof(rest)) {
+				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+					"%s: %p fd %d proxy header failed rest rlen = %z (will set dead)",
+				__func__, xprt, xprt->xp_fd, rlen);
+				SVC_DESTROY(xprt);
+				return SVC_STAT(xprt);
+			}
+			rest[0] = ntohl(rest[0]);
+			rest[1] = ntohl(rest[1]);
+
+			if (rest[0] != PP2_SIG_UINT32_2 ||
+			    rest[1] != PP2_SIG_UINT32_3) {
+				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+					"%s: %p fd %d proxy header failed rest1=%08x rest2=%08x (will set dead)",
+				__func__, xprt, xprt->xp_fd, (int) rest[1], (int) rest[2]);
+				SVC_DESTROY(xprt);
+			}
+
+			rlen = recv(xprt->xp_fd, &s, sizeof(s),
+				    MSG_WAITALL);
+
+			if (rlen != sizeof(s)) {
+				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+					"%s: %p fd %d proxy header failed header rlen = %z (will set dead)",
+				__func__, xprt, xprt->xp_fd, rlen);
+				SVC_DESTROY(xprt);
+				return SVC_STAT(xprt);
+			}
+
+			s.len = ntohs(s.len);
+			pa = mem_zalloc(s.len);
+			rlen = recv(xprt->xp_fd, pa, s.len, MSG_WAITALL);
+
+			if (rlen != s.len) {
+				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+					"%s: %p fd %d proxy header rest len failed header rlen = %z (will set dead)",
+				__func__, xprt, xprt->xp_fd, rlen);
+				SVC_DESTROY(xprt);
+				return SVC_STAT(xprt);
+			}
+
+			if (s.ver_cmd == PP2_VERSIOB2_CMD_PROXY) {
+				if (s.fam == PP2_TRANS_STREAM_FAM_INET) {
+					struct sockaddr_in *ss4;
+
+					xprt->xp_proxy = xprt->xp_remote;
+					ss4 = (struct sockaddr_in *)
+							&xprt->xp_remote.ss;
+					ss4->sin_family = AF_INET;
+					memcpy(&ss4->sin_addr,
+					       &pa->ip4.src_addr,
+					       sizeof(struct in_addr));
+					ss4->sin_port = pa->ip4.src_port;
+
+				} else if (s.fam ==
+						   PP2_TRANS_STREAM_FAM_INET6) {
+					struct sockaddr_in6 *ss6;
+
+					xprt->xp_proxy = xprt->xp_remote;
+					ss6 = (struct sockaddr_in6 *)
+							&xprt->xp_remote.ss;
+					xprt->xp_remote.ss.ss_family = AF_INET6;
+					memcpy(&ss6->sin6_addr,
+					       &pa->ip6.src_addr,
+					       sizeof(struct in6_addr));
+					ss6->sin6_port = pa->ip6.src_port;
+
+				} else {
+					/* NOTE: we don't support UNIX or UDP
+					 * sockets
+					 */
+					__warnx(TIRPC_DEBUG_FLAG_ERROR,
+						"%s: %p fd %d invalid proxy protocol = %0x2 (will set dead)",
+						__func__, xprt, xprt->xp_fd,
+						(int) s.fam);
+					SVC_DESTROY(xprt);
+					return SVC_STAT(xprt);
+				}
+
+				/* Now look to see if there's more... */
+				hap_again = true;
+				goto again;
+
+			} else if (s.ver_cmd == PP2_VERSION2_CMD_LOCAL) {
+				__warnx(TIRPC_DEBUG_FLAG_EVENT,
+					"%s: %p fd %d proxy ignored for local",
+					__func__, xprt, xprt->xp_fd);
+			} else {
+				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+					"%s: %p fd %d invalid proxy command = %0x2 (will set dead)",
+					__func__, xprt, xprt->xp_fd,
+					(int) s.ver_cmd);
+				SVC_DESTROY(xprt);
+				return SVC_STAT(xprt);
+			}
+
+			if (unlikely(svc_rqst_rearm_events(xprt,
+						   SVC_XPRT_FLAG_ADDED_RECV))) {
+				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+					"%s: %p fd %d svc_rqst_rearm_events failed (will set dead)",
+				__func__, xprt, xprt->xp_fd);
+				SVC_DESTROY(xprt);
+#ifndef USE_LTTNG_NTIRPC
+			}
+#else
+				tracepoint(xprt, recv_exit, __func__, __LINE__,
+					   xprt, "REARM FAILED", -1);
+			} else {
+				tracepoint(xprt, recv_exit, __func__, __LINE__,
+					   xprt, "MORE", 0);
+			}
+#endif /* USE_LTTNG_NTIRPC */
+			return SVC_STAT(xprt);
+			/* return (XPRT_IDLE); */
+		}
+	
 		flags = UIO_FLAG_FREE | UIO_FLAG_MORE;
 
 		if (xd->sx_fbtbc & LAST_FRAG) {


### PR DESCRIPTION
On TCP connections, if we receive an HA Proxy V2 header, we will replace xp_remote with the address provided in the header. The original address will have been copied to xp_proxy which will allow the upper layer (nfs-ganesha for example) to validate that HA Proxy is allowed from that host. This allows a server to protect itself from spoofing by unauthorized proxies.

Attempting the do the validation in ntirpc resulted in the client endlessly retrying the connection.

Signed-off-by: Frank S. Filz <ffilzlnx@mindspring.com>