### PR TITLE
Destroy XPRT when FD already exists

### DIFF
--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -458,7 +458,14 @@ svc_vc_rendezvous(SVCXPRT *xprt)
 	newxprt = makefd_xprt(fd, req_xd->sx_dr.sendsz, req_xd->sx_dr.recvsz,
 			      &si, SVC_XPRT_FLAG_CLOSE);
 	if ((!newxprt) || (!(newxprt->xp_flags & SVC_XPRT_FLAG_INITIAL))) {
-		close(fd);
+
+		if (newxprt) {
+			SVC_DESTROY(newxprt);
+			/* Was never added to epoll */
+			SVC_RELEASE(newxprt, SVC_RELEASE_FLAG_NONE);
+		} else {
+			close(fd);
+		}
 		return (XPRT_DIED);
 	}
 


### PR DESCRIPTION
When makefd_xprt returns that the FD already exists, even though we know it was just opened, destroy the associated XPRT instead of just closing the FD.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>