### PR TITLE
Fix SVC_DESTROY to release non-transient xprt's references

### DIFF
--- a/ntirpc/rpc/clnt.h
+++ b/ntirpc/rpc/clnt.h
@@ -544,6 +544,14 @@ clnt_dg_ncreate(const int fd, const struct netbuf *raddr,
 extern CLIENT *clnt_raw_ncreate(rpcprog_t, rpcvers_t);
 
 /*
+ * Get the transport handle for a given rpc_client.
+ */
+extern SVCXPRT *clnt_vc_get_client_xprt(const CLIENT *clnt);
+/*
+ *      const struct rpc_client *clnt;         -- rpc client
+ */
+
+/*
  * Client request processing
  */
 static inline void clnt_req_fill(struct clnt_req *cc, struct rpc_client *clnt,

--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -175,6 +175,11 @@ typedef struct svc_init_params {
 #define SVC_XPRT_FLAG_LOCKED		0x00010000
 #define SVC_XPRT_FLAG_UNLOCK		0x00020000
 
+/* This flag serves as an instruction during svcxprt lookup, to not
+ * implicitly create a new svcxprt, if the lookup does not find one.
+ */
+#define SVC_XPRT_FLAG_LOOKUP_ONLY	0x00040000
+
 /*
  * SVC_REF flags
  */

--- a/src/clnt_vc.c
+++ b/src/clnt_vc.c
@@ -253,6 +253,22 @@ clnt_vc_ncreatef(const int fd,	/* open file descriptor */
 }
 
 /*
+ * Get the transport handle for a given rpc_client.
+ */
+SVCXPRT *
+clnt_vc_get_client_xprt(const struct rpc_client *clnt)
+{
+	if (clnt == NULL)
+		return NULL;
+
+	struct cx_data *cx = CX_DATA(clnt);
+
+	if (cx->cx_rec)
+		return &(cx->cx_rec->xprt);
+	return NULL;
+}
+
+/*
  * Create an RPC client handle from an active service transport
  * handle, i.e., to issue calls on the channel.
  */

--- a/src/clnt_vc.c
+++ b/src/clnt_vc.c
@@ -198,8 +198,13 @@ clnt_vc_ncreatef(const int fd,	/* open file descriptor */
 		}
 	}
 
+	uint32_t updated_flags = flags;
+	if (flags & CLNT_CREATE_FLAG_SVCXPRT)
+		/* Set flag to not create new svcxprt */
+		updated_flags |= SVC_XPRT_FLAG_LOOKUP_ONLY;
+
 	/* find or create shared fd state; ref+1 */
-	xprt = svc_fd_ncreatef(fd, sendsz, recvsz, flags);
+	xprt = svc_fd_ncreatef(fd, sendsz, recvsz, updated_flags);
 	if (!xprt) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s: fd %d svc_fd_ncreatef failed",

--- a/src/libntirpc.map.in.cmake
+++ b/src/libntirpc.map.in.cmake
@@ -67,6 +67,7 @@ NTIRPC_${NTIRPC_VERSION_BASE} {
     clnt_sperrno;
     clnt_tli_create;
     clnt_tp_ncreate_timed;
+    clnt_vc_get_client_xprt;
     clnt_vc_ncreatef;
     clnt_vc_ncreate_svc;
 

--- a/src/rpc_rdma.c
+++ b/src/rpc_rdma.c
@@ -2229,6 +2229,16 @@ static bool
 rpc_rdma_control(SVCXPRT *xprt, const u_int rq, void *in)
 {
 	switch (rq) {
+	case SVCGET_XP_UNREF_USER_DATA:
+	    mutex_lock(&ops_lock);
+	    *(svc_xprt_void_fun_t *) in = xprt->xp_ops->xp_unref_user_data;
+	    mutex_unlock(&ops_lock);
+	    break;
+	case SVCSET_XP_UNREF_USER_DATA:
+	    mutex_lock(&ops_lock);
+	    xprt->xp_ops->xp_unref_user_data = *(svc_xprt_void_fun_t) in;
+	    mutex_unlock(&ops_lock);
+	    break;
 	case SVCGET_XP_FREE_USER_DATA:
 	    mutex_lock(&ops_lock);
 	    *(svc_xprt_fun_t *)in = xprt->xp_ops->xp_free_user_data;
@@ -2252,6 +2262,7 @@ static struct xp_ops rpc_rdma_ops = {
 	.xp_reply = (svc_req_fun_t)abort,
 	.xp_checksum = NULL,		/* not used */
 	.xp_unlink = rpc_rdma_unlink_it,
+	.xp_unref_user_data = NULL,	/* no default */
 	.xp_destroy = rpc_rdma_destroy_it,
 	.xp_control = rpc_rdma_control,
 	.xp_free_user_data = NULL,	/* no default */

--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -551,6 +551,16 @@ svc_dg_control(SVCXPRT *xprt, const u_int rq, void *in)
 	case SVCSET_XP_FLAGS:
 		xprt->xp_flags = *(u_int *) in;
 		break;
+	case SVCGET_XP_UNREF_USER_DATA:
+		mutex_lock(&ops_lock);
+		*(svc_xprt_void_fun_t *) in = xprt->xp_ops->xp_unref_user_data;
+		mutex_unlock(&ops_lock);
+		break;
+	case SVCSET_XP_UNREF_USER_DATA:
+		mutex_lock(&ops_lock);
+		xprt->xp_ops->xp_unref_user_data = *(svc_xprt_void_fun_t) in;
+		mutex_unlock(&ops_lock);
+		break;
 	case SVCGET_XP_FREE_USER_DATA:
 		mutex_lock(&ops_lock);
 		*(svc_xprt_fun_t *) in = xprt->xp_ops->xp_free_user_data;
@@ -585,6 +595,7 @@ svc_dg_override_ops(SVCXPRT *xprt, SVCXPRT *rendezvous)
 		ops.xp_reply = svc_dg_reply;
 		ops.xp_checksum = svc_dg_checksum;
 		ops.xp_unlink = svc_dg_unlink_it;
+		ops.xp_unref_user_data = NULL;	/* no default */
 		ops.xp_destroy = svc_dg_destroy_it;
 		ops.xp_control = svc_dg_control;
 		ops.xp_free_user_data = NULL;	/* no default */
@@ -610,6 +621,7 @@ svc_dg_rendezvous_ops(SVCXPRT *xprt)
 		ops.xp_reply = (svc_req_fun_t)abort;
 		ops.xp_checksum = NULL;		/* not used */
 		ops.xp_unlink = svc_dg_unlink_it;
+		ops.xp_unref_user_data = NULL;	/* no default */
 		ops.xp_destroy = svc_dg_destroy_it;
 		ops.xp_control = svc_dg_control;
 		ops.xp_free_user_data = NULL;	/* no default */

--- a/src/svc_internal.h
+++ b/src/svc_internal.h
@@ -153,6 +153,9 @@ static inline void
 svc_override_ops(struct xp_ops *ops, SVCXPRT *rendezvous)
 {
 	if (rendezvous) {
+		if (!ops->xp_unref_user_data)
+			ops->xp_unref_user_data = rendezvous->xp_ops->xp_unref_user_data;
+
 		if (!ops->xp_free_user_data)
 			ops->xp_free_user_data =
 				rendezvous->xp_ops->xp_free_user_data;

--- a/src/svc_raw.c
+++ b/src/svc_raw.c
@@ -218,6 +218,7 @@ svc_raw_ops(SVCXPRT *xprt)
 		ops.xp_reply = svc_raw_reply;
 		ops.xp_checksum = NULL;		/* optional */
 		ops.xp_unlink = svc_raw_unlink;
+		ops.xp_unref_user_data = NULL;	/* no default */
 		ops.xp_destroy = svc_raw_destroy;
 		ops.xp_control = svc_raw_control;
 		ops.xp_free_user_data = NULL;	/* no default */

--- a/src/svc_rdma.c
+++ b/src/svc_rdma.c
@@ -254,6 +254,16 @@ svc_rdma_control(SVCXPRT *xprt, const u_int rq, void *in)
 	case SVCSET_XP_FLAGS:
 	    xprt->xp_flags = *(u_int *)in;
 	    break;
+	case SVCGET_XP_UNREF_USER_DATA:
+	    mutex_lock(&ops_lock);
+	    *(svc_xprt_void_fun_t *) in = xprt->xp_ops->xp_unref_user_data;
+	    mutex_unlock(&ops_lock);
+	    break;
+	case SVCSET_XP_UNREF_USER_DATA:
+	    mutex_lock(&ops_lock);
+	    xprt->xp_ops->xp_unref_user_data = *(svc_xprt_void_fun_t) in;
+	    mutex_unlock(&ops_lock);
+	    break;
 	case SVCGET_XP_FREE_USER_DATA:
 	    mutex_lock(&ops_lock);
 	    *(svc_xprt_fun_t *)in = xprt->xp_ops->xp_free_user_data;
@@ -288,6 +298,7 @@ svc_rdma_ops(SVCXPRT *xprt)
 		ops.xp_decode = svc_rdma_decode;
 		ops.xp_reply = svc_rdma_reply;
 		ops.xp_checksum = NULL;		/* not used */
+		ops.xp_unref_user_data = NULL;	/* no default */
 		ops.xp_destroy = svc_rdma_destroy,
 		ops.xp_control = svc_rdma_control;
 		ops.xp_free_user_data = NULL;	/* no default */

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -616,6 +616,16 @@ svc_vc_control(SVCXPRT *xprt, const u_int rq, void *in)
 	case SVCSET_XP_FLAGS:
 		xprt->xp_flags = *(u_int *) in;
 		break;
+	case SVCGET_XP_UNREF_USER_DATA:
+		mutex_lock(&ops_lock);
+		*(svc_xprt_void_fun_t *) in = xprt->xp_ops->xp_unref_user_data;
+		mutex_unlock(&ops_lock);
+		break;
+	case SVCSET_XP_UNREF_USER_DATA:
+		mutex_lock(&ops_lock);
+		xprt->xp_ops->xp_unref_user_data = *(svc_xprt_void_fun_t) in;
+		mutex_unlock(&ops_lock);
+		break;
 	case SVCGET_XP_FREE_USER_DATA:
 		mutex_lock(&ops_lock);
 		*(svc_xprt_fun_t *) in = xprt->xp_ops->xp_free_user_data;
@@ -643,6 +653,16 @@ svc_vc_rendezvous_control(SVCXPRT *xprt, const u_int rq, void *in)
 		break;
 	case SVCSET_CONNMAXREC:
 		xd->sx_dr.maxrec = *(int *)in;
+		break;
+	case SVCGET_XP_UNREF_USER_DATA:
+		mutex_lock(&ops_lock);
+		*(svc_xprt_void_fun_t *) in = xprt->xp_ops->xp_unref_user_data;
+		mutex_unlock(&ops_lock);
+		break;
+	case SVCSET_XP_UNREF_USER_DATA:
+		mutex_lock(&ops_lock);
+		xprt->xp_ops->xp_unref_user_data = *(svc_xprt_void_fun_t) in;
+		mutex_unlock(&ops_lock);
 		break;
 	case SVCGET_XP_FREE_USER_DATA:
 		mutex_lock(&ops_lock);
@@ -1125,6 +1145,7 @@ svc_vc_override_ops(SVCXPRT *xprt, SVCXPRT *rendezvous)
 		ops.xp_reply = svc_vc_reply;
 		ops.xp_checksum = svc_vc_checksum;
 		ops.xp_unlink = svc_vc_unlink_it;
+		ops.xp_unref_user_data = NULL;	/* no default */
 		ops.xp_destroy = svc_vc_destroy_it;
 		ops.xp_control = svc_vc_control;
 		ops.xp_free_user_data = NULL;	/* no default */
@@ -1151,6 +1172,7 @@ svc_vc_rendezvous_ops(SVCXPRT *xprt)
 		ops.xp_reply = (svc_req_fun_t)abort;
 		ops.xp_checksum = NULL;		/* not used */
 		ops.xp_unlink = svc_vc_unlink_it;
+		ops.xp_unref_user_data = NULL;	/* no default */
 		ops.xp_destroy = svc_vc_destroy_it;
 		ops.xp_control = svc_vc_rendezvous_control;
 		ops.xp_free_user_data = NULL;	/* no default */


### PR DESCRIPTION
As of today, when a xprt is to be destroyed from within ntirpc, its non-transient references held within Ganesha (if any) would prevent it from being actually destroyed. An example of such a non-transient reference is the NFSv41 session's backchannel. If a backchannel holds a reference to an xprt that needs to be destroyed, in the current implementation that reference will not be released, unless the backchannel somehow gets terminated. Such a reference will prevent the xprt from being truly destroyed. 

These set of commits (along with others in nfs-ganesha repo) are targeted towards fixing the above issue. The proposed set of changes in the destroy path, aim to release the pending references of (and from) the xprt by different user-data structures held within Ganesha.