### PR TITLE
worker pool threads, enable setting an appropriate thread stack size

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -139,11 +139,14 @@ typedef struct svc_init_params {
 	u_int gss_max_gc;
 	uint32_t channels;
 	int32_t idle_timeout;
+	uint32_t thr_stack_size;
 } svc_init_params;
 
 /* Svc param flags */
 #define SVC_FLAG_NONE             0x0000
 #define SVC_FLAG_NOREG_XPRTS      0x0001
+
+#define SVC_PARAM_HAS_THR_STACK_SIZE 1
 
 /*
  * SVCXPRT xp_flags

--- a/ntirpc/rpc/work_pool.h
+++ b/ntirpc/rpc/work_pool.h
@@ -45,6 +45,7 @@
 struct work_pool_params {
 	int32_t thrd_max;
 	int32_t thrd_min;
+	uint32_t thr_stack_size;
 };
 
 struct work_pool_thread;

--- a/src/svc.c
+++ b/src/svc.c
@@ -127,7 +127,7 @@ struct work_pool svc_work_pool;
 bool
 svc_init(svc_init_params *params)
 {
-	struct work_pool_params work_pool_params;
+	struct work_pool_params work_pool_params = {0,};
 	uint32_t channels = params->channels ? params->channels : 8;
 
 	mutex_lock(&__svc_params->mtx);
@@ -186,6 +186,7 @@ svc_init(svc_init_params *params)
 
 	work_pool_params.thrd_min = __svc_params->ioq.thrd_min;
 	work_pool_params.thrd_max = __svc_params->ioq.thrd_max;
+	work_pool_params.thr_stack_size = params->thr_stack_size;
 	/*
 	 * thrd_max should > channels.
 	 */

--- a/src/work_pool.c
+++ b/src/work_pool.c
@@ -119,7 +119,10 @@ work_pool_init(struct work_pool *pool, const char *name,
 		return rc;
 	}
 
-	rc = pthread_attr_setstacksize(&pool->attr, WORK_POOL_STACK_SIZE);
+	rc = pthread_attr_setstacksize(&pool->attr,
+				       params->thr_stack_size > 0 ?
+				       params->thr_stack_size :
+				       WORK_POOL_STACK_SIZE);
 	if (rc) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s() can't set pthread's stack size: %s (%d)",


### PR DESCRIPTION
glibc's default thread stack size is 8M. N.B. This can be overridden across the whole process by setting the stack size with ulimit; by default threads will inherit the same size for their thread stack. w

Empirical testing shows that, e.g., ganesha works fine with ntirpc using a thread stack size as small 32K. (At 16K, NFSv4 mounts fail; the stack underflows.)