### PR TITLE
Fix for connection termination

### DIFF
--- a/src/svc_ioq.c
+++ b/src/svc_ioq.c
@@ -343,16 +343,12 @@ void svc_ioq_write(SVCXPRT *xprt)
 #endif /* USE_LTTNG_NTIRPC */
 		mutex_lock(&rec->writeq.qmutex);
 		if (rc < 0) {
-			/* Dequeue the failed request */
-			TAILQ_REMOVE(&rec->writeq.qh, have, q);
-			mutex_unlock(&rec->writeq.qmutex);
-
-			/* IO failed, destroy rather than releasing */
+			/* IO failed, destroy the XPRT but continue the loop in order to
+			   release resources */
 			__warnx(TIRPC_DEBUG_FLAG_SVC_VC,
 				"%s: %p fd %d About to destroy - rc = %d",
 				__func__, xprt, xprt->xp_fd, rc);
 			SVC_DESTROY(xprt);
-			break;
 		} else if (rc == EWOULDBLOCK){
 			__warnx(TIRPC_DEBUG_FLAG_SVC_VC,
 				"%s: %p fd %d EWOULDBLOCK",
@@ -384,20 +380,20 @@ void svc_ioq_write(SVCXPRT *xprt)
 					   &rec->xprt, (int) xioq->has_blocked);
 #endif /* USE_LTTNG_NTIRPC */
 			}
-
-			/* Dequeue the completed request */
-			TAILQ_REMOVE(&rec->writeq.qh, have, q);
-
-			/* Fetch the next request */
-			have = TAILQ_FIRST(&rec->writeq.qh);
-			mutex_unlock(&rec->writeq.qmutex);
-
-			__warnx(TIRPC_DEBUG_FLAG_SVC_VC,
-				"%s: %p fd %d About to release",
-				__func__, xprt, xprt->xp_fd);
-			SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
-			XDR_DESTROY(xioq->xdrs);
 		}
+
+		/* Dequeue the completed request */
+		TAILQ_REMOVE(&rec->writeq.qh, have, q);
+
+		/* Fetch the next request */
+		have = TAILQ_FIRST(&rec->writeq.qh);
+		mutex_unlock(&rec->writeq.qmutex);
+
+		__warnx(TIRPC_DEBUG_FLAG_SVC_VC,
+			"%s: %p fd %d About to release",
+			__func__, xprt, xprt->xp_fd);
+		SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
+		XDR_DESTROY(xioq->xdrs);
 	}
 }
 

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -643,6 +643,11 @@ svc_rqst_rearm_events_locked(SVCXPRT *xprt, uint16_t ev_flags)
 	tracepoint(xprt, rearm, __func__, __LINE__, xprt, ev_flags);
 #endif /* USE_LTTNG_NTIRPC */
 
+	const bool is_xprt_destroyed = xprt->xp_flags & (ev_flags | SVC_XPRT_FLAG_DESTROYED);
+	/* MUST follow the destroyed check above */
+	const bool is_rec_shutdown = !is_xprt_destroyed && (
+		sr_rec->ev_flags & SVC_RQST_FLAG_SHUTDOWN);
+
 	__warnx(TIRPC_DEBUG_FLAG_SVC_RQST,
 		"%s: xprt %p fd %d ev_flags%s%s%s%s%s%s%s%s%s",
 		__func__, xprt, xprt->xp_fd,
@@ -654,14 +659,9 @@ svc_rqst_rearm_events_locked(SVCXPRT *xprt, uint16_t ev_flags)
 		ev_flags & SVC_XPRT_FLAG_DESTROYING  ? " DESTROYING" : "",
 		ev_flags & SVC_XPRT_FLAG_RELEASING   ? " RELEASING" : "",
 		ev_flags & SVC_XPRT_FLAG_UREG        ? " UREG" : "",
-		sr_rec->ev_flags & SVC_RQST_FLAG_SHUTDOWN
-					? "sr_rec->ev_flags SHUTDOWN" : "");
+		is_rec_shutdown                      ? "sr_rec->ev_flags SHUTDOWN" : "");
 
-	if (xprt->xp_flags & (ev_flags | SVC_XPRT_FLAG_DESTROYED))
-		return (0);
-
-	/* MUST follow the destroyed check above */
-	if (sr_rec->ev_flags & SVC_RQST_FLAG_SHUTDOWN)
+	if (is_xprt_destroyed || is_rec_shutdown)
 		return (0);
 
 	/* Don't take a ref on the xprt.  We take a ref in hook, and release it

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -533,10 +533,10 @@ svc_vc_rendezvous(SVCXPRT *xprt)
 	newxprt->xp_parent = xprt;
 	if (xprt->xp_dispatch.rendezvous_cb(newxprt)
 	 || svc_rqst_xprt_register(newxprt, xprt)) {
+		// Note xp_parent is released in svc_vc_destroy_task
 		SVC_DESTROY(newxprt);
 		/* Was never added to epoll */
 		SVC_RELEASE(newxprt, SVC_RELEASE_FLAG_NONE);
-		SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 		return (XPRT_DESTROYED);
 	}
 

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -554,14 +554,20 @@ svc_vc_destroy_task(struct work_pool_entry *wpe)
 	uint16_t xp_flags;
 	bool reset_xprt_fd = false;
 
+	const int32_t xp_refcnt = atomic_fetch_int32_t(&rec->xprt.xp_refcnt);
 	__warnx(TIRPC_DEBUG_FLAG_REFCNT,
 		"%s() %p fd %d xp_refcnt %" PRId32,
-		__func__, rec, rec->xprt.xp_fd, rec->xprt.xp_refcnt);
+		__func__, rec, rec->xprt.xp_fd, xp_refcnt);
 
-	if (rec->xprt.xp_refcnt) {
+	if (xp_refcnt > 0) {
 		/* instead of nanosleep */
 		work_pool_submit(&svc_work_pool, &(rec->ioq.ioq_wpe));
 		return;
+	} else if (unlikely(xp_refcnt < 0)) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			"%s() negative refcnt: %p fd %d xp_refcnt %" PRId32,
+			__func__, rec, rec->xprt.xp_fd, xp_refcnt);
+		abort();
 	}
 
 	xp_flags = atomic_postclear_uint16_t_bits(&rec->xprt.xp_flags,


### PR DESCRIPTION
When terminating a connection (e.g. `SVC_DESTROY`), there are some potential issues that can happen in rare cases.

This branch fixes issues that were found in testing.

In addition to the fixes, added a *detection* for negative XPRT `refcnt`. It can happen due to excessive calls to `SVC_RELEASE`, and could lead to either:
 - Undefined behavior: If the XPRT is released while still being used
 - Leakage: If the XPRT refcnt becomes 0 in  `svc_release_it`, and just before checking the `refcnt` again in `svc_vc_destroy_task` it becomes -1.  In that case it won't be released and cause a leak.
