### PR TITLE
gitignore - add .cache/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ cscope.*
 .gdb_history
 .gdbinit
 core
+.cache


### PR DESCRIPTION
.cache is used by clang-based tagging/compiling.  Ignore it, so it doesn't get added to git.