### PR TITLE
Close the FDs upon FIN from client

### DIFF
--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -488,6 +488,9 @@ svc_dg_destroy_task(struct work_pool_entry *wpe)
 	    && rec->xprt.xp_fd != RPC_ANYFD) {
 		(void)close(rec->xprt.xp_fd);
 		rec->xprt.xp_fd = RPC_ANYFD;
+		if (rec->xprt.xp_fd_send != RPC_ANYFD)
+			close(rec->xprt.xp_fd_send);
+		rec->xprt.xp_fd_send = RPC_ANYFD;
 	}
 
 	if (rec->xprt.xp_ops->xp_free_user_data)

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -573,6 +573,10 @@ svc_vc_destroy_task(struct work_pool_entry *wpe)
 			 __func__, rec->xprt.xp_fd);
 		/* Mark xprt_fd for reset */
 		reset_xprt_fd = true;
+		rec->xprt.xp_fd = RPC_ANYFD;
+		if (rec->xprt.xp_fd_send != RPC_ANYFD)
+			(void)close(rec->xprt.xp_fd_send);
+		rec->xprt.xp_fd_send = RPC_ANYFD;
 	}
 
 	if (rec->xprt.xp_ops->xp_free_user_data)


### PR DESCRIPTION
Seen in the customer environment that once packet's checksum validation gets failed by server, client sends FIN to close the connection. But since there were refcounts on transport due to the back channels to client server do not respond with an FIN-ACK. Hence client thinks that the old session is intact and do not reestablish the connection. After the default 120s of lease expiry, once the client is notified of expiry by sending FIN from server, client tries to reclaim old locks & states with the old session and gets errors.

This PR fixes the above issue by closing the FDs upon FIN from client. xprt structure cleanup continues to happen along with the existing client expiry, which kicks in after the lease expiry.