### PR TITLE
Add runtime support to set global svc-gss-auth status, based on NFS_KRB5 section of Ganesha config

### DIFF
--- a/ntirpc/rpc/gss_internal.h
+++ b/ntirpc/rpc/gss_internal.h
@@ -135,5 +135,6 @@ bool svcauth_gss_acquire_cred(void);
 bool svcauth_gss_release_cred(void);
 bool svcauth_gss_import_name(char *service);
 bool svcauth_gss_set_svc_name(gss_name_t name);
+void svcauth_gss_set_status(bool status_enabled);
 
 #endif				/* GSS_INTERNAL_H */

--- a/ntirpc/rpc/gss_internal.h
+++ b/ntirpc/rpc/gss_internal.h
@@ -129,6 +129,7 @@ unref_svc_rpc_gss_data(struct svc_rpc_gss_data *gd)
 struct svc_rpc_gss_data *authgss_ctx_hash_get(struct rpc_gss_cred *gc);
 bool authgss_ctx_hash_set(struct svc_rpc_gss_data *gd);
 bool authgss_ctx_hash_del(struct svc_rpc_gss_data *gd);
+void authgss_ctx_hash_clear(void);
 
 bool svcauth_gss_acquire_cred(void);
 bool svcauth_gss_release_cred(void);

--- a/src/authgss_hash.c
+++ b/src/authgss_hash.c
@@ -42,6 +42,8 @@
 
 /* GSS context cache */
 
+extern bool svcauth_gss_enabled;
+
 struct authgss_x_part {
 	uint32_t gen;
 	uint32_t size;
@@ -166,6 +168,16 @@ authgss_ctx_hash_get(struct rpc_gss_cred *gc)
 	struct authgss_x_part *axp;
 	struct rbtree_x_part *t;
 
+        /**
+         * If auth-gss is disabled, we need to stop requests from using cached
+         * gss-contexts.
+         */
+        if (!svcauth_gss_enabled) {
+                __warnx(TIRPC_DEBUG_FLAG_RPCSEC_GSS,
+                        "%s: auth_gss disabled: GET cached context skipped", __func__);
+                return NULL;
+        }
+
 	authgss_hash_init();
 
 	gss_ctx = (gss_union_ctx_id_desc *) (gc->gc_ctx.value);
@@ -173,7 +185,17 @@ authgss_ctx_hash_get(struct rpc_gss_cred *gc)
 	gk.ctx = (gc->gc_ctx.value);
 
 	t = rbtx_partition_of_scalar(&authgss_hash_st.xt, gk.hk.k);
+
 	mutex_lock(&t->mtx);
+
+	/* Recheck the above condition after obtaining lock */
+	if (!svcauth_gss_enabled) {
+		mutex_unlock(&t->mtx);
+		__warnx(TIRPC_DEBUG_FLAG_RPCSEC_GSS,
+			"%s: auth_gss disabled: GET cached context skipped", __func__);
+		return NULL;
+	}
+
 	ngd =
 	    rbtree_x_cached_lookup(&authgss_hash_st.xt, t, &gk.node_k, gk.hk.k);
 	if (ngd) {
@@ -199,6 +221,16 @@ authgss_ctx_hash_set(struct svc_rpc_gss_data *gd)
 	gss_union_ctx_id_desc *gss_ctx;
 	bool rslt;
 
+        /**
+         * If auth-gss is disabled, we need to stop requests from writing possibly
+         * older gss-contexts to the cache.
+         */
+        if (!svcauth_gss_enabled) {
+                __warnx(TIRPC_DEBUG_FLAG_RPCSEC_GSS,
+                        "%s: auth_gss disabled: SET cached context skipped", __func__);
+                return false;
+        }
+
 	authgss_hash_init();
 
 	gss_ctx = (gss_union_ctx_id_desc *) (gd->ctx);
@@ -206,7 +238,23 @@ authgss_ctx_hash_set(struct svc_rpc_gss_data *gd)
 
 	(void)atomic_inc_uint32_t(&gd->refcnt);
 	t = rbtx_partition_of_scalar(&authgss_hash_st.xt, gd->hk.k);
+
 	mutex_lock(&t->mtx);
+
+	/**
+	 * When auth-gss is disabled, there could be inflight requests waiting for
+	 * the mutex to write gss-contexts to the cache. While gss-auth disabling
+	 * would clear the context cache, we need to prevent these waiting in-flight
+	 * requests from writing potentially invalid data to the cache. So, we make
+	 * them recheck the global status after obtaining the mutex.
+	 */
+	if (!svcauth_gss_enabled) {
+		mutex_unlock(&t->mtx);
+		(void)atomic_dec_uint32_t(&gd->refcnt);
+		__warnx(TIRPC_DEBUG_FLAG_RPCSEC_GSS,
+			"%s: auth_gss disabled: SET cached context skipped", __func__);
+		return false;
+	}
 	rslt =
 	    rbtree_x_cached_insert(&authgss_hash_st.xt, t, &gd->node_k,
 				   gd->hk.k);

--- a/src/libntirpc.map.in.cmake
+++ b/src/libntirpc.map.in.cmake
@@ -156,6 +156,7 @@ NTIRPC_${NTIRPC_VERSION_BASE} {
     svcauth_gss_import_name;
     svcauth_gss_nextverf;
     svcauth_gss_release_cred;
+    svcauth_gss_set_status;
     svcauth_gss_set_svc_name;
     svcerr_auth;
     svcerr_decode;

--- a/src/svc_auth_gss.c
+++ b/src/svc_auth_gss.c
@@ -48,42 +48,66 @@ static struct svc_auth_ops svc_auth_gss_ops;
 #define SVCAUTH_PRIVATE(auth) \
 	((struct svc_rpc_gss_data *)(auth)->svc_ah_private)
 
-/* Global server credentials. */
-gss_cred_id_t svcauth_gss_creds;
-static gss_name_t svcauth_gss_name;
-static int64_t svcauth_gss_creds_expires;
-static gss_cred_id_t svcauth_prev_gss_creds;
+#define OLDEST_TIMESTAMP 1
 
-/* RW-Locks to synchronise reads and writes to global auth variables */
-static rwlock_t svcauth_gss_creds_lock = RWLOCK_INITIALIZER;
-static rwlock_t svcauth_gss_name_lock = RWLOCK_INITIALIZER;
+struct svcauth_gss_creds_holder {
+	gss_cred_id_t gss_creds;
+	gss_cred_id_t prev_gss_creds;
+	int64_t gss_creds_expires;
+	/* RW-Lock to synchronise reads and writes to svcauth_gss_creds_holder */
+	rwlock_t gss_creds_lock;
+};
+
+struct svcauth_gss_name_holder {
+	gss_name_t gss_name;
+	/* RW-Lock to synchronise reads and writes to svcauth_gss_name_holder */
+	rwlock_t gss_name_lock;
+};
+
+/* Global server credentials. */
+static struct svcauth_gss_creds_holder server_creds = {
+	.gss_creds = NULL,
+	.prev_gss_creds = NULL,
+	.gss_creds_expires = OLDEST_TIMESTAMP,
+	.gss_creds_lock = RWLOCK_INITIALIZER
+};
+
+static struct svcauth_gss_name_holder server_gss_name = {
+	.gss_name = NULL,
+	.gss_name_lock = RWLOCK_INITIALIZER
+};
 
 /* Global flag to indicate if svcauth_gss is enabled (default: enabled) */
 bool svcauth_gss_enabled = true;
+
 static mutex_t svcauth_gss_status_lock = MUTEX_INITIALIZER;
 
-/*
- * This function sets the global svcauth_gss authentication status.
- * The status can be ON or OFF, depending on the input.
+/**
+ * @brief This function sets the global svcauth_gss authentication status
  *
+ * The status can be ON or OFF, depending on the input.
  * If the new status is OFF, we reset the global auth state variables and
  * clear gss-context cache.
  *
  * We protect the entire function through a mutex to prevent conflicts between
  * threads trying to set different statuses.
+ *
+ * @note When enabling the status, this function must be called after the
+ * auth-gss name and credentials have been initialised.
  */
 void
 svcauth_gss_set_status(bool status_enabled)
 {
 	OM_uint32 maj_stat, min_stat;
 
-	/* Acquire mutex to overwrite global `svcauth_gss_enabled` */
+	/* Acquire mutex to prevent interference by another invocation */
 	mutex_lock(&svcauth_gss_status_lock);
 
 	if (svcauth_gss_enabled == status_enabled) {
 		mutex_unlock(&svcauth_gss_status_lock);
 		__warnx(TIRPC_DEBUG_FLAG_AUTH,
-			"%s: svcauth_gss is already set to %d", __func__, status_enabled);
+			"%s: svcauth_gss status is already set to %d",
+			__func__, status_enabled);
 		return;
 	}
 	svcauth_gss_enabled = status_enabled;
@@ -95,51 +119,52 @@ svcauth_gss_set_status(bool status_enabled)
 	}
 
 	/* Reset all state related to svcauth_gss credentials */
-	rwlock_wrlock(&svcauth_gss_creds_lock);
+	rwlock_wrlock(&server_creds.gss_creds_lock);
 
-	if (svcauth_gss_creds != NULL) {
-		maj_stat = gss_release_cred(&min_stat, &svcauth_gss_creds);
+	if (server_creds.gss_creds != NULL) {
+		maj_stat = gss_release_cred(&min_stat, &server_creds.gss_creds);
 
 		if (maj_stat != GSS_S_COMPLETE) {
 			__warnx(TIRPC_DEBUG_FLAG_AUTH,
 				"%s: failed to release gss_creds major=%u minor=%u",
 				__func__, maj_stat, min_stat);
 		}
-		svcauth_gss_creds = NULL;
+		server_creds.gss_creds = NULL;
 	}
-	if (svcauth_prev_gss_creds != NULL) {
-		maj_stat = gss_release_cred(&min_stat, &svcauth_prev_gss_creds);
+	if (server_creds.prev_gss_creds != NULL) {
+		maj_stat = gss_release_cred(&min_stat, &server_creds.prev_gss_creds);
 
 		if (maj_stat != GSS_S_COMPLETE) {
 			__warnx(TIRPC_DEBUG_FLAG_AUTH,
 				"%s: failed to release prev_gss_creds major=%u minor=%u",
 				__func__, maj_stat, min_stat);
 		}
-		svcauth_prev_gss_creds = NULL;
+		server_creds.prev_gss_creds = NULL;
 	}
 	/* Set expiry-time in the past to not use existing creds */
-	svcauth_gss_creds_expires = 1;
+	server_creds.gss_creds_expires = OLDEST_TIMESTAMP;
 
-	rwlock_unlock(&svcauth_gss_creds_lock);
+	rwlock_unlock(&server_creds.gss_creds_lock);
 
 	/* Reset svcauth_gss service name */
-	rwlock_wrlock(&svcauth_gss_name_lock);
+	rwlock_wrlock(&server_gss_name.gss_name_lock);
 
-	if (svcauth_gss_name != NULL) {
-		maj_stat = gss_release_name(&min_stat, &svcauth_gss_name);
+	if (server_gss_name.gss_name != NULL) {
+		maj_stat = gss_release_name(&min_stat, &server_gss_name.gss_name);
 		if (maj_stat != GSS_S_COMPLETE) {
 			__warnx(TIRPC_DEBUG_FLAG_AUTH,
 				"%s: failed to release gss_name major=%u minor=%u",
 				__func__, maj_stat, min_stat);
 		}
-		svcauth_gss_name = NULL;
+		server_gss_name.gss_name = NULL;
 	}
-	rwlock_unlock(&svcauth_gss_name_lock);
+	rwlock_unlock(&server_gss_name.gss_name_lock);
 
 	/* Clear authgss-context cache */
 	authgss_ctx_hash_clear();
 
-        mutex_unlock(&svcauth_gss_status_lock);
+	/* Now release the mutex to permit other threads */
+	mutex_unlock(&svcauth_gss_status_lock);
 }
 
 bool
@@ -147,25 +172,27 @@ svcauth_gss_set_svc_name(gss_name_t name)
 {
 	OM_uint32 maj_stat, min_stat;
 
-	/* Acquire write lock before updating svcauth_gss_name */
-	rwlock_wrlock(&svcauth_gss_name_lock);
+	/* Acquire write lock before updating server_gss_name.gss_name */
+	rwlock_wrlock(&server_gss_name.gss_name_lock);
 
-	if (svcauth_gss_name != NULL) {
-		maj_stat = gss_release_name(&min_stat, &svcauth_gss_name);
+	if (server_gss_name.gss_name != NULL) {
+		maj_stat = gss_release_name(&min_stat,
+			&server_gss_name.gss_name);
 		if (maj_stat != GSS_S_COMPLETE) {
-			rwlock_unlock(&svcauth_gss_name_lock);
+			rwlock_unlock(&server_gss_name.gss_name_lock);
 			return (false);
 		}
-		svcauth_gss_name = NULL;
+		server_gss_name.gss_name = NULL;
 	}
 
 	/* XXX Ganesha */
-	if (svcauth_gss_name == GSS_C_NO_NAME) {
-		rwlock_unlock(&svcauth_gss_name_lock);
+	if (server_gss_name.gss_name == GSS_C_NO_NAME) {
+		rwlock_unlock(&server_gss_name.gss_name_lock);
 		return (true);
 	}
-	maj_stat = gss_duplicate_name(&min_stat, name, &svcauth_gss_name);
-	rwlock_unlock(&svcauth_gss_name_lock);
+	maj_stat = gss_duplicate_name(&min_stat, name,
+		&server_gss_name.gss_name);
+	rwlock_unlock(&server_gss_name.gss_name_lock);
 
 	if (maj_stat != GSS_S_COMPLETE)
 		return (false);
@@ -223,46 +250,48 @@ svcauth_gss_acquire_cred(void)
 
 	now = get_time_fast();
 
-	rwlock_rdlock(&svcauth_gss_creds_lock);
-	if (svcauth_gss_creds && (!svcauth_gss_creds_expires || svcauth_gss_creds_expires > now)) {
-		rwlock_unlock(&svcauth_gss_creds_lock);
+	rwlock_rdlock(&server_creds.gss_creds_lock);
+	if (server_creds.gss_creds && (!server_creds.gss_creds_expires ||
+		server_creds.gss_creds_expires > now)) {
+		rwlock_unlock(&server_creds.gss_creds_lock);
 		return (true);
 	}
-	rwlock_unlock(&svcauth_gss_creds_lock);
+	rwlock_unlock(&server_creds.gss_creds_lock);
 
-	/* Now acquire write-lock for writing svcauth_gss_creds */
-	rwlock_wrlock(&svcauth_gss_creds_lock);
+	/* Now acquire write-lock for writing server_creds.gss_creds */
+	rwlock_wrlock(&server_creds.gss_creds_lock);
 
-	if (svcauth_gss_creds && (!svcauth_gss_creds_expires || svcauth_gss_creds_expires > now)) {
+	if (server_creds.gss_creds && (!server_creds.gss_creds_expires ||
+		server_creds.gss_creds_expires > now)) {
 		maj_stat = GSS_S_COMPLETE;
 	} else {
-		ancient_creds = svcauth_prev_gss_creds;
-		old_creds = svcauth_gss_creds;
+		ancient_creds = server_creds.prev_gss_creds;
+		old_creds = server_creds.gss_creds;
 		timerec = 0;
 		now = get_time_fast();
 
-		/* Acquire read-lock before reading svcauth_gss_name */
-		rwlock_rdlock(&svcauth_gss_name_lock);
-		maj_stat =
-		    gss_acquire_cred(&min_stat, svcauth_gss_name, 0, GSS_C_NULL_OID_SET,
-				     GSS_C_ACCEPT, &svcauth_gss_creds, NULL, &timerec);
-		rwlock_unlock(&svcauth_gss_name_lock);
+		/* Acquire read-lock before reading server_gss_name.gss_name */
+		rwlock_rdlock(&server_gss_name.gss_name_lock);
+		maj_stat = gss_acquire_cred(&min_stat, server_gss_name.gss_name,
+			0, GSS_C_NULL_OID_SET, GSS_C_ACCEPT,
+			&server_creds.gss_creds, NULL, &timerec);
+		rwlock_unlock(&server_gss_name.gss_name_lock);
 
 		if (maj_stat == GSS_S_COMPLETE) {
 			if (timerec == GSS_C_INDEFINITE)
-				svcauth_gss_creds_expires = 0;
+				server_creds.gss_creds_expires = 0;
 			else
-				svcauth_gss_creds_expires = now + timerec;
+				server_creds.gss_creds_expires = now + timerec;
 			if (old_creds) {
-				svcauth_prev_gss_creds = old_creds;
+				server_creds.prev_gss_creds = old_creds;
 			}
 			if (ancient_creds) {
 				(void) gss_release_cred(&min_stat, &ancient_creds);
 			}
 		}
 	}
-	/* Release the svcauth_gss_creds write-lock */
-	rwlock_unlock(&svcauth_gss_creds_lock);
+	/* Release the server_creds.gss_creds write-lock */
+	rwlock_unlock(&server_creds.gss_creds_lock);
 
 	if (maj_stat != GSS_S_COMPLETE) {
 		__warnx(TIRPC_DEBUG_FLAG_AUTH,
@@ -277,22 +306,22 @@ svcauth_gss_acquire_cred(void)
 bool
 svcauth_gss_release_cred(void)
 {
-	rwlock_wrlock(&svcauth_gss_creds_lock);
+	rwlock_wrlock(&server_creds.gss_creds_lock);
 #if 0
 	OM_uint32 maj_stat, min_stat;
 
-	maj_stat = gss_release_cred(&min_stat, &svcauth_gss_creds);
+	maj_stat = gss_release_cred(&min_stat, &server_creds.gss_creds);
 	if (maj_stat != GSS_S_COMPLETE) {
-		rwlock_unlock(&svcauth_gss_creds_lock);
+		rwlock_unlock(&server_creds.gss_creds_lock);
 		return (false);
 	}
-	svcauth_gss_creds = NULL;
+	server_creds.gss_creds = NULL;
 #else
-	svcauth_gss_creds_expires = 1;
+	server_creds.gss_creds_expires = OLDEST_TIMESTAMP;
 	/* make any future callers to svcauth_gss_acquire_cred() should get a new cred. */
 #endif
 
-	rwlock_unlock(&svcauth_gss_creds_lock);
+	rwlock_unlock(&server_creds.gss_creds_lock);
 	return (true);
 }
 
@@ -321,20 +350,20 @@ svcauth_gss_accept_sec_context(struct svc_req *req,
 		return (false);
 	}
 
-	rwlock_rdlock(&svcauth_gss_creds_lock);
+	rwlock_rdlock(&server_creds.gss_creds_lock);
 
-	if (svcauth_gss_creds == NULL) {
-		rwlock_unlock(&svcauth_gss_creds_lock);
+	/* We can not accept incoming context, if server gss-creds are NULL. */
+	if (server_creds.gss_creds == NULL) {
+		rwlock_unlock(&server_creds.gss_creds_lock);
 		xdr_free((xdrproc_t)xdr_rpc_gss_init_args, (void *)&recv_tok);
 		return false;
 	}
 
-	gr->gr_major =
-	    gss_accept_sec_context(&gr->gr_minor, &gd->ctx, svcauth_gss_creds,
-				   &recv_tok, GSS_C_NO_CHANNEL_BINDINGS,
-				   &gd->client_name, &mech, &gr->gr_token,
-				   &ret_flags, &time_rec, NULL);
-	rwlock_unlock(&svcauth_gss_creds_lock);
+	gr->gr_major = gss_accept_sec_context(&gr->gr_minor, &gd->ctx,
+		server_creds.gss_creds, &recv_tok, GSS_C_NO_CHANNEL_BINDINGS,
+		&gd->client_name, &mech, &gr->gr_token,
+		&ret_flags, &time_rec, NULL);
+	rwlock_unlock(&server_creds.gss_creds_lock);
 
 	xdr_free((xdrproc_t)xdr_rpc_gss_init_args, (void *)&recv_tok);
 


### PR DESCRIPTION
This change is a part of the larger change-list for enabling dynamic updation of NFS_KRB5 section of Ganesha configuration, without requiring a restart of the Ganesha process. This updation supports disabling the existing enabled rpcsec_gss authentication, and vice-versa.