### PR TITLE
Add RETRY in svc_destroy_it to prevent destroying uninitialized xprt

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -476,6 +476,7 @@ static inline void svc_release_it(SVCXPRT *xprt, u_int flags,
 #define SVC_RELEASE(xprt, flags)					\
 	svc_release_it(xprt, flags, __func__, __LINE__)
 
+#define SVC_DESTROY_RETRY 10
 /* SVC_DESTROY() is SVC_RELEASE() with once-only semantics.
  * Idempotent SVC_XPRT_FLAG_DESTROYED (bit SVC_XPRT_FLAG_DESTROYING)
  * indicates that more references should not be taken.
@@ -483,6 +484,7 @@ static inline void svc_release_it(SVCXPRT *xprt, u_int flags,
 static inline void svc_destroy_it(SVCXPRT *xprt,
 				  const char *tag, const int line)
 {
+	int retry;
 	uint16_t flags = atomic_postset_uint16_t_bits(&xprt->xp_flags,
 						      SVC_XPRT_FLAG_DESTROYING);
 
@@ -496,6 +498,20 @@ static inline void svc_destroy_it(SVCXPRT *xprt,
 		/* previously set, do nothing */
 		return;
 	}
+
+	/* A newly created xprt will be 1. inserted into the tree
+	 * of svc_xprt_fd, then 2. get xp_ops initialized. But if
+	 * shutdown happens in between, xprt without xp_ops initialization
+	 * will be in the tree of svc_xprt_fd for destroying.
+	 * Since the initialization of xp_ops will not acuqire the
+	 * current held lock, try RETRY here to wait for the
+	 * initialization to be done
+	 */
+	retry = 0;
+	while (xprt->xp_ops == NULL && retry < SVC_DESTROY_RETRY) {
+		pthread_yield();
+		retry += 1;
+	};
 
 	/* unlink before dropping last ref */
 	(*(xprt)->xp_ops->xp_unlink)(xprt, flags, tag, line);


### PR DESCRIPTION
During showdown, ganesha tries to desstroy all xprts, but then crashes because ganesha assert a xprt to be destroyed must have xp_ops initialized already. But in svc_vc_ncreatef and svc_fd_ncreatef, we don't have lock to protect the allocation and initialization part to be together. Shutdown could happen in between, in this case, above assertion will fail Instead of directly asserting, RETRY with some sleep to wait for the initialization of xp_ops to be done