### PR TITLE
add function rbtx_cleanup

### DIFF
--- a/ntirpc/misc/rbtree_x.h
+++ b/ntirpc/misc/rbtree_x.h
@@ -50,6 +50,8 @@ struct rbtree_x {
 extern int rbtx_init(struct rbtree_x *xt, opr_rbtree_cmpf_t cmpf,
 		     uint32_t npart, uint32_t flags);
 
+extern void rbtx_cleanup(struct rbtree_x *xt);
+
 static inline struct opr_rbtree_node *rbtree_x_cached_lookup(
 	struct rbtree_x *xt,
 	struct rbtree_x_part *t,

--- a/src/libntirpc.map.in.cmake
+++ b/src/libntirpc.map.in.cmake
@@ -105,6 +105,7 @@ NTIRPC_${NTIRPC_VERSION_BASE} {
 
     # r*
     rbtx_init;
+    rbtx_cleanup;
     rpc_broadcast;
     rpc_broadcast_exp;
     rpc_call;

--- a/src/rbtree_x.c
+++ b/src/rbtree_x.c
@@ -77,3 +77,22 @@ int rbtx_init(struct rbtree_x *xt, opr_rbtree_cmpf_t cmpf, uint32_t npart,
 
 	return (code);
 }
+
+void rbtx_cleanup(struct rbtree_x *xt)
+{
+    int ix;
+    struct rbtree_x_part *t;
+    uint32_t npart = xt->npart;
+    uint32_t flags = xt->flags;
+
+    if (xt->tree) {
+        for (ix = 0; ix < xt->npart; ++ix) {
+            t = &(xt->tree[ix]);
+            mutex_destroy(&t->mtx);
+            pthread_rwlock_destroy(&t->lock);
+            pthread_spin_destroy(&t->sp);
+        }
+        if (flags & RBT_X_FLAG_ALLOC)
+            mem_free(xt->tree, npart * sizeof(struct rbtree_x_part));
+    }
+}


### PR DESCRIPTION
Currently we have rbtx_init, but not a corresponding clean up function. Add this rbtx_cleanup function to clean up resources allocated in the init part.