### PR TITLE
Tirpc Fixes to enabled NFS over RDMA

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -42,6 +42,9 @@
 #ifndef _TIRPC_SVC_H
 #define _TIRPC_SVC_H
 
+#ifdef USE_RPC_RDMA
+#include <assert.h>
+#endif
 #include <sys/cdefs.h>
 #include <rpc/rpc_msg.h>
 #include <rpc/types.h>
@@ -142,6 +145,13 @@ typedef struct svc_init_params {
 	u_int gss_max_idle_gen;
 	u_int gss_max_gc;
 	uint32_t channels;
+
+#if defined(_USE_NFS_RDMA) || defined(USE_RPC_RDMA)
+	uint16_t nfs_rdma_port; /* Shared with Ganesha */
+	uint32_t max_rdma_connections;
+	bool enable_rdma_dump;
+#endif
+
 	int32_t idle_timeout;
 	uint32_t thr_stack_size;
 } svc_init_params;
@@ -271,6 +281,11 @@ struct svc_xprt {
 	void *xp_u1;		/* client user data */
 	void *xp_u2;		/* client user data */
 
+#if defined(_USE_NFS_RDMA) || defined(USE_RPC_RDMA)
+	bool xp_rdma;		/* True if this xprt is RDMA enabled.
+				 * Shared with Ganesha */
+#endif
+
 	struct rpc_address xp_local;	/* local address, length, port */
 	struct rpc_address xp_remote;	/* remote address, length, port */
 	struct rpc_address xp_proxy;	/* proxy address, length, port */
@@ -338,6 +353,12 @@ struct svc_req {
 	void *rq_u1;		/* user data */
 	void *rq_u2;		/* user data */
 	uint64_t rq_cksum;
+
+#if defined(_USE_NFS_RDMA) || defined(USE_RPC_RDMA)
+	/* Data buffer used to server read/readdir from fs */
+	int data_chunk_length;	/* Shared with Ganesha */
+	uint8_t *data_chunk;	/* Shared with Ganesha */
+#endif
 
 	/* Moved in N TI-RPC */
 	struct SVCAUTH *rq_auth;	/* auth handle */

--- a/src/rpc_dplx_internal.h
+++ b/src/rpc_dplx_internal.h
@@ -78,6 +78,10 @@ struct rpc_dplx_rec {
 
 	size_t maxrec;
 	long pagesz;
+#ifdef USE_RPC_RDMA
+	u_int recv_hdr_sz;
+	u_int send_hdr_sz;
+#endif
 	u_int recvsz;
 	u_int sendsz;
 	uint32_t call_xid;		/**< current call xid */

--- a/src/rpc_rdma.c
+++ b/src/rpc_rdma.c
@@ -87,35 +87,9 @@
 /** defaults **/
 #define WORKER_STACK_SIZE (65535) /* was 2116488 */
 
-struct connection_requests {
-	struct rdma_cm_id **id_queue;
-	sem_t	q_sem;
-	sem_t	u_sem;
-	uint32_t q_head;
-	uint32_t q_tail;
-	u_int	q_size;
-};
-
-struct rpc_rdma_state {
-	LIST_HEAD(pdh_s, rpc_rdma_pd) pdh;	/**< Protection Domain list */
-	mutex_t lock;
-
-	struct connection_requests c_r;		/* never freed??? */
-
-	pthread_t cm_thread;		/**< Thread id for connection manager */
-	pthread_t cq_thread;		/**< Thread id for completion queue */
-	pthread_t stats_thread;
-
-	int cm_epollfd;
-	int cq_epollfd;
-	int stats_epollfd;
-
-	int32_t run_count;
-};
-
 /* GLOBAL VARIABLES */
 
-static struct rpc_rdma_state rpc_rdma_state;
+struct rpc_rdma_state rpc_rdma_state;
 
 void
 rpc_rdma_internals_init(void)
@@ -403,6 +377,11 @@ rpc_rdma_worker_callback(struct work_pool_entry *wpe)
 		opr_containerof(wpe, struct rpc_rdma_cbc, wpe);
 	RDMAXPRT *xprt = (RDMAXPRT *)wpe->arg;
 
+	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
+		"%s() %p opcode: %d %d %d %d %d %d",
+		__func__, cbc->opcode, xprt, IBV_WC_SEND, IBV_WC_RDMA_WRITE,
+		IBV_WC_RDMA_READ, IBV_WC_RECV, IBV_WC_RECV_RDMA_WITH_IMM);
+
 	if (cbc->status) {
 		if (cbc->negative_cb) {
 			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
@@ -412,7 +391,8 @@ rpc_rdma_worker_callback(struct work_pool_entry *wpe)
 		}
 
 		/* wpe->arg referenced before work_pool_submit() */
-		SVC_RELEASE(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
+		if (!cbc->call_inline)
+			SVC_RELEASE(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
 		return;
 	}
 
@@ -438,7 +418,8 @@ rpc_rdma_worker_callback(struct work_pool_entry *wpe)
 	}
 
 	/* wpe->arg referenced before work_pool_submit() */
-	SVC_RELEASE(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
+	if (!cbc->call_inline)
+		SVC_RELEASE(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
 }
 
 /**
@@ -476,7 +457,7 @@ rpc_rdma_fd_add(RDMAXPRT *xprt, int fd, int epollfd)
 	return 0;
 }
 
-static int
+int
 rpc_rdma_fd_del(int fd, int epollfd)
 {
 	int rc = epoll_ctl(epollfd, EPOLL_CTL_DEL, fd, NULL);
@@ -684,27 +665,34 @@ rpc_rdma_cq_event_handler(RDMAXPRT *xprt)
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s() ibv_req_notify_cq failed: %d.",
 			__func__, rc);
+		return rc;
 	}
 
 	while (rc == 0
 	       && (npoll = ibv_poll_cq(xprt->cq, IBV_POLL_EVENTS, wc)) > 0) {
 		for (i = 0; i < npoll; i++) {
 			if (xprt->bad_recv_wr) {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
 					"%s() Something was bad on that recv",
 					__func__);
+				rc = -1;
 			}
+
 			if (xprt->bad_send_wr) {
 				__warnx(TIRPC_DEBUG_FLAG_ERROR,
 					"%s() Something was bad on that send",
 					__func__);
+				rc = -1;
 			}
+
 			cbc = (struct rpc_rdma_cbc *)wc[i].wr_id;
 			cbc->opcode = wc[i].opcode;
 			cbc->status = wc[i].status;
 			cbc->wpe.arg = xprt;
 
 			if (wc[i].status) {
+				rc = -1;
+
 				switch (wc[i].opcode) {
 					case IBV_WC_SEND:
 					case IBV_WC_RDMA_WRITE:
@@ -719,19 +707,19 @@ rpc_rdma_cq_event_handler(RDMAXPRT *xprt)
 						break;
 				}
 
-				SVC_REF(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
-				work_pool_submit(&svc_work_pool, &cbc->wpe);
+				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+					"%s() cq completion status: %s (%d) xprt state %x opcode %d cbc %p "
+					"inline %d",
+					__func__, ibv_wc_status_str(wc[i].status), wc[i].status,
+					xprt->state, wc[i].opcode, cbc, cbc->call_inline);
 
-				if (xprt->state != RDMAXS_CLOSING
-				 && xprt->state != RDMAXS_CLOSED
-				 && xprt->state != RDMAXS_ERROR) {
-					rc = wc[i].status;
-					__warnx(TIRPC_DEBUG_FLAG_ERROR,
-						"%s() cq completion failed status: %s (%d)",
-						__func__,
-						ibv_wc_status_str(rc), rc);
-
+				if (cbc->call_inline) {
+					rpc_rdma_worker_callback(&cbc->wpe);
+				} else {
+					SVC_REF(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
+					work_pool_submit(&svc_work_pool, &cbc->wpe);
 				}
+
 				continue;
 			}
 
@@ -756,9 +744,14 @@ rpc_rdma_cq_event_handler(RDMAXPRT *xprt)
 						__func__,
 						ntohl(wc[i].imm_data));
 				}
-
-				SVC_REF(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
-				work_pool_submit(&svc_work_pool, &cbc->wpe);
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s:%d submit cbc %p wpe %p inline %d",
+					__func__, __LINE__, cbc, &cbc->wpe, cbc->call_inline);
+				if (cbc->call_inline) {
+					rpc_rdma_worker_callback(&cbc->wpe);
+				} else {
+					SVC_REF(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
+					work_pool_submit(&svc_work_pool, &cbc->wpe);
+				}
 				break;
 
 			case IBV_WC_RECV:
@@ -784,7 +777,7 @@ rpc_rdma_cq_event_handler(RDMAXPRT *xprt)
 				/* fill all the sizes in case of multiple sge
 				 * assumes _tail was set to _wrap before call
 				 */
-				data = IOQ_(TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh));
+				data = IOQ_(TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh));
 				while (data && ioquv_length(data) < len) {
 					VALGRIND_MAKE_MEM_DEFINED(data->v.vio_head, ioquv_length(data));
 					len -= ioquv_length(data);
@@ -798,9 +791,14 @@ rpc_rdma_cq_event_handler(RDMAXPRT *xprt)
 						"%s() ERROR %d leftover bytes?",
 						__func__, len);
 				}
-
-				SVC_REF(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
-				work_pool_submit(&svc_work_pool, &cbc->wpe);
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s:%d submit cbc %p wpe %p inline %d",
+					__func__, __LINE__, cbc, &cbc->wpe, cbc->call_inline);
+				if (cbc->call_inline) {
+					rpc_rdma_worker_callback(&cbc->wpe);
+				} else {
+					SVC_REF(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
+					work_pool_submit(&svc_work_pool, &cbc->wpe);
+				}
 				break;
 
 			default:
@@ -838,7 +836,9 @@ rpc_rdma_cq_thread(void *arg)
 	int n;
 	int rc;
 
+	__warnx(TIRPC_DEBUG_FLAG_ERROR, "Starting rpc_rdma_cq_thread");
 	rcu_register_thread();
+
 	while (rpc_rdma_state.run_count > 0) {
 		n = epoll_wait(rpc_rdma_state.cq_epollfd,
 				epoll_events, EPOLL_EVENTS, EPOLL_WAIT_MS);
@@ -860,7 +860,8 @@ rpc_rdma_cq_thread(void *arg)
 			xprt = (RDMAXPRT*)epoll_events[i].data.ptr;
 			if (!xprt) {
 				__warnx(TIRPC_DEBUG_FLAG_ERROR,
-					"%s() got an event on a fd that should have been removed! (no xprt)",
+					"%s() got an event on a fd that should have "
+					"been removed! (no xprt)",
 					__func__);
 				continue;
 			}
@@ -868,33 +869,25 @@ rpc_rdma_cq_thread(void *arg)
 			if (epoll_events[i].events == EPOLLERR
 			 || epoll_events[i].events == EPOLLHUP) {
 				__warnx(TIRPC_DEBUG_FLAG_ERROR,
-					"%s() epoll error or hup (%d)",
-					__func__, epoll_events[i].events);
+					"%s() epoll error or hup (%d) xprt %p",
+					__func__, epoll_events[i].events, xprt);
+
+				SVC_DESTROY(&xprt->sm_dr.xprt);
 				continue;
+			}
+
+			if (xprt->sm_dr.xprt.xp_flags & SVC_XPRT_FLAG_DESTROYED) {
+				__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s : xprt already "
+					" destroyed %p", __func__, xprt);
 			}
 
 			mutex_lock(&xprt->cm_lock);
-			if (xprt->state >= RDMAXS_CLOSING) {
-				/* CLOSING, CLOSED, ERROR */
-				// closing xprt, skip this, will be done on flush
-				rpc_rdma_fd_del(xprt->comp_channel->fd,
-						rpc_rdma_state.cq_epollfd);
-				mutex_unlock(&xprt->cm_lock);
-				continue;
-			}
 
 			rc = rpc_rdma_cq_event_handler(xprt);
 			if (rc) {
-				if (xprt->state != RDMAXS_CLOSING
-				 && xprt->state != RDMAXS_CLOSED
-				 && xprt->state != RDMAXS_ERROR) {
-					__warnx(TIRPC_DEBUG_FLAG_ERROR,
-						"%s() something went wrong with our cq_event_handler",
-						__func__);
-					xprt->state = RDMAXS_ERROR;
-					cond_broadcast(&xprt->cm_cond);
-				}
+				SVC_DESTROY(&xprt->sm_dr.xprt);
 			}
+
 			mutex_unlock(&xprt->cm_lock);
 		}
 	}
@@ -911,8 +904,11 @@ static int
 rpc_rdma_cm_event_handler(RDMAXPRT *ep_xprt, struct rdma_cm_event *event)
 {
 	struct rdma_cm_id *cm_id = event->id;
+
+	/* cm_id->context set in rpc_rdma_clone set for client xprt.
+	 * for connect its listen xprt set by rdma_create_id.
+	 * For established its new connected client xprt*/
 	RDMAXPRT *xprt = cm_id->context;
-	uint32_t u;
 	int rc = 0;
 
 	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
@@ -972,58 +968,9 @@ rpc_rdma_cm_event_handler(RDMAXPRT *ep_xprt, struct rdma_cm_event *event)
 		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
 			"%s() %p CONNECT_REQUEST",
 			__func__, xprt);
+		rpc_rdma_state.c_r.id_queue[0] = cm_id;
+		svc_rdma_rendezvous(&xprt->sm_dr.xprt);
 
-		rc = sem_trywait(&rpc_rdma_state.c_r.u_sem);
-		if (rc) {
-			rc = errno;
-			if (EAGAIN != rc) {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
-					"%s() %p[%u] sem_trywait failed: %s (%d)",
-					__func__, xprt, xprt->state,
-					strerror(rc), rc);
-				return rc;
-			}
-
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
-				"%s() %p WARNING too many connection requests! "
-				"Need to increase backlog parameter.\n",
-				__func__, xprt);
-
-			/* After advisory message, wait for available slot.
-			 */
-			rc = sem_wait(&rpc_rdma_state.c_r.u_sem);
-			if (rc) {
-				rc = errno;
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
-					"%s() %p[%u] sem_wait failed: %s (%d)",
-					__func__, xprt, xprt->state,
-					strerror(rc), rc);
-				return rc;
-			}
-		}
-
-		u = atomic_postinc_uint32_t(&rpc_rdma_state.c_r.q_tail);
-		if (u >= rpc_rdma_state.c_r.q_size) {
-			u_int q_mask = rpc_rdma_state.c_r.q_size - 1;
-
-			/* masking allows update by lock-free tasks,
-			 * as long as overrun never 2 * q_size
-			 */
-			u &= q_mask;
-			atomic_clear_uint32_t_bits(&rpc_rdma_state.c_r.q_tail,
-						   ~q_mask);
-		}
-		rpc_rdma_state.c_r.id_queue[u] = cm_id;
-
-		/* signal accept handler */
-		rc = sem_post(&rpc_rdma_state.c_r.q_sem);
-		if (rc) {
-			rc = errno;
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
-				"%s() sem_post failed",
-				__func__, strerror(rc), rc);
-			return rc;
-		}
 		break;
 
 	case RDMA_CM_EVENT_ADDR_ERROR:
@@ -1035,10 +982,9 @@ rpc_rdma_cm_event_handler(RDMAXPRT *ep_xprt, struct rdma_cm_event *event)
 			"%s() %p[%u] cma event %s, error %d",
 			__func__, xprt, xprt->state,
 			rdma_event_str(event->event), event->status);
-		mutex_lock(&xprt->cm_lock);
-		xprt->state = RDMAXS_ERROR;
-		cond_broadcast(&xprt->cm_cond);
-		mutex_unlock(&xprt->cm_lock);
+
+		SVC_DESTROY(&xprt->sm_dr.xprt);
+
 		break;
 
 	case RDMA_CM_EVENT_DISCONNECTED:
@@ -1046,18 +992,8 @@ rpc_rdma_cm_event_handler(RDMAXPRT *ep_xprt, struct rdma_cm_event *event)
 			"%s() %p[%u] DISCONNECT EVENT...",
 			__func__, xprt, xprt->state);
 
-		// don't call completion again
-		if (xprt->comp_channel)
-			rpc_rdma_fd_del(xprt->comp_channel->fd,
-					rpc_rdma_state.cq_epollfd);
+		SVC_DESTROY(&xprt->sm_dr.xprt);
 
-		mutex_lock(&xprt->cm_lock);
-		xprt->state = RDMAXS_CLOSED;
-		cond_broadcast(&xprt->cm_cond);
-		mutex_unlock(&xprt->cm_lock);
-
-		if (__svc_params->disconnect_cb)
-			__svc_params->disconnect_cb(&xprt->sm_dr.xprt);
 		break;
 
 	case RDMA_CM_EVENT_DEVICE_REMOVAL:
@@ -1087,7 +1023,6 @@ static void *
 rpc_rdma_cm_thread(void *nullarg)
 {
 	RDMAXPRT *xprt;
-	RDMAXPRT *cm_xprt;
 	struct rdma_cm_event *event;
 	struct epoll_event epoll_events[EPOLL_EVENTS];
 	int i;
@@ -1113,6 +1048,7 @@ rpc_rdma_cm_thread(void *nullarg)
 		}
 
 		for (i = 0; i < n; ++i) {
+			/* data.ptr is in rpc_rdma_fd_add */
 			xprt = (RDMAXPRT*)epoll_events[i].data.ptr;
 			if (!xprt) {
 				__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -1124,23 +1060,24 @@ rpc_rdma_cm_thread(void *nullarg)
 			if (epoll_events[i].events == EPOLLERR
 			 || epoll_events[i].events == EPOLLHUP) {
 				__warnx(TIRPC_DEBUG_FLAG_ERROR,
-					"%s() epoll error or hup (%d)",
-					__func__, epoll_events[i].events);
+					"%s() epoll error or hup (%d) xprt %p",
+					__func__, epoll_events[i].events, xprt);
+				SVC_DESTROY(&xprt->sm_dr.xprt);
 				continue;
 			}
 
-			if (xprt->state == RDMAXS_CLOSED) {
+			if (xprt->sm_dr.xprt.xp_flags & SVC_XPRT_FLAG_DESTROYED) {
 				__warnx(TIRPC_DEBUG_FLAG_ERROR,
-					"%s() got a cm event on a closed xprt?",
-					__func__);
+					"%s() got a cm event on a closed xprt %p",
+					__func__, xprt);
 				continue;
 			}
 
 			if (!xprt->event_channel) {
-				if (xprt->state != RDMAXS_CLOSED)
-					__warnx(TIRPC_DEBUG_FLAG_ERROR,
-						"%s() no event channel? :D",
-						__func__);
+				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+					"%s() no event channel xprt %p",
+					__func__, xprt);
+				SVC_DESTROY(&xprt->sm_dr.xprt);
 				continue;
 			}
 
@@ -1148,26 +1085,20 @@ rpc_rdma_cm_thread(void *nullarg)
 			if (rc) {
 				rc = errno;
 				__warnx(TIRPC_DEBUG_FLAG_ERROR,
-					"%s() rdma_get_cm_event failed: %d.",
-					__func__, rc);
+					"%s() rdma_get_cm_event failed: %d xprt %p",
+					__func__, rc, xprt);
+				SVC_DESTROY(&xprt->sm_dr.xprt);
 				continue;
 			}
 
-			cm_xprt = event->id->context;
+			/* For connect events xprt and cm_xprt should be same */
+
 			rc = rpc_rdma_cm_event_handler(xprt, event);
+
 			rdma_ack_cm_event(event);
 
-			if (rc
-			 && (cm_xprt->state != RDMAXS_LISTENING
-			  || cm_xprt == xprt)) {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
-					"%s() rpc_rdma_cm_event_handler: %d.",
-					__func__, rc);
-			}
-
-			if (cm_xprt->state == RDMAXS_CLOSED
-			 && cm_xprt->destroy_on_disconnect)
-				SVC_DESTROY(&cm_xprt->sm_dr.xprt);
+			if (rc)
+				SVC_DESTROY(&xprt->sm_dr.xprt);
 		}
 	}
 	rcu_unregister_thread();
@@ -1184,7 +1115,8 @@ rpc_rdma_cm_thread(void *nullarg)
 static void
 rpc_rdma_flush_buffers(RDMAXPRT *xprt)
 {
-	int rc;
+	/* Wait for > cb_timeout */
+	int retries = RDMA_CB_TIMEOUT_SEC * 2;
 
 	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
 		"%s() %p[%u]",
@@ -1192,53 +1124,178 @@ rpc_rdma_flush_buffers(RDMAXPRT *xprt)
 
 	mutex_lock(&xprt->cm_lock);
 
-	if (xprt->state != RDMAXS_ERROR) {
-		do {
-			rc = rpc_rdma_cq_event_handler(xprt);
-		} while (rc == 0);
+	rpc_rdma_cq_event_handler(xprt);
 
-		if (rc != EAGAIN)
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
-				"%s() couldn't flush pending data in cq: %d",
-				__func__, rc);
-	}
-#ifdef FIXME
-	/* only flush rx if client or accepting server */
-	if (xprt->server >= 0)
-	    for (i = 0, ctx = xprt->rcb;
-		 i < xprt->xa->rq_depth;
-		 i++,
-		 ctx = (struct rpc_rdma_cbc*)((uint8_t*)ctx + sizeof(struct rpc_rdma_cbc) + xprt->xa->max_recv_sge*sizeof(struct ibv_sge)))
-			if (ctx->used == MSK_CTX_PENDING)
-				rpc_rdma_worker_signal(xprt, ctx, IBV_WC_FATAL_ERR, IBV_WC_RECV);
-
-	for (i = 0, ctx = (struct rpc_rdma_cbc *)xprt->wcb;
-	     i < xprt->xa->sq_depth;
-	     i++, ctx = (struct rpc_rdma_cbc*)((uint8_t*)ctx + sizeof(struct rpc_rdma_cbc) + xprt->xa->max_send_sge*sizeof(struct ibv_sge)))
-		if (ctx->used == MSK_CTX_PENDING)
-			rpc_rdma_worker_signal(xprt, ctx, IBV_WC_FATAL_ERR, IBV_WC_SEND);
-
-	/* only flush rx if client or accepting server */
-	if (xprt->server >= 0) do {
-		wait = 0;
-			for (i = 0, ctx = xprt->rcb;
-			     i < xprt->xa->rq_depth;
-			     i++, ctx = rpc_rdma_next_ctx(ctx, xprt->xa->max_recv_sge))
-				if (ctx->used != MSK_CTX_FREE)
-					wait++;
-
-	} while (wait && usleep(100000));
-	do {
-		wait = 0;
-		for (i = 0, ctx = (struct rpc_rdma_cbc *)xprt->wcb;
-		     i < xprt->xa->sq_depth;
-		     i++, ctx = rpc_rdma_next_ctx(ctx, xprt->xa->max_recv_sge))
-			if (ctx->used != MSK_CTX_FREE)
-				wait++;
-
-	} while (wait && usleep(100000));
-#endif
 	mutex_unlock(&xprt->cm_lock);
+
+	while(atomic_fetch_uint32_t(&xprt->active_requests) && retries--) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s retry %d "
+		    "active requests %u xprt %p", __func__, retries,
+		    atomic_fetch_uint32_t(&xprt->active_requests), xprt);
+		sleep(1);
+	}
+}
+
+/* Destroy all the buf/cbc queues/pools and
+ * free registered memory */
+void
+rdma_cleanup_cbcs_task(struct work_pool_entry *wpe) {
+	struct rpc_dplx_rec *rec =
+	    opr_containerof(wpe, struct rpc_dplx_rec, ioq.ioq_wpe);
+
+	RDMAXPRT *xd = (RDMAXPRT *) &(rec->xprt);
+
+	rpc_rdma_flush_buffers(xd);
+	rpc_rdma_close_connection(xd);
+
+	/* If cbclist is still not empty, then most likely we won't
+	 * get any callbacks, since we already destroyed qp and cq,
+	 * so just force remove outstanding cbcs and release refs.
+	 * pool_head may not be initialized, so check for qcount */
+
+	if (xd->cbclist.qcount && !TAILQ_EMPTY(&xd->cbclist.qh)) {
+		struct poolq_head *ioqh = &xd->cbclist;
+
+		pthread_mutex_lock(&ioqh->qmutex);
+
+		struct poolq_entry *have = TAILQ_FIRST(&ioqh->qh);
+
+		/* release queued buffers */
+		while (have) {
+			struct rpc_rdma_cbc *cbc =
+				opr_containerof(have, struct rpc_rdma_cbc, cbc_list);
+
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s cbc %p refcnt %d "
+			    "xd %p", __func__, cbc, cbc->refcnt, xd);
+
+			assert(cbc->refcnt);
+
+			cbc->cbc_flags = CBC_FLAG_RELEASE;
+
+			if (cbc->refcnt > 1) {
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s cbc %p refcnt "
+				    "%d > 1 xd %p", __func__, cbc, cbc->refcnt, xd);
+				cbc->refcnt = 1;
+			}
+
+			pthread_mutex_unlock(&ioqh->qmutex);
+
+			/* This will remove it from cbclist */
+			cbc_release_it(cbc);
+
+			pthread_mutex_lock(&ioqh->qmutex);
+
+			have = TAILQ_FIRST(&ioqh->qh);;
+		}
+
+		assert(ioqh->qcount == 0);
+
+		pthread_mutex_unlock(&ioqh->qmutex);
+	}
+	SVC_RELEASE(&rec->xprt, SVC_REF_FLAG_NONE);
+}
+
+static void
+rdma_destroy_cbcs(RDMAXPRT *xd) {
+	/* pool_head may not be initialized, so check for qcount */
+	if (xd->cbqh.qcount && !TAILQ_EMPTY(&xd->cbqh.qh)) {
+		struct poolq_head *ioqh = &xd->cbqh;
+
+		pthread_mutex_lock(&ioqh->qmutex);
+
+		struct poolq_entry *have = TAILQ_FIRST(&ioqh->qh);
+
+		/* release queued buffers */
+		while (have) {
+			struct poolq_entry *next = TAILQ_NEXT(have, q);
+
+			struct xdr_ioq *recvq =
+				opr_containerof(have, struct xdr_ioq, ioq_s);
+
+			struct rpc_rdma_cbc *cbc =
+			     opr_containerof(recvq, struct rpc_rdma_cbc, recvq);
+
+			TAILQ_REMOVE(&ioqh->qh, have, q);
+			(ioqh->qcount)--;
+
+			mem_free(cbc, ioqh->qsize);
+
+			have = next;
+		}
+		assert(ioqh->qcount == 0);
+
+		pthread_mutex_unlock(&ioqh->qmutex);
+
+		poolq_head_destroy(ioqh);
+	}
+}
+
+static void
+rdma_destroy_extra_bufs(RDMAXPRT *xd) {
+	/* pool_head may not be initialized, so check for qcount */
+	if (xd->extra_bufs.qcount && !TAILQ_EMPTY(&xd->extra_bufs.qh)) {
+		struct poolq_head *ioqh = &xd->extra_bufs;
+
+		pthread_mutex_lock(&ioqh->qmutex);
+
+		struct poolq_entry *have = TAILQ_FIRST(&ioqh->qh);
+
+		/* release queued buffers */
+		while (have) {
+			struct poolq_entry *next = TAILQ_NEXT(have, q);
+
+			struct rpc_extra_io_bufs *io_buf =
+				opr_containerof(have, struct rpc_extra_io_bufs, q);
+
+			assert(io_buf->mr);
+			ibv_dereg_mr(io_buf->mr);
+			io_buf->mr = NULL;
+
+			assert(io_buf->buffer_aligned);
+			mem_free(io_buf->buffer_aligned, io_buf->buffer_total);
+			io_buf->buffer_aligned = NULL;
+
+			xd->extra_bufs_count--;
+
+			TAILQ_REMOVE(&ioqh->qh, have, q);
+			(ioqh->qcount)--;
+
+			mem_free(io_buf, ioqh->qsize);
+
+			have = next;
+		}
+		assert(ioqh->qcount == 0);
+
+		pthread_mutex_unlock(&ioqh->qmutex);
+
+		poolq_head_destroy(ioqh);
+	}
+}
+
+/* Destroy all the buf/cbc queues/pools and
+ * free registered memory */
+static void
+xdr_ioq_rdma_destroy_pools(RDMAXPRT *xd) {
+
+	xdr_rdma_buf_pool_destroy(&xd->inbufs_hdr.uvqh);
+	xdr_rdma_buf_pool_destroy(&xd->outbufs_hdr.uvqh);
+
+	xdr_rdma_buf_pool_destroy(&xd->inbufs_data.uvqh);
+	xdr_rdma_buf_pool_destroy(&xd->outbufs_data.uvqh);
+
+	rdma_destroy_cbcs(xd);
+
+	if (xd->mr) {
+		ibv_dereg_mr(xd->mr);
+		xd->mr = NULL;
+	}
+
+	if (xd->buffer_aligned) {
+		mem_free(xd->buffer_aligned, xd->buffer_total);
+		xd->buffer_aligned = NULL;
+	}
+
+	rdma_destroy_extra_bufs(xd);
 }
 
 /**
@@ -1246,16 +1303,13 @@ rpc_rdma_flush_buffers(RDMAXPRT *xprt)
  *
  * @param[INOUT] xprt
  *
- * @return void, even if the functions _can_ fail we choose to ignore it. //FIXME?
+ * @return void
  */
 static void
 rpc_rdma_destroy_stuff(RDMAXPRT *xprt)
 {
 	if (xprt->qp) {
-		// flush all pending receive/send buffers to error callback
-		rpc_rdma_flush_buffers(xprt);
-
-		ibv_destroy_qp(xprt->qp);
+		rdma_destroy_qp(xprt->cm_id);
 		xprt->qp = NULL;
 	}
 
@@ -1265,13 +1319,34 @@ rpc_rdma_destroy_stuff(RDMAXPRT *xprt)
 	}
 
 	if (xprt->comp_channel) {
+		if (((RDMAXPRT *)xprt)->state == RDMAXS_CONNECTED) {
+			rpc_rdma_fd_del(((RDMAXPRT *)xprt)->comp_channel->fd,
+			    rpc_rdma_state.cq_epollfd);
+		}
+
 		ibv_destroy_comp_channel(xprt->comp_channel);
 		xprt->comp_channel = NULL;
 	}
 
-	if (!TAILQ_EMPTY(&xprt->cbqh.qh)) {
-		xdr_ioq_destroy_pool(&xprt->cbqh);
+	if (xprt->cm_id) {
+		rdma_destroy_id(xprt->cm_id);
+		xprt->cm_id = NULL;
 	}
+}
+
+void
+rpc_rdma_close_connection(RDMAXPRT *xd)
+{
+	/* inhibit repeated destroy */
+	xd->destroy_on_disconnect = false;
+
+	if (xd->cm_id && xd->cm_id->verbs)
+		rdma_disconnect(xd->cm_id);
+
+	if (xd->stats_sock)
+		rpc_rdma_stats_del(xd);
+
+	rpc_rdma_destroy_stuff(xd);
 }
 
 /**
@@ -1282,53 +1357,7 @@ rpc_rdma_destroy_stuff(RDMAXPRT *xprt)
 void
 rpc_rdma_destroy(RDMAXPRT *xd)
 {
-	/* inhibit repeated destroy */
-	xd->destroy_on_disconnect = false;
-
-	if (xd->state == RDMAXS_CONNECTED
-	 || xd->state == RDMAXS_CLOSED) {
-		mutex_lock(&xd->cm_lock);
-		if (xd->state != RDMAXS_CLOSED
-		 && xd->state != RDMAXS_LISTENING
-		 && xd->state != RDMAXS_ERROR)
-			xd->state = RDMAXS_CLOSING;
-
-		if (xd->cm_id && xd->cm_id->verbs)
-			rdma_disconnect(xd->cm_id);
-
-		while (xd->state != RDMAXS_CLOSED
-			&& xd->state != RDMAXS_LISTENING
-			&& xd->state != RDMAXS_ERROR) {
-			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
-				"%s() we're not closed yet, "
-				"waiting for disconnect_event",
-				__func__);
-			cond_wait(&xd->cm_cond, &xd->cm_lock);
-		}
-		xd->state = RDMAXS_CLOSED;
-		mutex_unlock(&xd->cm_lock);
-	}
-
-	if (xd->cm_id) {
-		rdma_destroy_id(xd->cm_id);
-		xd->cm_id = NULL;
-	}
-
-	if (xd->stats_sock)
-		rpc_rdma_stats_del(xd);
-
-	/* event channel is shared between all children,
-	 * so don't close it unless it's its own.
-	 */
-	if ((xd->server != RDMAX_SERVER_CHILD)
-	 && xd->event_channel) {
-		rpc_rdma_fd_del(xd->event_channel->fd,
-				rpc_rdma_state.cm_epollfd);
-		rdma_destroy_event_channel(xd->event_channel);
-		xd->event_channel = NULL;
-	}
-
-	rpc_rdma_destroy_stuff(xd);
+	xdr_ioq_rdma_destroy_pools(xd);
 	rpc_rdma_pd_put(xd);
 
 	if (atomic_dec_int32_t(&rpc_rdma_state.run_count) <= 0) {
@@ -1341,7 +1370,6 @@ rpc_rdma_destroy(RDMAXPRT *xd)
 	 */
 	cond_destroy(&xd->cm_cond);
 	mutex_destroy(&xd->cm_lock);
-	XDR_DESTROY(xd->sm_dr.ioq.xdrs);
 	rpc_dplx_rec_destroy(&xd->sm_dr);
 
 	mem_free(xd, sizeof(*xd));
@@ -1370,7 +1398,6 @@ rpc_rdma_allocate(const struct rpc_rdma_attr *xa)
 	xd = mem_zalloc(sizeof(*xd));
 
 	xd->sm_dr.xprt.xp_type = XPRT_RDMA;
-	xd->sm_dr.xprt.xp_refcnt = 1;
 	xd->sm_dr.xprt.xp_ops = &rpc_rdma_ops;
 
 	xd->xa = xa;
@@ -1380,7 +1407,13 @@ rpc_rdma_allocate(const struct rpc_rdma_attr *xa)
 	/* initialize locking first, will be destroyed last (above).
 	 */
 	xdr_ioq_setup(&xd->sm_dr.ioq);
+
+	/* svc_xprt ref taken here */
 	rpc_dplx_rec_init(&xd->sm_dr);
+
+	xd->sm_dr.ioq.rdma_ioq = true;
+	xd->sm_dr.ioq.xdrs[0].x_lib[1] = xd;
+	xd->active_requests = 0;
 
 	rc = mutex_init(&xd->cm_lock, NULL);
 	if (rc) {
@@ -1478,22 +1511,9 @@ rpc_rdma_ncreatef(const struct rpc_rdma_attr *xa,
 
 	/* buffer sizes MUST be page sized */
 	xd->sm_dr.pagesz = sysconf(_SC_PAGESIZE);
-	if (recvsize) {
-		/* round up */
-		xd->sm_dr.recvsz = recvsize + (xd->sm_dr.pagesz - 1);
-		xd->sm_dr.recvsz &= ~(xd->sm_dr.pagesz - 1);
-	} else {
-		/* default */
-		xd->sm_dr.recvsz = xd->sm_dr.pagesz;
-	}
-	if (sendsize) {
-		/* round up */
-		xd->sm_dr.sendsz = sendsize + (xd->sm_dr.pagesz - 1);
-		xd->sm_dr.sendsz &= ~(xd->sm_dr.pagesz - 1);
-	} else {
-		/* default */
-		xd->sm_dr.recvsz = xd->sm_dr.pagesz;
-	}
+
+	xd->sm_dr.recv_hdr_sz = xd->sm_dr.send_hdr_sz = RDMA_HDR_CHUNK_SZ;
+	xd->sm_dr.recvsz = xd->sm_dr.sendsz = RDMA_DATA_CHUNK_SZ;
 
 	/* round up to the next power of two */
 	rpc_rdma_state.c_r.q_size = 2;
@@ -1512,13 +1532,12 @@ rpc_rdma_ncreatef(const struct rpc_rdma_attr *xa,
 		goto failure;
 	}
 	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
-		"%s() NFS/RDMA engine bound",
-		__func__);
+		"%s() NFS/RDMA engine bound recvsz %llu sendsz %llu xd %p",
+		__func__, xd->sm_dr.recvsz, xd->sm_dr.sendsz, xd);
 
 	return (&xd->sm_dr.xprt);
 
 failure:
-	rpc_rdma_destroy(xd);
 	return NULL;
 }
 
@@ -1535,9 +1554,9 @@ rpc_rdma_create_qp(RDMAXPRT *xprt, struct rdma_cm_id *cm_id)
 {
 	int rc;
 	struct ibv_qp_init_attr qp_attr = {
-		.cap.max_send_wr = xprt->xa->sq_depth,
+		.cap.max_send_wr = MAX_CBC_OUTSTANDING,
 		.cap.max_send_sge = xprt->xa->max_send_sge,
-		.cap.max_recv_wr = xprt->xa->rq_depth,
+		.cap.max_recv_wr = MAX_CBC_OUTSTANDING,
 		.cap.max_recv_sge = xprt->xa->max_recv_sge,
 		.cap.max_inline_data = 0, // change if IMM
 		.qp_type = (xprt->conn_type == RDMA_PS_UDP
@@ -1556,6 +1575,17 @@ rpc_rdma_create_qp(RDMAXPRT *xprt, struct rdma_cm_id *cm_id)
 			__func__, xprt, xprt->state, strerror(rc), rc);
 		return rc;
 	}
+
+	struct ibv_qp_attr attr;
+	memset(&attr, 0, sizeof(attr));
+	ibv_query_qp(cm_id->qp, &attr, IBV_QP_STATE | IBV_QP_AV |
+	    IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
+	    IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER, &qp_attr);
+
+	__warnx(TIRPC_DEBUG_FLAG_EVENT,
+		"%s() %p[%u] ibv_query_qp path mtu %d state %d qp type %d",
+		__func__, xprt, xprt->state, attr.qp_state,
+		attr.path_mtu, qp_attr.qp_type);
 
 	xprt->qp = cm_id->qp;
 	return 0;
@@ -1635,9 +1665,48 @@ rpc_rdma_setup_stuff(RDMAXPRT *xprt)
 	}
 
 	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
-		"%s() %p[%u] created qp %p",
-		__func__, xprt, xprt->state, xprt->qp);
+		"%s() %p[%u] created qp %p handle %u qp_num %u",
+		__func__, xprt, xprt->state, xprt->qp,
+		xprt->qp->handle, xprt->qp->qp_num);
 	return 0;
+}
+
+void
+rpc_rdma_allocate_cbc_locked(struct poolq_head *ioqh)
+{
+
+	struct rpc_rdma_cbc *cbc = mem_zalloc(ioqh->qsize);
+
+	xdr_ioq_setup(&cbc->recvq);
+	xdr_ioq_setup(&cbc->sendq);
+	xdr_ioq_setup(&cbc->dataq);
+	xdr_ioq_setup(&cbc->freeq);
+
+	cbc->recvq.ioq_uv.uvq_fetch =
+	cbc->sendq.ioq_uv.uvq_fetch =
+	cbc->dataq.ioq_uv.uvq_fetch =
+	cbc->freeq.ioq_uv.uvq_fetch = xdr_rdma_ioq_uv_fetch_nothing;
+
+	cbc->recvq.rdma_ioq = cbc->sendq.rdma_ioq =
+	cbc->dataq.rdma_ioq = cbc->freeq.rdma_ioq = true;
+
+	cbc->recvq.xdrs[0].x_ops =
+	cbc->sendq.xdrs[0].x_ops =
+	cbc->dataq.xdrs[0].x_ops =
+	cbc->freeq.xdrs[0].x_ops = &xdr_ioq_ops_rdma;
+
+	cbc->recvq.xdrs[0].x_op =
+	cbc->sendq.xdrs[0].x_op =
+	cbc->dataq.xdrs[0].x_op =
+	cbc->freeq.xdrs[0].x_op = XDR_FREE; /* catch setup errors */
+
+	cbc->recvq.ioq_pool = ioqh;
+	cbc->wpe.fun = rpc_rdma_worker_callback;
+	pthread_cond_init(&cbc->cb_done, NULL);
+	pthread_mutex_init(&cbc->cb_done_mutex, NULL);
+
+	(ioqh->qcount)++;
+	TAILQ_INSERT_TAIL(&ioqh->qh, &cbc->recvq.ioq_s, q);
 }
 
 /**
@@ -1646,8 +1715,6 @@ rpc_rdma_setup_stuff(RDMAXPRT *xprt)
 static int
 rpc_rdma_setup_cbq(struct poolq_head *ioqh, u_int depth, u_int sge)
 {
-	struct rpc_rdma_cbc *cbc;
-
 	if (ioqh->qsize) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s() contexts already allocated",
@@ -1656,31 +1723,23 @@ rpc_rdma_setup_cbq(struct poolq_head *ioqh, u_int depth, u_int sge)
 	}
 	ioqh->qsize = sizeof(struct rpc_rdma_cbc)
 		    + sizeof(struct ibv_sge) * sge;
-	TAILQ_INIT(&ioqh->qh);
+
+	poolq_head_setup(ioqh);
 
 	/* individual entries is less efficient than big array -- but uses
 	 * "standard" IOQ operations, xdr_ioq_destroy_pool(), and
 	 * debugging memory bounds checking of trailing ibv_sge array.
 	 */
+	/* Initiaze recvq and sendq */
+
+	pthread_mutex_lock(&ioqh->qmutex);
+
 	while (depth--) {
-		cbc = mem_zalloc(ioqh->qsize);
-
-		xdr_ioq_setup(&cbc->workq);
-		xdr_ioq_setup(&cbc->holdq);
-
-		cbc->workq.ioq_uv.uvq_fetch =
-		cbc->holdq.ioq_uv.uvq_fetch = xdr_ioq_uv_fetch_nothing;
-		cbc->workq.xdrs[0].x_ops =
-		cbc->holdq.xdrs[0].x_ops = &xdr_ioq_ops;
-		cbc->workq.xdrs[0].x_op =
-		cbc->holdq.xdrs[0].x_op = XDR_FREE; /* catch setup errors */
-
-		cbc->workq.ioq_pool = ioqh;
-		cbc->wpe.fun = rpc_rdma_worker_callback;
-
-		(ioqh->qcount)++;
-		TAILQ_INSERT_TAIL(&ioqh->qh, &cbc->workq.ioq_s, q);
+		rpc_rdma_allocate_cbc_locked(ioqh);
 	}
+
+	pthread_mutex_unlock(&ioqh->qmutex);
+
 	return 0;
 }
 
@@ -1847,8 +1906,7 @@ rpc_rdma_clone(RDMAXPRT *l_xprt, struct rdma_cm_id *cm_id)
 		}
 	} else {
 		rc = rpc_rdma_setup_cbq(&xd->cbqh,
-					xd->xa->rq_depth +
-					xd->xa->sq_depth,
+					MAX_CBC_ALLOCATION,
 					xd->xa->credits);
 		if (rc) {
 			__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -1873,7 +1931,7 @@ rpc_rdma_clone(RDMAXPRT *l_xprt, struct rdma_cm_id *cm_id)
 	return xd;
 
 failure:
-	rpc_rdma_destroy(xd);
+	SVC_DESTROY(&xd->sm_dr.xprt);
 	return (NULL);
 }
 
@@ -1930,8 +1988,10 @@ static RDMAXPRT *
 rpc_rdma_accept_timedwait(RDMAXPRT *l_xprt, struct timespec *abstime)
 {
 	struct rdma_cm_id *cm_id;
-	uint32_t u;
-	int rc;
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() %p[%u] listening (after bind_server)?",
+		__func__, l_xprt, l_xprt->state);
 
 	if (!l_xprt || l_xprt->state != RDMAXS_LISTENING) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -1940,61 +2000,7 @@ rpc_rdma_accept_timedwait(RDMAXPRT *l_xprt, struct timespec *abstime)
 		return (NULL);
 	}
 
-	/* Drain connection_requests */
-	if (abstime) {
-		rc = sem_timedwait(&rpc_rdma_state.c_r.q_sem, abstime);
-		if (rc) {
-			rc = errno;
-			if (ETIMEDOUT == rc) {
-				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
-					"%s() ETIMEDOUT",
-					__func__);
-			} else {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
-					"%s() sem_timedwait failed",
-					__func__, strerror(rc), rc);
-			}
-			return (NULL);
-		}
-	} else {
-		rc = sem_wait(&rpc_rdma_state.c_r.q_sem);
-		if (rc) {
-			rc = errno;
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
-				"%s() sem_wait failed",
-				__func__, strerror(rc), rc);
-			return (NULL);
-		}
-	}
-
-	u = atomic_postinc_uint32_t(&rpc_rdma_state.c_r.q_head);
-	if (u >= rpc_rdma_state.c_r.q_size) {
-		u_int q_mask = rpc_rdma_state.c_r.q_size - 1;
-
-		/* masking allows update by lock-free tasks,
-		 * as long as overrun never 2 * q_size
-		 */
-		u &= q_mask;
-		atomic_clear_uint32_t_bits(&rpc_rdma_state.c_r.q_head, ~q_mask);
-	}
-	cm_id = rpc_rdma_state.c_r.id_queue[u];
-
-	/* Increase available count */
-	rc = sem_post(&rpc_rdma_state.c_r.u_sem);
-	if (rc) {
-		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
-			"%s() sem_post failed",
-			__func__, strerror(rc), rc);
-		return (NULL);
-	}
-
-	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
-		"%s() thread %lx, q %u, cm_id %p",
-		__func__,
-		pthread_self(),
-		u,
-		cm_id);
+	cm_id = rpc_rdma_state.c_r.id_queue[0];
 
 	if (!cm_id) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -2011,6 +2017,9 @@ rpc_rdma_accept_wait(RDMAXPRT *l_xprt,int msleep)
 {
 	struct timespec ts;
 
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() accept wait msleep %d",
+		__func__, msleep);
 	if (msleep == 0)
 		return rpc_rdma_accept_timedwait(l_xprt, NULL);
 
@@ -2206,22 +2215,6 @@ rpc_rdma_connect(RDMAXPRT *xprt)
 				rpc_rdma_state.cm_epollfd);
 }
 
-static void
-rpc_rdma_unlink_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
-{
-	return;
-}
-
-static void
-rpc_rdma_destroy_it(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
-{
-	if (xprt->xp_ops->xp_free_user_data) {
-		/* call free hook */
-		xprt->xp_ops->xp_free_user_data(xprt);
-	}
-	rpc_rdma_destroy(RDMA_DR(REC_XPRT(xprt)));
-}
-
 extern mutex_t ops_lock;
 
 static bool
@@ -2261,9 +2254,9 @@ static struct xp_ops rpc_rdma_ops = {
 	.xp_decode = (svc_req_fun_t)abort,
 	.xp_reply = (svc_req_fun_t)abort,
 	.xp_checksum = NULL,		/* not used */
-	.xp_unlink = rpc_rdma_unlink_it,
-	.xp_unref_user_data = NULL,	/* no default */
-	.xp_destroy = rpc_rdma_destroy_it,
+	.xp_unlink = svc_rdma_unlink,
+	.xp_unref_user_data = NULL,     /* no default */
+	.xp_destroy = svc_rdma_destroy,
 	.xp_control = rpc_rdma_control,
 	.xp_free_user_data = NULL,	/* no default */
 };

--- a/src/rpc_rdma.h
+++ b/src/rpc_rdma.h
@@ -39,9 +39,11 @@
 #ifndef _TIRPC_RPC_RDMA_H
 #define _TIRPC_RPC_RDMA_H
 
+#include <semaphore.h>
 #include <rdma/rdma_cma.h>
 #include <rpc/svc.h>
 #include <rpc/xdr_ioq.h>
+#include <rpc/work_pool.h>
 
 #include "rpc_dplx_internal.h"
 
@@ -64,18 +66,41 @@ struct msk_stats {
 	uint64_t nsec_compevent;
 };
 
+typedef enum rpc_extra_io_buf_type {
+	IO_INBUF = 1,	/* Buffers used for recv */
+	IO_OUTBUF	/* Buffers used for send */
+} rpc_extra_io_buf_type_t;
+
+/* Track buffers allocated on demand */
+struct rpc_extra_io_bufs {
+        struct ibv_mr *mr;
+        uint32_t buffer_total;
+        uint8_t *buffer_aligned;
+        struct poolq_entry q;
+	rpc_extra_io_buf_type_t type;
+};
+
 typedef struct rpc_rdma_xprt RDMAXPRT;
 
 struct rpc_rdma_cbc;
 typedef int (*rpc_rdma_callback_t)(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt);
+
+#define CBC_FLAG_NONE		0x0000
+#define CBC_FLAG_RELEASE	0x0001
+#define CBC_FLAG_RELEASING	0x0002
+
+#define RDMA_CB_TIMEOUT_SEC 10
 
 /**
  * \struct rpc_rdma_cbc
  * Context data we can use during recv/send callbacks
  */
 struct rpc_rdma_cbc {
-	struct xdr_ioq workq;
-	struct xdr_ioq holdq;
+	/* recvq should always be first, since we use xdrs to get cbc */
+	struct xdr_ioq recvq; /* queue to hold requests and rdma_read bufs */
+	struct xdr_ioq sendq; /* queue to hold responses and rdma_write bufs */
+	struct xdr_ioq dataq; /* queue to hold data_bufs from protocol */
+	struct xdr_ioq freeq; /* queue to hold used bufs */
 
 	struct xdr_ioq_uv *call_uv;
 	void *call_head;
@@ -83,6 +108,16 @@ struct rpc_rdma_cbc {
 	void *write_chunk;	/* current in list of arrays */
 	void *reply_chunk;	/* current in array */
 	void *call_data;
+	bool_t call_inline;
+	int32_t refcnt;
+	uint16_t cbc_flags;
+	struct poolq_entry *have;
+	struct xdr_ioq_uv *data_chunk_uv;
+	struct poolq_entry cbc_list;
+	uint8_t *non_registered_buf;
+	int non_registered_buf_len;
+	pthread_cond_t cb_done;
+	pthread_mutex_t cb_done_mutex;
 
 	struct work_pool_entry wpe;
 	rpc_rdma_callback_t positive_cb;
@@ -115,6 +150,14 @@ struct rpc_rdma_pd {
 #define RDMAX_CLIENT 0
 #define RDMAX_SERVER_CHILD -1
 
+#define RDMA_HDR_CHUNK_SZ 8192
+#define MAX_CBC_OUTSTANDING 1024
+#define MAX_CBC_ALLOCATION (MAX_CBC_OUTSTANDING * 2)
+#define MAX_RECV_OUTSTANDING MAX_CBC_OUTSTANDING
+#define RDMA_DATA_CHUNKS 32
+#define RDMA_DATA_CHUNK_SZ 1048576
+#define RDMA_HDR_CHUNKS MAX_CBC_OUTSTANDING
+
 /**
  * \struct rpc_rdma_xprt
  * RDMA transport instance
@@ -140,10 +183,20 @@ struct rpc_rdma_xprt {
 	u_int8_t *buffer_aligned;
 	size_t buffer_total;
 
-	struct xdr_ioq_uv_head inbufs;	/* recvsize */
-	struct xdr_ioq_uv_head outbufs;	/* sendsz */
+	struct xdr_ioq_uv_head inbufs_hdr;	/* Buffers to hold request headers */
+	struct xdr_ioq_uv_head inbufs_data;	/* Buffers to hold request data */
+	struct xdr_ioq_uv_head outbufs_hdr;	/* Buffers to hold response headers */
+	struct xdr_ioq_uv_head outbufs_data;	/* Buffers to hold response data */
 
 	struct poolq_head cbqh;		/**< combined callback contexts */
+
+	struct poolq_head extra_bufs;
+
+	u_int extra_bufs_count;
+
+	uint32_t active_requests;
+
+	struct poolq_head cbclist;
 
 	mutex_t cm_lock;		/**< lock for connection events */
 	cond_t cm_cond;			/**< cond for connection events */
@@ -166,9 +219,7 @@ struct rpc_rdma_xprt {
 		RDMAXS_ROUTE_RESOLVED,
 		RDMAXS_CONNECT_REQUEST,
 		RDMAXS_CONNECTED,
-		RDMAXS_CLOSING,
-		RDMAXS_CLOSED,
-		RDMAXS_ERROR, 		/* always last */
+		RDMAXS_ERROR
 	} state;			/**< transport state machine */
 
 	/* FIXME why configurable??? */
@@ -216,6 +267,32 @@ typedef struct rec_rdma_strm {
 	int credits;
 } RECRDMA;
 
+struct connection_requests {
+	struct rdma_cm_id **id_queue;
+	sem_t	q_sem;
+	sem_t	u_sem;
+	uint32_t q_head;
+	uint32_t q_tail;
+	u_int	q_size;
+};
+
+struct rpc_rdma_state {
+	LIST_HEAD(pdh_s, rpc_rdma_pd) pdh;	/**< Protection Domain list */
+	mutex_t lock;
+
+	struct connection_requests c_r;		/* never freed??? */
+
+	pthread_t cm_thread;		/**< Thread id for connection manager */
+	pthread_t cq_thread;		/**< Thread id for completion queue */
+	pthread_t stats_thread;
+
+	int cm_epollfd;
+	int cq_epollfd;
+	int stats_epollfd;
+
+	int32_t run_count;
+};
+
 static inline void *xdr_encode_hyper(uint32_t *iptr, uint64_t val)
 {
 	*iptr++ = htonl((uint32_t)((val >> 32) & 0xffffffff));
@@ -228,6 +305,88 @@ static inline uint64_t xdr_decode_hyper(uint64_t *iptr)
 	return ((uint64_t) ntohl(((uint32_t*)iptr)[0]) << 32)
 		| (ntohl(((uint32_t*)iptr)[1]));
 }
+
+/* Take ref on cbc before we do ibv_post */
+static inline void cbc_ref_it(struct rpc_rdma_cbc *cbc)
+{
+	int32_t refs =
+		atomic_inc_int32_t(&cbc->refcnt);
+	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s: take_ref cbc %p ref %d "
+		"refs %d",
+		__func__, cbc, cbc->refcnt, refs);
+}
+
+#define x_xprt(xdrs) ((RDMAXPRT *)((xdrs)->x_lib[1]))
+
+/* Release ref on cbc on callback from ibv_post */
+static inline void cbc_release_it(struct rpc_rdma_cbc *cbc)
+{
+	int32_t refs =
+		atomic_dec_int32_t(&cbc->refcnt);
+	RDMAXPRT *xd = x_xprt(cbc->recvq.xdrs);
+
+	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s: release_ref cbc %p ref %d "
+		"refs %d",
+		__func__, cbc, cbc->refcnt, refs);
+
+	if ((refs == 0) && (cbc->cbc_flags & CBC_FLAG_RELEASE)) {
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s: destroy_cbc "
+			"cbc %p ref %d flags %x",
+			__func__, cbc, cbc->refcnt, cbc->cbc_flags);
+
+		uint16_t flags = atomic_postset_uint16_t_bits(&cbc->cbc_flags,
+		    CBC_FLAG_RELEASING);
+
+		if (flags & CBC_FLAG_RELEASING) {
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s: destroy_cbc "
+				" already destroying cbc %p ref %d flags %x",
+				__func__, cbc, cbc->refcnt, cbc->cbc_flags);
+			return;
+		}
+
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s: destroy_cbc "
+			" destroying cbc %p ref %d flags %x",
+			__func__, cbc, cbc->refcnt, cbc->cbc_flags);
+
+		pthread_mutex_lock(&xd->cbclist.qmutex);
+		TAILQ_REMOVE(&xd->cbclist.qh, &cbc->cbc_list, q);
+		xd->cbclist.qcount--;
+		pthread_mutex_unlock(&xd->cbclist.qmutex);
+
+		SVC_RELEASE(&xd->sm_dr.xprt, SVC_REF_FLAG_NONE);
+
+		if (cbc->non_registered_buf) {
+			mem_free(cbc->non_registered_buf, cbc->non_registered_buf_len);
+		}
+
+
+		/* cbqh is pointed by recvq */
+		xdr_rdma_ioq_release(&cbc->sendq.ioq_uv.uvqh, false, &cbc->sendq);
+		xdr_rdma_ioq_release(&cbc->dataq.ioq_uv.uvqh, false, &cbc->dataq);
+		xdr_rdma_ioq_release(&cbc->freeq.ioq_uv.uvqh, false, &cbc->freeq);
+		xdr_rdma_ioq_release(&cbc->recvq.ioq_uv.uvqh, false, &cbc->recvq);
+
+		/* Remove cbc from ioq before we add it back to cbqh */
+		pthread_mutex_lock(&xd->sm_dr.ioq.ioq_uv.uvqh.qmutex);
+		TAILQ_REMOVE(&xd->sm_dr.ioq.ioq_uv.uvqh.qh, &cbc->recvq.ioq_s, q);
+		(xd->sm_dr.ioq.ioq_uv.uvqh.qcount)--;
+		pthread_mutex_unlock(&xd->sm_dr.ioq.ioq_uv.uvqh.qmutex);
+
+		__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc_track end %p recvq %p %d sendq %p %d "
+			"dataq %p %d freeq %p %d ioq %p %d xd %p",
+			__func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount,
+			&cbc->sendq, cbc->sendq.ioq_uv.uvqh.qcount, &cbc->dataq,
+			cbc->dataq.ioq_uv.uvqh.qcount, &cbc->freeq,
+			cbc->freeq.ioq_uv.uvqh.qcount, &xd->sm_dr.ioq,
+			xd->sm_dr.ioq.ioq_uv.uvqh.qcount, xd);
+
+		/* Add cbc back to cbqh */
+		xdr_rdma_ioq_release(&cbc->recvq.ioq_uv.uvqh, true, &cbc->recvq);
+
+	}
+}
+
+extern struct rpc_rdma_state rpc_rdma_state;
 
 void rpc_rdma_internals_init(void);
 void rpc_rdma_internals_fini(void);
@@ -245,14 +404,30 @@ int rpc_rdma_connect_finalize(RDMAXPRT *);
 
 /* XDR functions */
 int xdr_rdma_create(RDMAXPRT *);
+void xdr_rdma_add_inbufs_data(RDMAXPRT *xd);
+void xdr_rdma_add_outbufs_data(RDMAXPRT *xd);
+void xdr_rdma_add_inbufs_hdr(RDMAXPRT *xd);
+void xdr_rdma_add_outbufs_hdr(RDMAXPRT *xd);
 void xdr_rdma_callq(RDMAXPRT *);
-void xdr_rdma_destroy(RDMAXPRT *);
 
 bool xdr_rdma_clnt_reply(XDR *, u_int32_t);
 bool xdr_rdma_clnt_flushout(struct rpc_rdma_cbc *);
 
 bool xdr_rdma_svc_recv(struct rpc_rdma_cbc *, u_int32_t);
-bool xdr_rdma_svc_reply(struct rpc_rdma_cbc *, u_int32_t);
-bool xdr_rdma_svc_flushout(struct rpc_rdma_cbc *);
+bool xdr_rdma_svc_reply(struct rpc_rdma_cbc *, u_int32_t,
+    bool rdma_buf_used);
+bool xdr_rdma_svc_flushout(struct rpc_rdma_cbc *, bool rdma_buf_used);
+void rpc_rdma_allocate_cbc_locked(struct poolq_head *ioqh);
+
+int rpc_rdma_fd_del(int fd, int epollfd);
+
+void svc_rdma_unlink(SVCXPRT *xprt, u_int flags, const char *tag,
+    const int line);
+void svc_rdma_destroy(SVCXPRT *xprt, u_int flags, const char *tag,
+    const int line);
+
+void rdma_cleanup_cbcs_task(struct work_pool_entry *wpe);
+
+void rpc_rdma_close_connection(RDMAXPRT *xd);
 
 #endif /* !_TIRPC_RPC_RDMA_H */

--- a/src/svc.c
+++ b/src/svc.c
@@ -130,6 +130,11 @@ svc_init(svc_init_params *params)
 	struct work_pool_params work_pool_params = {0,};
 	uint32_t channels = params->channels ? params->channels : 8;
 
+#ifdef USE_RPC_RDMA
+	__svc_params->nfs_rdma_port = params->nfs_rdma_port;
+	__svc_params->enable_rdma_dump = params->enable_rdma_dump;
+#endif
+
 	mutex_lock(&__svc_params->mtx);
 	if (__svc_params->initialized) {
 		__warnx(TIRPC_DEBUG_FLAG_WARN,
@@ -232,6 +237,7 @@ svc_init(svc_init_params *params)
 
 #ifdef USE_RPC_RDMA
 	rpc_rdma_internals_init();
+	__svc_params->max_rdma_connections = params->max_rdma_connections;
 #endif
 
 	__svc_params->initialized = true;

--- a/src/svc_internal.h
+++ b/src/svc_internal.h
@@ -82,6 +82,13 @@ struct svc_params {
 	u_long flags;
 	u_int max_connections;
 	int32_t idle_timeout;
+
+#if defined(_USE_NFS_RDMA) || defined(USE_RPC_RDMA)
+	uint16_t nfs_rdma_port;
+	u_int max_rdma_connections;
+	bool enable_rdma_dump;
+#endif
+
 };
 
 enum xprt_stat svc_request(SVCXPRT *xprt, XDR *xdrs);
@@ -181,6 +188,11 @@ static inline int svc_rqst_rearm_events(SVCXPRT *xprt, uint16_t ev_flags)
 
 int svc_rqst_xprt_register(SVCXPRT *, SVCXPRT *);
 void svc_rqst_xprt_unregister(SVCXPRT *, uint32_t);
+
+#if defined(USE_RPC_RDMA)
+void svc_rqst_xprt_unregister_rdma(SVCXPRT *, uint32_t);
+#endif
+
 int svc_rqst_evchan_write(SVCXPRT *, struct xdr_ioq *, bool);
 void svc_rqst_xprt_send_complete(SVCXPRT *);
 void svc_rqst_unhook(SVCXPRT *);

--- a/src/svc_xprt.h
+++ b/src/svc_xprt.h
@@ -32,6 +32,10 @@
 #include <misc/portable.h>
 #include <misc/rbtree_x.h>
 
+#ifdef USE_RPC_RDMA
+#include "rpc_rdma.h"
+#endif
+
 /**
  * @file svc_xprt.h
  * @contributeur William Allen Simpson <bill@cohortfs.com>
@@ -65,4 +69,7 @@ int svc_xprt_foreach(svc_xprt_each_func_t, void *);
 void svc_xprt_dump_xprts(const char *);
 void svc_xprt_shutdown(void);
 
+#ifdef USE_RPC_RDMA
+int svc_rdma_add_xprt_fd(SVCXPRT *xprt);
+#endif
 #endif				/* TIRPC_SVC_XPRT_H */

--- a/src/xdr_rdma.c
+++ b/src/xdr_rdma.c
@@ -55,7 +55,6 @@
  * they are rarely checked.
  */
 
-#define CALLQ_SIZE (2)
 #define RFC5666_BUFFER_SIZE (1024)
 #define RPCRDMA_VERSION (1)
 
@@ -71,6 +70,9 @@
 static void
 rpcrdma_dump_msg(struct xdr_ioq_uv *data, char *comment, uint32_t xid)
 {
+	if (!__svc_params->enable_rdma_dump)
+		return;
+
 	char *buffer;
 	uint8_t *datum = data->v.vio_head;
 	int sized = ioquv_length(data);
@@ -185,147 +187,136 @@ struct rdma_msg {
 	} rdma_body;
 };
 
-/***********************************/
-/****** Utilities for buffers ******/
-/***********************************/
-
-static void
-xdr_rdma_chunk_in(struct poolq_entry *have, u_int k, u_int m, u_int sized)
-{
-	/* final buffer limited to truncated length */
-	IOQ_(have)->v.vio_head = IOQ_(have)->v.vio_base;
-	IOQ_(have)->v.vio_tail = (char *)IOQ_(have)->v.vio_base + m;
-	IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base + sized;
-
-	while (0 < --k && NULL != (have = TAILQ_PREV(have, poolq_head_s, q))) {
-		/* restore defaults after previous usage */
-		IOQ_(have)->v.vio_head = IOQ_(have)->v.vio_base;
-		IOQ_(have)->v.vio_tail =
-		IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base + sized;
-	}
-}
-
-static void
-xdr_rdma_chunk_out(struct poolq_entry *have, u_int k, u_int m, u_int sized)
-{
-	/* final buffer limited to truncated length */
-	IOQ_(have)->v.vio_head =
-	IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
-	IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base + m;
-
-	while (0 < --k && NULL != (have = TAILQ_PREV(have, poolq_head_s, q))) {
-		/* restore defaults after previous usage */
-		IOQ_(have)->v.vio_head =
-		IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
-		IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base + sized;
-	}
-}
-
-static uint32_t
-xdr_rdma_chunk_fetch(struct xdr_ioq *xioq, struct poolq_head *ioqh,
-		     char *comment, u_int length, u_int sized, u_int max_sge,
-		     void (*setup)(struct poolq_entry *, u_int, u_int, u_int))
-{
-	struct poolq_entry *have;
-	uint32_t k = length / sized;
-	uint32_t m = length % sized;
-
-	if (m) {
-		/* need fractional buffer */
-		k++;
-	} else {
-		/* have full-sized buffer */
-		m = sized;
-	}
-
-	/* ensure never asking for more buffers than allowed */
-	if (k > max_sge) {
-		__warnx(TIRPC_DEBUG_FLAG_XDR,
-			"%s() requested chunk %" PRIu32
-			" is too long (%" PRIu32 ">%" PRIu32 ")",
-			__func__, length, k, max_sge);
-		k = max_sge;
-		m = sized;
-	}
-
-	/* ensure we can get all of our buffers without deadlock
-	 * (wait for them all to be appended)
-	 */
-	have = xdr_ioq_uv_fetch(xioq, ioqh, comment, k, IOQ_FLAG_NONE);
-	(*setup)(have, k, m, sized);
-	return k;
-}
-
 /***********************/
 /****** Callbacks ******/
 /***********************/
 
 /* note parameter order matching svc.h svc_req callbacks */
 
-static int
-xdr_rdma_respond_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
+static void
+xdr_rdma_callback_signal(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
 {
-	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+	pthread_mutex_lock(&cbc->cb_done_mutex);
+	cbc_release_it(cbc);
+	pthread_cond_signal(&cbc->cb_done);
+	pthread_mutex_unlock(&cbc->cb_done_mutex);
+}
+
+static int
+xdr_rdma_respond_callback_send(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
+{
+	int ret = 0;
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR,
 		"%s() %p[%u] cbc %p\n",
 		__func__, xprt, xprt->state, cbc);
 
-	mutex_lock(&xprt->sm_dr.ioq.ioq_uv.uvqh.qmutex);
-	TAILQ_REMOVE(&xprt->sm_dr.ioq.ioq_uv.uvqh.qh, &cbc->workq.ioq_s, q);
-	(xprt->sm_dr.ioq.ioq_uv.uvqh.qcount)--;
-	mutex_unlock(&xprt->sm_dr.ioq.ioq_uv.uvqh.qmutex);
+	if (xprt->sm_dr.xprt.xp_flags & SVC_XPRT_FLAG_DESTROYED) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, " %s xprt %p cbc %p "
+			"already destroyed", __func__, xprt, cbc);
 
-	xdr_ioq_destroy(&cbc->workq, sizeof(*cbc));
-	return (0);
+		ret =  -1;
+	}
+
+	cbc_release_it(cbc);
+
+	SVC_RELEASE(&xprt->sm_dr.xprt, SVC_RELEASE_FLAG_NONE);
+
+	return ret;
+}
+
+static int
+xdr_rdma_destroy_callback_send(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
+{
+	int ret = 0;
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR,
+		"%s() %p[%u] cbc %p\n",
+		__func__, xprt, xprt->state, cbc);
+
+	if (xprt->sm_dr.xprt.xp_flags & SVC_XPRT_FLAG_DESTROYED) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, " %s xprt %p cbc %p "
+			"already destroyed", __func__, xprt, cbc);
+
+		ret = -1;
+	}
+
+	cbc_release_it(cbc);
+
+	SVC_DESTROY(&xprt->sm_dr.xprt);
+	SVC_RELEASE(&xprt->sm_dr.xprt, SVC_RELEASE_FLAG_NONE);
+
+	return ret;
+}
+
+static int
+xdr_rdma_respond_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
+{
+	int ret = 0;
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR,
+		"%s() %p[%u] cbc %p\n",
+		__func__, xprt, xprt->state, cbc);
+
+	if (xprt->sm_dr.xprt.xp_flags & SVC_XPRT_FLAG_DESTROYED) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, " %s xprt %p cbc %p "
+			"already destroyed", __func__, xprt, cbc);
+
+		ret = -1;
+	}
+
+	xdr_rdma_callback_signal(cbc, xprt);
+
+	return ret;
 }
 
 static int
 xdr_rdma_destroy_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
 {
-	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+	int ret = 0;
+	__warnx(TIRPC_DEBUG_FLAG_XDR,
 		"%s() %p[%u] cbc %p\n",
 		__func__, xprt, xprt->state, cbc);
 
-	mutex_lock(&xprt->sm_dr.ioq.ioq_uv.uvqh.qmutex);
-	TAILQ_REMOVE(&xprt->sm_dr.ioq.ioq_uv.uvqh.qh, &cbc->workq.ioq_s, q);
-	(xprt->sm_dr.ioq.ioq_uv.uvqh.qcount)--;
-	mutex_unlock(&xprt->sm_dr.ioq.ioq_uv.uvqh.qmutex);
+	if (xprt->sm_dr.xprt.xp_flags & SVC_XPRT_FLAG_DESTROYED) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, " %s xprt %p cbc %p "
+			"already destroyed", __func__, xprt, cbc);
 
-	xdr_ioq_destroy(&cbc->workq, sizeof(*cbc));
-	return (0);
+		ret = -1;
+	}
+
+	xdr_rdma_callback_signal(cbc, xprt);
+
+	SVC_DESTROY(&xprt->sm_dr.xprt);
+
+	return ret;
 }
 
-/**
- * xdr_rdma_wait_callback: send/recv callback that just unlocks a mutex.
- *
- */
 static int
-xdr_rdma_wait_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
+xdr_rdma_destroy_callback_recv(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
 {
-	mutex_t *lock = cbc->callback_arg;
+	int ret = 0;
 
-	__warnx(TIRPC_DEBUG_FLAG_ERROR,
-		"%s() %p[%u] cbc %p\n",
+	__warnx(TIRPC_DEBUG_FLAG_XDR,
+		"Error in recv callback %s() %p[%u] cbc %p\n",
 		__func__, xprt, xprt->state, cbc);
 
-	mutex_unlock(lock);
-	return (0);
-}
+	if (xprt->sm_dr.xprt.xp_flags & SVC_XPRT_FLAG_DESTROYED) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, " %s xprt %p cbc %p "
+			"already destroyed", __func__, xprt, cbc);
 
-/**
- * xdr_rdma_warn_callback: send/recv callback that just unlocks a mutex.
- *
- */
-static int
-xdr_rdma_warn_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
-{
-	mutex_t *lock = cbc->callback_arg;
+		ret = -1;
+	}
 
-	__warnx(TIRPC_DEBUG_FLAG_ERROR,
-		"%s() %p[%u] cbc %p\n",
-		__func__, xprt, xprt->state, cbc);
+	cbc->cbc_flags = CBC_FLAG_RELEASE;
 
-	mutex_unlock(lock);
-	return (0);
+	/* Release senital ref */
+	cbc_release_it(cbc);
+
+	SVC_DESTROY(&xprt->sm_dr.xprt);
+	SVC_RELEASE(&xprt->sm_dr.xprt, SVC_RELEASE_FLAG_NONE);
+
+	return ret;
 }
 
 /**
@@ -335,9 +326,34 @@ xdr_rdma_warn_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
 static int
 xdr_rdma_wrap_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
 {
-	XDR *xdrs = cbc->holdq.xdrs;
+	int ret = 0;
 
-	return (int)svc_request(&xprt->sm_dr.xprt, xdrs);
+	if (xprt->sm_dr.xprt.xp_flags & SVC_XPRT_FLAG_DESTROYED) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, " %s xprt %p cbc %p "
+			"already destroyed", __func__, xprt, cbc);
+
+		ret = -1;
+		goto err;
+	}
+
+	/* Use xdrs from recvq in context */
+	XDR *xdrs = cbc->recvq.xdrs;
+
+	atomic_inc_uint32_t(&xprt->active_requests);
+
+	ret = (int)svc_request(&xprt->sm_dr.xprt, xdrs);
+
+	atomic_dec_uint32_t(&xprt->active_requests);
+
+err:
+	cbc->cbc_flags = CBC_FLAG_RELEASE;
+
+	/* Release senital ref */
+	cbc_release_it(cbc);
+
+	SVC_RELEASE(&xprt->sm_dr.xprt, SVC_RELEASE_FLAG_NONE);
+
+	return ret;
 }
 
 /***********************************/
@@ -362,7 +378,7 @@ xdr_rdma_wrap_callback(struct rpc_rdma_cbc *cbc, RDMAXPRT *xprt)
 static int
 xdr_rdma_post_recv_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge)
 {
-	struct poolq_entry *have = TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh);
+	struct poolq_entry *have = TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh);
 	int i = 0;
 	int ret;
 
@@ -394,8 +410,8 @@ xdr_rdma_post_recv_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge)
 
 		if (!mr) {
 			__warnx(TIRPC_DEBUG_FLAG_ERROR,
-				"%s() Missing mr: Not requesting.",
-				__func__);
+				"%s() Missing mr: Not requesting addr %p",
+				__func__, IOQ_(have)->v.vio_head);
 			return EINVAL;
 		}
 
@@ -410,6 +426,9 @@ xdr_rdma_post_recv_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge)
 		cbc->sg_list[i++].lkey = mr->lkey;
 
 		have = TAILQ_NEXT(have, q);
+
+		if (i < sge)
+			assert(have);
 	}
 
 	cbc->wr.rwr.next = NULL;
@@ -448,9 +467,28 @@ static int
 xdr_rdma_post_recv_cb(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge)
 {
 	cbc->positive_cb = xdr_rdma_wrap_callback;
-	cbc->negative_cb = xdr_rdma_destroy_callback;
+	cbc->negative_cb = xdr_rdma_destroy_callback_recv;
 	cbc->callback_arg = NULL;
-	return xdr_rdma_post_recv_n(xprt, cbc, sge);
+	cbc->call_inline = 0;
+
+	SVC_REF(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
+
+	int ret = xdr_rdma_post_recv_n(xprt, cbc, sge);
+
+	if (ret) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s post_recv failed xprt %p "
+			"cbc %p error %d", __func__, xprt, cbc, ret);
+
+		cbc->cbc_flags = CBC_FLAG_RELEASE;
+
+		/* Release senital ref */
+		cbc_release_it(cbc);
+
+		SVC_DESTROY(&xprt->sm_dr.xprt);
+		SVC_RELEASE(&xprt->sm_dr.xprt, SVC_RELEASE_FLAG_NONE);
+	}
+
+	return ret;
 }
 
 /**
@@ -473,7 +511,8 @@ static int
 xdr_rdma_post_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 		     struct xdr_rdma_segment *rs, enum ibv_wr_opcode opcode)
 {
-	struct poolq_entry *have = TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh);
+	struct poolq_entry *have = cbc->have;
+
 	uint32_t totalsize = 0;
 	int i = 0;
 	int ret;
@@ -499,7 +538,7 @@ xdr_rdma_post_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 		return EINVAL;
 	}
 
-	// opcode-specific checks:
+	/* opcode-specific checks */
 	switch (opcode) {
 	case IBV_WR_RDMA_WRITE:
 	case IBV_WR_RDMA_READ:
@@ -511,8 +550,8 @@ xdr_rdma_post_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 		}
 		break;
 	case IBV_WR_SEND:
-	case IBV_WR_SEND_WITH_IMM:
 		break;
+	case IBV_WR_SEND_WITH_IMM:
 	default:
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s() unsupported op code: %d",
@@ -526,9 +565,8 @@ xdr_rdma_post_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 
 		if (!length) {
 			__warnx(TIRPC_DEBUG_FLAG_XDR,
-				"%s() Empty buffer: Not sending.",
+				"%s() Empty buffer: sending.",
 				__func__);
-			break;
 		}
 		if (!mr) {
 			__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -549,12 +587,14 @@ xdr_rdma_post_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 
 		totalsize += length;
 		have = TAILQ_NEXT(have, q);
+
+		if (i < sge)
+			assert(have);
 	}
 
 	cbc->wr.wwr.next = NULL;
 	cbc->wr.wwr.wr_id = (uint64_t)cbc;
 	cbc->wr.wwr.opcode = opcode;
-//FIXME	cbc->wr.wwr.imm_data = htonl(data->imm_data);
 	cbc->wr.wwr.send_flags = IBV_SEND_SIGNALED;
 	cbc->wr.wwr.sg_list = cbc->sg_list;
 	cbc->wr.wwr.num_sge = i;
@@ -579,12 +619,26 @@ xdr_rdma_post_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 	ret = ibv_post_send(xprt->qp, &cbc->wr.wwr, &xprt->bad_send_wr);
 	if (ret) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
-			"%s() %p[%u] cbc %p ibv_post_send failed: %s (%d)",
-			__func__, xprt, xprt->state, cbc, strerror(ret), ret);
+			"%s() %p[%u] cbc %p ibv_post_send failed: %s (%d), "
+			"num sge %d imm_data %d",
+			__func__, xprt, xprt->state, cbc, strerror(ret), ret,
+			cbc->wr.wwr.num_sge, cbc->wr.wwr.imm_data);
 		return ret; // FIXME np_uerror(ret)
 	}
 
 	return 0;
+}
+
+static inline int
+xdr_rdma_wait_cb_done_locked(struct rpc_rdma_cbc *cbc)
+{
+	struct timespec ts;
+	ts.tv_sec = time(NULL) + RDMA_CB_TIMEOUT_SEC;
+	ts.tv_nsec = 0;
+	/* cond_wait should atomically release cb_done_mutex */
+	return pthread_cond_timedwait(&cbc->cb_done,
+		    &cbc->cb_done_mutex, &ts);
+
 }
 
 /**
@@ -599,114 +653,74 @@ xdr_rdma_post_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 static inline int
 xdr_rdma_post_send_cb(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge)
 {
-	cbc->positive_cb = xdr_rdma_respond_callback;
-	cbc->negative_cb = xdr_rdma_destroy_callback;
-	cbc->callback_arg = cbc;
-	return xdr_rdma_post_send_n(xprt, cbc, sge, NULL, IBV_WR_SEND);
-}
-
-#ifdef UNUSED
-/**
- * Post a receive chunk and waits for _that one and not any other_ to be filled.
- * Generally a bad idea to use that one unless only that one is used.
- *
- * @param[IN] xprt
- * @param[INOUT] cbc	CallBack Context xdr_ioq and xdr_ioq_uv(s)
- *
- * @return 0 on success, the value of errno on error
- */
-static int
-xdr_rdma_wait_recv_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc)
-{
-	mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 	int ret;
 
-	cbc->positive_cb = xdr_rdma_wait_callback;
-	cbc->negative_cb = xdr_rdma_warn_callback;
-	cbc->callback_arg = &lock;
+	cbc->positive_cb = xdr_rdma_respond_callback_send;
+	cbc->negative_cb = xdr_rdma_destroy_callback_send;
+	cbc->callback_arg = NULL;
+	cbc->call_inline = 1;
 
-	mutex_lock(&lock);
-	ret = xdr_rdma_post_recv_n(xprt, cbc);
+	cbc_ref_it(cbc);
 
-	if (!ret) {
-		mutex_lock(&lock);
-		mutex_unlock(&lock);
-	}
-	mutex_destroy(&lock);
+	SVC_REF(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
 
-	return ret;
-}
-
-/**
- * Post a send chunk and waits for that one to be completely sent
- * @param[IN] xprt
- * @param[IN] cbc	CallBack Context xdr_ioq and xdr_ioq_uv(s)
- * @param[IN] sge	scatter/gather elements to send
- *
- * @return 0 on success, the value of errno on error
- */
-static int
-xdr_rdma_wait_send_n(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge)
-{
-	mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
-	int ret;
-
-	cbc->positive_cb = xdr_rdma_wait_callback;
-	cbc->negative_cb = xdr_rdma_warn_callback;
-	cbc->callback_arg = &lock;
-
-	mutex_lock(&lock);
 	ret = xdr_rdma_post_send_n(xprt, cbc, sge, NULL, IBV_WR_SEND);
 
-	if (!ret) {
-		mutex_lock(&lock);
-		mutex_unlock(&lock);
+	if (ret) {
+		/* Assuming there won't be callback */
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: failed ret %d err %d "
+			" xprt %p cbc %p", __func__, ret, errno, xprt, cbc);
+		cbc_release_it(cbc);
+
+		SVC_DESTROY(&xprt->sm_dr.xprt);
+		SVC_RELEASE(&xprt->sm_dr.xprt, SVC_RELEASE_FLAG_NONE);
 	}
-	mutex_destroy(&lock);
 
 	return ret;
 }
-
-static inline int
-xdr_rdma_post_read_cb(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
-		      struct xdr_rdma_segment *rs)
-{
-	cbc->positive_cb = xdr_rdma_respond_callback;
-	cbc->negative_cb = xdr_rdma_destroy_callback;
-	cbc->callback_arg = cbc;
-	return xdr_rdma_post_send_n(xprt, cbc, sge, rs, IBV_WR_RDMA_READ);
-}
-
-static inline int
-xdr_rdma_post_write_cb(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
-		       struct xdr_rdma_segment *rs)
-{
-	cbc->positive_cb = xdr_rdma_respond_callback;
-	cbc->negative_cb = xdr_rdma_destroy_callback;
-	cbc->callback_arg = cbc;
-	return xdr_rdma_post_send_n(xprt, cbc, sge, rs, IBV_WR_RDMA_WRITE);
-}
-#endif /* UNUSED */
 
 static int
 xdr_rdma_wait_read_cb(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 		     struct xdr_rdma_segment *rs)
 {
-	mutex_t lock = MUTEX_INITIALIZER;
 	int ret;
 
-	cbc->positive_cb = xdr_rdma_wait_callback;
-	cbc->negative_cb = xdr_rdma_warn_callback;
-	cbc->callback_arg = &lock;
+	cbc->positive_cb = xdr_rdma_respond_callback;
+	cbc->negative_cb = xdr_rdma_destroy_callback;
+	cbc->callback_arg = NULL;
+	cbc->call_inline = 1;
 
-	mutex_lock(&lock);
+	pthread_mutex_lock(&cbc->cb_done_mutex);
+
+	cbc_ref_it(cbc);
+
+	SVC_REF(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
+
 	ret = xdr_rdma_post_send_n(xprt, cbc, sge, rs, IBV_WR_RDMA_READ);
 
-	if (!ret) {
-		mutex_lock(&lock);
-		mutex_unlock(&lock);
+	if (ret) {
+		/* Assuming there won't be callback */
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: failed ret %d err %d "
+			" xprt %p cbc %p", __func__, ret, errno, xprt, cbc);
+	} else {
+		ret = xdr_rdma_wait_cb_done_locked(cbc);
+
+		if (ret == ETIMEDOUT) {
+			__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: Failed to "
+			    "get callback cbc %p "
+			    "refs %d", __func__, cbc, cbc->refcnt);
+		}
 	}
-	mutex_destroy(&lock);
+
+	if (ret) {
+		cbc_release_it(cbc);
+		SVC_DESTROY(&xprt->sm_dr.xprt);
+	}
+
+	/* Release here since we wait for callback */
+	SVC_RELEASE(&xprt->sm_dr.xprt, SVC_RELEASE_FLAG_NONE);
+
+	pthread_mutex_unlock(&cbc->cb_done_mutex);
 
 	return ret;
 }
@@ -715,21 +729,28 @@ static int
 xdr_rdma_wait_write_cb(RDMAXPRT *xprt, struct rpc_rdma_cbc *cbc, int sge,
 		      struct xdr_rdma_segment *rs)
 {
-	mutex_t lock = MUTEX_INITIALIZER;
 	int ret;
 
-	cbc->positive_cb = xdr_rdma_wait_callback;
-	cbc->negative_cb = xdr_rdma_warn_callback;
-	cbc->callback_arg = &lock;
+	cbc->positive_cb = xdr_rdma_respond_callback_send;
+	cbc->negative_cb = xdr_rdma_destroy_callback_send;
+	cbc->callback_arg = NULL;
+	cbc->call_inline = 1;
 
-	mutex_lock(&lock);
+	cbc_ref_it(cbc);
+
+	SVC_REF(&xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
+
 	ret = xdr_rdma_post_send_n(xprt, cbc, sge, rs, IBV_WR_RDMA_WRITE);
 
-	if (!ret) {
-		mutex_lock(&lock);
-		mutex_unlock(&lock);
+	if (ret) {
+		/* Assuming there won't be callback */
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: failed ret %d err %d "
+			" xprt %p cbc %p", __func__, ret, errno, xprt, cbc);
+		cbc_release_it(cbc);
+
+		SVC_DESTROY(&xprt->sm_dr.xprt);
+		SVC_RELEASE(&xprt->sm_dr.xprt, SVC_RELEASE_FLAG_NONE);
 	}
-	mutex_destroy(&lock);
 
 	return ret;
 }
@@ -747,16 +768,20 @@ typedef struct xdr_write_list wl_t;
 static inline void
 xdr_rdma_skip_read_list(uint32_t **pptr)
 {
+	uint32_t *ptr1 = *pptr;
 	while (rl(*pptr)->present) {
 		*pptr += sizeof(struct xdr_read_list)
 			 / sizeof(**pptr);
 	}
 	(*pptr)++;
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: ptr1 %p ptr2 %p diff %d", __func__, ptr1, *pptr, (*pptr) - ptr1);
 }
 
 static inline void
 xdr_rdma_skip_write_list(uint32_t **pptr)
 {
+	uint32_t *ptr1 = *pptr;
 	if (wl(*pptr)->present) {
 		*pptr += (sizeof(struct xdr_write_list)
 			  + sizeof(struct xdr_write_chunk)
@@ -764,11 +789,13 @@ xdr_rdma_skip_write_list(uint32_t **pptr)
 			 / sizeof(**pptr);
 	}
 	(*pptr)++;
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: ptr1 %p ptr2 %p diff %d", __func__, ptr1, *pptr, (*pptr) - ptr1);
 }
 
 static inline void
 xdr_rdma_skip_reply_array(uint32_t **pptr)
 {
+	uint32_t *ptr1 = *pptr;
 	if (wl(*pptr)->present) {
 		*pptr += (sizeof(struct xdr_write_list)
 			  + sizeof(struct xdr_write_chunk)
@@ -777,6 +804,7 @@ xdr_rdma_skip_reply_array(uint32_t **pptr)
 	} else {
 		(*pptr)++;
 	}
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: ptr1 %p ptr2 %p diff %d", __func__, ptr1, *pptr, (*pptr) - ptr1);
 }
 
 static inline uint32_t *
@@ -848,97 +876,289 @@ xdr_rdma_encode_error(struct xdr_ioq_uv *call_uv, enum rpcrdma_errcode err)
 	call_uv->v.vio_tail = (uint8_t *)va;
 }
 
-#ifdef UNUSED
-void
-xdr_rdma_encode_reply_array(wl_t *ary, int chunks)
-{
-	ary->present = xdr_one;
-	ary->elements = htonl(chunks);
-}
-
-void
-xdr_rdma_encode_array_chunk(wl_t *ary, int chunk_no, u32 handle,
-			    u64 offset, u32 write_len)
-{
-	struct xdr_rdma_segment *seg = &ary->entry[chunk_no].target;
-	seg->handle = htonl(handle);
-	seg->length = htonl(write_len);
-	xdr_encode_hyper((u32 *) &seg->offset, offset);
-}
-
-void
-xdr_rdma_encode_reply_header(struct svcxprt_rdma *xprt,
-				  struct rdma_msg *rdma_argp,
-				  struct rdma_msg *rdma_resp,
-				  enum rdma_proc rdma_type)
-{
-	rdma_resp->rdma_xid = htonl(rdma_argp->rdma_xid);
-	rdma_resp->rdma_vers = htonl(rdma_argp->rdma_vers);
-	rdma_resp->rdma_credit = htonl(xprt->sc_max_requests);
-	rdma_resp->rdma_type = htonl(rdma_type);
-
-	/* Encode <nul> chunks lists */
-	rdma_resp->rdma_body.rm_chunks[0] = xdr_zero;
-	rdma_resp->rdma_body.rm_chunks[1] = xdr_zero;
-	rdma_resp->rdma_body.rm_chunks[2] = xdr_zero;
-}
-#endif /* UNUSED */
-
-/* post recv buffers.
- * keep at least 2 spare waiting for calls,
- * the remainder can be used for incoming rdma buffers.
- */
+/* post recv buffers */
 void
 xdr_rdma_callq(RDMAXPRT *xd)
 {
+	/* Get context buf from cbqh and add to sm_dr
+	 * rpc_rdma_allocate->xdr_ioq_setup(&xd->sm_dr.ioq);
+	 * Check if we have credits availabled from cbqh
+	 * rpc_rdma_setup_cbq
+	 * rc = rpc_rdma_setup_cbq(&xd->cbqh,
+	 * xd->xa->rq_depth + xd->xa->sq_depth, xd->xa->credits);
+	 * Remove from cbqh and add to sm_dr.ioq */
+
 	struct poolq_entry *have =
-		xdr_ioq_uv_fetch(&xd->sm_dr.ioq, &xd->cbqh,
+		xdr_rdma_ioq_uv_fetch(&xd->sm_dr.ioq, &xd->cbqh,
 				 "callq context", 1, IOQ_FLAG_NONE);
 	struct rpc_rdma_cbc *cbc = (struct rpc_rdma_cbc *)(_IOQ(have));
 
-	have = xdr_ioq_uv_fetch(&cbc->workq, &xd->inbufs.uvqh,
+	cbc->recvq.xdrs[0].x_lib[1] =
+	cbc->sendq.xdrs[0].x_lib[1] =
+	cbc->dataq.xdrs[0].x_lib[1] =
+	cbc->freeq.xdrs[0].x_lib[1] = xd;
+
+	/* Get recv buf from inbufs_hdr and  add to context recvq */
+	have = xdr_rdma_ioq_uv_fetch(&cbc->recvq, &xd->inbufs_hdr.uvqh,
 				"callq buffer", 1, IOQ_FLAG_NONE);
 
 	/* input positions */
 	IOQ_(have)->v.vio_head = IOQ_(have)->v.vio_base;
 	IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_wrap;
 	IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base
-			       + xd->sm_dr.recvsz;
+			       + xd->sm_dr.recv_hdr_sz;
 
-	cbc->workq.xdrs[0].x_lib[1] =
-	cbc->holdq.xdrs[0].x_lib[1] = xd;
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc_track start %p recvq %p %d "
+		"sendq %p %d dataq %p %d freeq %p %d ioq %p %d xd %p",
+		__func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount,
+		&cbc->sendq, cbc->sendq.ioq_uv.uvqh.qcount, &cbc->dataq,
+		cbc->dataq.ioq_uv.uvqh.qcount, &cbc->freeq,
+		cbc->freeq.ioq_uv.uvqh.qcount, &xd->sm_dr.ioq,
+		xd->sm_dr.ioq.ioq_uv.uvqh.qcount, xd);
 
-	xdr_rdma_post_recv_cb(xd, cbc, 1);
+	cbc->call_inline = 0;
+	cbc->data_chunk_uv = NULL;
+	cbc->refcnt = 1; // Senital ref
+	cbc->cbc_flags = CBC_FLAG_NONE;
+	cbc->non_registered_buf = NULL;
+	cbc->non_registered_buf_len = 0;
+
+	pthread_mutex_lock(&xd->cbclist.qmutex);
+	TAILQ_INSERT_TAIL(&xd->cbclist.qh, &cbc->cbc_list, q);
+	xd->cbclist.qcount++;
+	pthread_mutex_unlock(&xd->cbclist.qmutex);
+
+	/* xprt ref is taken by xdr_rdma_post_recv_cb */
+	if (xdr_rdma_post_recv_cb(xd, cbc, 1)) {
+		 __warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: recv failed %p",
+			__func__, xd);
+	}
 }
 
 /****************************/
 /****** Main functions ******/
 /****************************/
 
-void
-xdr_rdma_destroy(RDMAXPRT *xd)
+/* Split b_addr into buf_count chunks of size buf_size and
+ * add it to uv_head */
+static void
+xdr_rdma_add_bufs(RDMAXPRT *xd, struct ibv_mr *mr,
+    struct xdr_ioq_uv_head *uv_head, xdr_ioq_uv_type_t buf_type,
+    uint32_t buf_size, uint32_t buf_count, uint8_t *b_addr)
 {
-	if (xd->mr) {
-		ibv_dereg_mr(xd->mr);
-		xd->mr = NULL;
+
+	/* Each pre-allocated buffer has a corresponding xdr_ioq_uv,
+	 * stored on the pool queues.
+	 */
+
+	pthread_mutex_lock(&uv_head->uvqh.qmutex);
+
+	for (int qcount = 0;
+	     qcount < buf_count;
+	     qcount++) {
+		struct xdr_ioq_uv *data = xdr_ioq_uv_create(0, UIO_FLAG_BUFQ);
+
+		assert(data);
+
+		data->rdma_uv = 1;
+
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
+			"%s() recvbuf at %p base %p",
+			__func__, data, b_addr);
+
+		data->v.vio_base =
+		data->v.vio_head =
+		data->v.vio_tail = b_addr;
+		data->v.vio_wrap = (char *)b_addr + buf_size;
+		data->rdma_v = data->v;
+		data->u.uio_p1 = &uv_head->uvqh;
+		data->u.uio_p2 = mr;
+		data->rdma_u = data->u;
+		data->uv_type = buf_type;
+		TAILQ_INSERT_TAIL(&uv_head->uvqh.qh, &data->uvq, q);
+		uv_head->uvqh.qcount++;
+
+		b_addr += buf_size;
 	}
 
-	xdr_ioq_destroy_pool(&xd->sm_dr.ioq.ioq_uv.uvqh);
+	pthread_mutex_unlock(&uv_head->uvqh.qmutex);
+}
 
-	/* must be after queues, xdr_ioq_destroy() moves them here */
-	xdr_ioq_release(&xd->inbufs.uvqh);
-	poolq_head_destroy(&xd->inbufs.uvqh);
-	xdr_ioq_release(&xd->outbufs.uvqh);
-	poolq_head_destroy(&xd->outbufs.uvqh);
+/* Add on demand allocated buffers to the extra_bufs */
+static void
+xdr_rdma_update_extra_bufs(RDMAXPRT *xd, struct ibv_mr *mr, uint32_t buffer_total,
+    uint8_t *buffer_aligned, rpc_extra_io_buf_type_t type)
+{
 
-	/* must be after pools */
-	if (xd->buffer_aligned) {
-		mem_free(xd->buffer_aligned, xd->buffer_total);
-		xd->buffer_aligned = NULL;
-	}
+	pthread_mutex_lock(&xd->extra_bufs.qmutex);
 
-	xd->sm_dr.ioq.xdrs[0].x_lib[0] = NULL;
-	xd->sm_dr.ioq.xdrs[0].x_lib[1] = NULL;
+	xd->extra_bufs.qsize = sizeof(struct rpc_extra_io_bufs);
+
+	struct rpc_extra_io_bufs *io_buf =
+	    mem_zalloc(xd->extra_bufs.qsize);
+
+	assert(io_buf);
+
+	io_buf->mr = mr;
+	io_buf->buffer_total = buffer_total;
+	io_buf->buffer_aligned = buffer_aligned;
+	io_buf->type = type;
+
+	TAILQ_INSERT_TAIL(&xd->extra_bufs.qh, &io_buf->q, q);
+
+	xd->extra_bufs_count++;
+	xd->extra_bufs.qcount++;
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() extra bufs count %u io_buf %p xd %p",
+		__func__, xd->extra_bufs_count, io_buf, xd);
+
+	pthread_mutex_unlock(&xd->extra_bufs.qmutex);
+}
+
+static struct ibv_mr *
+xdr_rdma_reg_mr(RDMAXPRT *xd, uint8_t *buffer_aligned, uint32_t buffer_total)
+{
+	return ibv_reg_mr(xd->pd->pd, buffer_aligned, buffer_total,
+			    IBV_ACCESS_LOCAL_WRITE |
+			    IBV_ACCESS_REMOTE_WRITE |
+			    IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC);
+}
+
+void
+xdr_rdma_add_outbufs_hdr(RDMAXPRT *xd)
+{
+	uint8_t *b;
+	int hdr_qdepth = RDMA_HDR_CHUNKS;
+	uint32_t buffer_total = xd->sm_dr.send_hdr_sz * hdr_qdepth;
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_total  %llu, sendsz %llu sq %llu xd %p pagesz %llu",
+		__func__, buffer_total, xd->sm_dr.send_hdr_sz, hdr_qdepth,
+		xd, xd->sm_dr.pagesz);
+
+	uint8_t *buffer_aligned = mem_aligned(xd->sm_dr.pagesz, buffer_total);
+
+	assert(buffer_aligned);
+	memset(buffer_aligned, 0, buffer_total);
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_aligned at %p proptection domain %p xd %p",
+		__func__, buffer_aligned, xd->pd->pd, xd);
+
+	struct ibv_mr *mr = xdr_rdma_reg_mr(xd, buffer_aligned, buffer_total);
+
+	assert(mr);
+
+	b = buffer_aligned;
+
+	xdr_rdma_add_bufs(xd, mr, &xd->outbufs_hdr, UV_HDR,
+	    xd->sm_dr.send_hdr_sz, hdr_qdepth, b);
+
+	xdr_rdma_update_extra_bufs(xd, mr, buffer_total, buffer_aligned,
+	    IO_OUTBUF);
+}
+
+void
+xdr_rdma_add_outbufs_data(RDMAXPRT *xd)
+{
+	uint8_t *b;
+	int data_qdepth = RDMA_DATA_CHUNKS;
+	uint32_t buffer_total = xd->sm_dr.sendsz * data_qdepth;
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_total  %llu, sendsz %llu sq %llu xd %p pagesz %llu",
+		__func__, buffer_total, xd->sm_dr.sendsz, data_qdepth,
+		xd, xd->sm_dr.pagesz);
+
+	uint8_t *buffer_aligned = mem_aligned(xd->sm_dr.pagesz, buffer_total);
+
+	assert(buffer_aligned);
+	memset(buffer_aligned, 0, buffer_total);
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_aligned at %p proptection domain %p xd %p",
+		__func__, buffer_aligned, xd->pd->pd, xd);
+
+	struct ibv_mr *mr = xdr_rdma_reg_mr(xd, buffer_aligned, buffer_total);
+
+	assert(mr);
+
+	b = buffer_aligned;
+
+	xdr_rdma_add_bufs(xd, mr, &xd->outbufs_data, UV_DATA,
+	    xd->sm_dr.sendsz, data_qdepth, b);
+
+	xdr_rdma_update_extra_bufs(xd, mr, buffer_total, buffer_aligned,
+	    IO_OUTBUF);
+}
+
+void
+xdr_rdma_add_inbufs_hdr(RDMAXPRT *xd)
+{
+	uint8_t *b;
+	int hdr_qdepth = RDMA_HDR_CHUNKS;
+	uint32_t buffer_total = xd->sm_dr.recv_hdr_sz * hdr_qdepth;
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_total  %llu, recvsz %llu rq %llu xd %p pagesz %llu",
+		__func__, buffer_total, xd->sm_dr.recv_hdr_sz, hdr_qdepth,
+		xd, xd->sm_dr.pagesz);
+
+	uint8_t *buffer_aligned = mem_aligned(xd->sm_dr.pagesz, buffer_total);
+
+	assert(buffer_aligned);
+	memset(buffer_aligned, 0, buffer_total);
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_aligned at %p proptection domain %p xd %p",
+		__func__, buffer_aligned, xd->pd->pd, xd);
+
+	struct ibv_mr *mr = xdr_rdma_reg_mr(xd, buffer_aligned, buffer_total);
+
+	assert(mr);
+
+	b = buffer_aligned;
+
+	xdr_rdma_add_bufs(xd, mr, &xd->inbufs_hdr, UV_HDR,
+	    xd->sm_dr.recv_hdr_sz, hdr_qdepth, b);
+
+	xdr_rdma_update_extra_bufs(xd, mr, buffer_total, buffer_aligned,
+	    IO_INBUF);
+}
+
+void
+xdr_rdma_add_inbufs_data(RDMAXPRT *xd)
+{
+	uint8_t *b;
+	int data_qdepth = RDMA_DATA_CHUNKS;
+	uint32_t buffer_total = xd->sm_dr.recvsz * data_qdepth;
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_total  %llu, recvsz %llu rq %llu xd %p pagesz %llu",
+		__func__, buffer_total, xd->sm_dr.recvsz, data_qdepth,
+		xd, xd->sm_dr.pagesz);
+
+	uint8_t *buffer_aligned = mem_aligned(xd->sm_dr.pagesz, buffer_total);
+
+	assert(buffer_aligned);
+	memset(buffer_aligned, 0, buffer_total);
+
+	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		"%s() buffer_aligned at %p proptection domain %p xd %p",
+		__func__, buffer_aligned, xd->pd->pd, xd);
+
+	struct ibv_mr *mr = xdr_rdma_reg_mr(xd, buffer_aligned, buffer_total);
+
+	assert(mr);
+
+	b = buffer_aligned;
+
+	xdr_rdma_add_bufs(xd, mr, &xd->inbufs_data, UV_DATA,
+	    xd->sm_dr.recvsz, data_qdepth, b);
+
+	xdr_rdma_update_extra_bufs(xd, mr, buffer_total, buffer_aligned,
+	    IO_INBUF);
 }
 
 /*
@@ -950,6 +1170,8 @@ int
 xdr_rdma_create(RDMAXPRT *xd)
 {
 	uint8_t *b;
+	int data_qdepth = RDMA_DATA_CHUNKS;
+	int hdr_qdepth = RDMA_HDR_CHUNKS;
 
 	if (!xd->pd || !xd->pd->pd) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -960,73 +1182,100 @@ xdr_rdma_create(RDMAXPRT *xd)
 
 	/* pre-allocated buffer_total:
 	 * the number of credits is irrelevant here.
+	 * We have kept credits same as outstanding.
+	 * Since there could be more than one buffers
+	 * required for each request, we need higher
+	 * number of buffers than credits.
 	 * instead, allocate buffers to match the read/write contexts.
 	 * more than one buffer can be chained to one ioq_uv head,
 	 * but never need more ioq_uv heads than buffers.
 	 */
-	xd->buffer_total = xd->sm_dr.recvsz * xd->xa->rq_depth
-			 + xd->sm_dr.sendsz * xd->xa->sq_depth;
+	size_t total_hdr_sz = RDMA_HDR_CHUNK_SZ * (RDMA_HDR_CHUNKS * 2);
+	size_t tirpc_buff_total = xd->sm_dr.recvsz * data_qdepth
+				  + xd->sm_dr.sendsz * data_qdepth;
+
+	xd->buffer_total = tirpc_buff_total + total_hdr_sz;
+
+	__warnx(TIRPC_DEBUG_FLAG_EVENT,
+		"%s() buffer_total %llu(%llu + %llu), xd %p pagesz %llu "
+		"recvsz data %llu hdr %llu rq %llu "
+		"sendsz data %llu hdr %llu sq %llu",
+		__func__, xd->buffer_total,
+		tirpc_buff_total, total_hdr_sz, xd, xd->sm_dr.pagesz,
+		xd->sm_dr.recvsz, xd->sm_dr.recv_hdr_sz, data_qdepth,
+		xd->sm_dr.sendsz, xd->sm_dr.send_hdr_sz, data_qdepth);
 
 	xd->buffer_aligned = mem_aligned(xd->sm_dr.pagesz, xd->buffer_total);
 
-	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
-		"%s() buffer_aligned at %p",
-		__func__, xd->buffer_aligned);
+	assert(xd->buffer_aligned);
+	memset(xd->buffer_aligned, 0, xd->buffer_total);
 
-	/* register it in two chunks for read and write??? */
-	xd->mr = ibv_reg_mr(xd->pd->pd, xd->buffer_aligned, xd->buffer_total,
-			    IBV_ACCESS_LOCAL_WRITE |
-			    IBV_ACCESS_REMOTE_WRITE |
-			    IBV_ACCESS_REMOTE_READ);
+	__warnx(TIRPC_DEBUG_FLAG_EVENT,
+		"%s() buffer_aligned at %p protection domain %p xd %p",
+		__func__, xd->buffer_aligned, xd->pd->pd, xd);
 
-	poolq_head_setup(&xd->inbufs.uvqh);
-	xd->inbufs.min_bsize = xd->sm_dr.pagesz;
-	xd->inbufs.max_bsize = xd->sm_dr.recvsz;
+	xd->mr = xdr_rdma_reg_mr(xd, xd->buffer_aligned,
+	    xd->buffer_total);
 
-	poolq_head_setup(&xd->outbufs.uvqh);
-	xd->outbufs.min_bsize = xd->sm_dr.pagesz;
-	xd->outbufs.max_bsize = xd->sm_dr.sendsz;
+	assert(xd->mr);
 
-	/* Each pre-allocated buffer has a corresponding xdr_ioq_uv,
-	 * stored on the pool queues.
-	 */
+	xd->sm_dr.xprt.xp_rdma = true;
+
+	poolq_head_setup(&xd->inbufs_data.uvqh);
+	xd->inbufs_data.min_bsize = xd->sm_dr.pagesz;
+	xd->inbufs_data.max_bsize = xd->sm_dr.recvsz;
+
+	poolq_head_setup(&xd->outbufs_data.uvqh);
+	xd->outbufs_data.min_bsize = xd->sm_dr.pagesz;
+	xd->outbufs_data.max_bsize = xd->sm_dr.sendsz;
+
+	poolq_head_setup(&xd->inbufs_hdr.uvqh);
+	xd->inbufs_hdr.min_bsize = xd->sm_dr.pagesz;
+	xd->inbufs_hdr.max_bsize = xd->sm_dr.recv_hdr_sz;
+
+	poolq_head_setup(&xd->outbufs_hdr.uvqh);
+	xd->outbufs_hdr.min_bsize = xd->sm_dr.pagesz;
+	xd->outbufs_hdr.max_bsize = xd->sm_dr.send_hdr_sz;
+
 	b = xd->buffer_aligned;
 
-	for (xd->inbufs.uvqh.qcount = 0;
-	     xd->inbufs.uvqh.qcount < xd->xa->rq_depth;
-	     xd->inbufs.uvqh.qcount++) {
-		struct xdr_ioq_uv *data = xdr_ioq_uv_create(0, UIO_FLAG_BUFQ);
+	xdr_rdma_add_bufs(xd, xd->mr, &xd->inbufs_data, UV_DATA,
+	    xd->sm_dr.recvsz, data_qdepth, b);
+	b = b + (data_qdepth * xd->sm_dr.recvsz);
 
-		data->v.vio_base =
-		data->v.vio_head =
-		data->v.vio_tail = b;
-		data->v.vio_wrap = (char *)b + xd->sm_dr.recvsz;
-		data->u.uio_p1 = &xd->inbufs.uvqh;
-		data->u.uio_p2 = xd->mr;
-		TAILQ_INSERT_TAIL(&xd->inbufs.uvqh.qh, &data->uvq, q);
+	xdr_rdma_add_bufs(xd, xd->mr, &xd->outbufs_data, UV_DATA,
+	    xd->sm_dr.sendsz, data_qdepth, b);
+	b = b + (data_qdepth * xd->sm_dr.sendsz);
 
-		b += xd->sm_dr.recvsz;
-	}
+	xdr_rdma_add_bufs(xd, xd->mr, &xd->inbufs_hdr, UV_HDR,
+	    xd->sm_dr.recv_hdr_sz, hdr_qdepth, b);
+	b = b + (hdr_qdepth * xd->sm_dr.recv_hdr_sz);
 
-	for (xd->outbufs.uvqh.qcount = 0;
-	     xd->outbufs.uvqh.qcount < xd->xa->sq_depth;
-	     xd->outbufs.uvqh.qcount++) {
-		struct xdr_ioq_uv *data = xdr_ioq_uv_create(0, UIO_FLAG_BUFQ);
+	xdr_rdma_add_bufs(xd, xd->mr, &xd->outbufs_hdr, UV_HDR,
+	    xd->sm_dr.send_hdr_sz, hdr_qdepth, b);
+	b = b + (hdr_qdepth * xd->sm_dr.send_hdr_sz);
 
-		data->v.vio_base =
-		data->v.vio_head =
-		data->v.vio_tail = b;
-		data->v.vio_wrap = (char *)b + xd->sm_dr.sendsz;
-		data->u.uio_p1 = &xd->outbufs.uvqh;
-		data->u.uio_p2 = xd->mr;
-		TAILQ_INSERT_TAIL(&xd->outbufs.uvqh.qh, &data->uvq, q);
+	poolq_head_setup(&xd->extra_bufs);
+	xd->extra_bufs_count = 0;
 
-		b += xd->sm_dr.sendsz;
-	}
+	/* Keep enough cbc available to serve cbc allocation.
+	 * We allocate MAX_CBC_OUTSTANDING * 2 cbcs.
+	 * we could have max cbcs required will be callq_size * 2 */
+	int callq_size = MAX_RECV_OUTSTANDING;
 
-	while (xd->sm_dr.ioq.ioq_uv.uvqh.qcount < CALLQ_SIZE) {
+	__warnx(TIRPC_DEBUG_FLAG_EVENT, "callq size %d", callq_size);
+
+	poolq_head_setup(&xd->cbclist);
+
+	while (xd->sm_dr.ioq.ioq_uv.uvqh.qcount < callq_size) {
+		/* Post callq_size buffers to do first recvs
+		 * callback will be done on recv which should rearam again */
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
+			"%s() qcount %d callq size %d",
+			__func__, xd->sm_dr.ioq.ioq_uv.uvqh.qcount);
 		xdr_rdma_callq(xd);
 	}
+
 	return 0;
 }
 
@@ -1034,7 +1283,7 @@ xdr_rdma_create(RDMAXPRT *xd)
  *
  * Client prepares for a reply
  *
- * potential output buffers are queued in workq.
+ * potential output buffers are queued in recvq.
  *
  * @param[IN] xdrs	cm_data
  *
@@ -1057,7 +1306,7 @@ xdr_rdma_clnt_reply(XDR *xdrs, u_int32_t xid)
 	}
 	xprt = x_xprt(xdrs);
 
-	work_uv = IOQ_(TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh));
+	work_uv = IOQ_(TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh));
 	rpcrdma_dump_msg(work_uv, "creply head", htonl(xid));
 
 	reply_array = (wl_t *)xdr_rdma_get_reply_array(work_uv->v.vio_head);
@@ -1077,7 +1326,7 @@ xdr_rdma_clnt_reply(XDR *xdrs, u_int32_t xid)
 			 * failing if no match. add a zero timeout
 			 * when implemented
 			 */
-			have = xdr_ioq_uv_fetch(&cbc->holdq, &xprt->inbufs.uvqh,
+			have = xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xprt->inbufs_data.uvqh,
 				"creply body", 1, IOQ_FLAG_NONE);
 			rpcrdma_dump_msg(IOQ_(have), "creply body", ntohl(xid));
 
@@ -1088,7 +1337,7 @@ xdr_rdma_clnt_reply(XDR *xdrs, u_int32_t xid)
 		}
 	}
 
-	xdr_ioq_reset(&cbc->holdq, 0);
+	xdr_ioq_reset(&cbc->sendq, 0);
 	return (true);
 }
 
@@ -1100,7 +1349,7 @@ xdr_rdma_clnt_reply(XDR *xdrs, u_int32_t xid)
  * but clones call rdma header in place for future use.
  *
  * @param[IN] cbc	incoming request
- *			call request is in workq
+ *			call request is in recvq
  *
  * called by svc_rdma_recv()
  */
@@ -1109,8 +1358,9 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 {
 	RDMAXPRT *xprt;
 	struct rdma_msg *cmsg;
-	uint32_t k;
 	uint32_t l;
+	bool ret = true;
+
 
 	if (!cbc) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -1118,14 +1368,33 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 			__func__);
 		return (false);
 	}
-	xprt = x_xprt(cbc->workq.xdrs);
 
-	/* free old buffers (should do nothing) */
-	xdr_ioq_release(&cbc->holdq.ioq_uv.uvqh);
+	/* Both sendq and recvq (xdrs)->x_lib[1] points to xprt */
+	xprt = x_xprt(cbc->recvq.xdrs);
+
+	if (xprt->sm_dr.xprt.xp_flags & SVC_XPRT_FLAG_DESTROYED) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, " %s xprt %p cbc %p "
+		    "already destroyed", __func__, xprt, cbc);
+		return false;
+	}
+
+        __warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc %p recvq %p %d sendq %p %d "
+		"dataq %p %d xd %p",
+                __func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount, &cbc->sendq,
+                cbc->sendq.ioq_uv.uvqh.qcount, &cbc->dataq, cbc->dataq.ioq_uv.uvqh.qcount,
+		xprt);
+
+	/* recvq will have request header part */
+	assert(cbc->recvq.ioq_uv.uvqh.qcount == 1);
+	assert(cbc->sendq.ioq_uv.uvqh.qcount == 0);
+	assert(cbc->dataq.ioq_uv.uvqh.qcount == 0);
+	assert(cbc->freeq.ioq_uv.uvqh.qcount == 0);
+
+	/* Maintain max_outstanding */
 	xdr_rdma_callq(xprt);
 
-	cbc->call_uv = IOQ_(TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh));
-	(cbc->call_uv->u.uio_references)++;
+	/* Get inbuf from recvq */
+	cbc->call_uv = IOQ_(TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh));
 	cbc->call_head = cbc->call_uv->v.vio_head;
 	cmsg = m_(cbc->call_head);
 	rpcrdma_dump_msg(cbc->call_uv, "call", cmsg->rdma_xid);
@@ -1138,8 +1407,8 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 			"%s() rdma_vers %" PRIu32 "?",
 			__func__, ntohl(cmsg->rdma_vers));
 		xdr_rdma_encode_error(cbc->call_uv, RDMA_ERR_VERS);
+		cbc->have = TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh);
 		xdr_rdma_post_send_cb(xprt, cbc, 1);
-		xdr_ioq_uv_release(cbc->call_uv);
 		return (false);
 	}
 
@@ -1152,13 +1421,18 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 			"%s() rdma_type %" PRIu32 "?",
 			__func__, ntohl(cmsg->rdma_type));
 		xdr_rdma_encode_error(cbc->call_uv, RDMA_ERR_BADHEADER);
+		cbc->have = TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh);
 		xdr_rdma_post_send_cb(xprt, cbc, 1);
-		xdr_ioq_uv_release(cbc->call_uv);
 		return (false);
 	}
 
 	/* locate NFS/RDMA (RFC-5666) chunk positions */
 	cbc->read_chunk = xdr_rdma_get_read_list(cmsg);
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s:%d read chunk %p present %u position %u",
+		__func__, __LINE__, cbc->read_chunk, rl(cbc->read_chunk)->present,
+		rl(cbc->read_chunk)->position);
+
 	cbc->write_chunk = (wl_t *)cbc->read_chunk;
 	xdr_rdma_skip_read_list((uint32_t **)&cbc->write_chunk);
 	cbc->reply_chunk = cbc->write_chunk;
@@ -1166,59 +1440,179 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 	cbc->call_data = cbc->reply_chunk;
 	xdr_rdma_skip_reply_array((uint32_t **)&cbc->call_data);
 
-	/* swap calling message from workq to holdq */
-	TAILQ_CONCAT(&cbc->holdq.ioq_uv.uvqh.qh, &cbc->workq.ioq_uv.uvqh.qh, q);
-	cbc->holdq.ioq_uv.uvqh.qcount = cbc->workq.ioq_uv.uvqh.qcount;
-	cbc->workq.ioq_uv.uvqh.qcount = 0;
+	struct xdr_write_list *reply_array = (wl_t *)cbc->reply_chunk;
+	bool data_chunk = 0;
 
-	/* skip past the header for the calling buffer */
-	xdr_ioq_reset(&cbc->holdq, ((uintptr_t)cbc->call_data
+	/* We need data_chunk for read/readdir in 2 cases
+	 * 1> read/readdir with reply/write list.
+	 * 2> read/readdir without reply/write list.
+	 * If reply/write list not present we allocate
+	 * data_chunk by default since we don't know which request we
+	 * received, in this case we allocate data_chunk of smaller
+	 * size */
+	if (reply_array->present == 0) {
+		reply_array = (wl_t *)cbc->write_chunk;
+		if (reply_array->present) {
+			/* Allocate data_chunk of larger size if write_chunks
+			 * are requested for rdma_write to serve NFS reads */
+			data_chunk = 1;
+		}
+	} else {
+		/* Allocate data_chunk of larget size if reply_chunks
+		 * requested for rdma_write to serve NFS readdir */
+		data_chunk = 1;
+	}
+
+	/* Allocate data buffer for read/readdir */
+	if (data_chunk) {
+		struct xdr_ioq_uv *data_chunk_uv = IOQ_(xdr_rdma_ioq_uv_fetch(&cbc->dataq,
+		    &xprt->outbufs_data.uvqh,
+		    "sreply data_chunk_L", 1, IOQ_FLAG_NONE));
+
+		/* entry was already added directly to the queue */
+		data_chunk_uv->v.vio_head = data_chunk_uv->v.vio_tail =
+		    data_chunk_uv->v.vio_base;
+		/* tail adjusted below */
+		data_chunk_uv->v.vio_wrap = (char *)data_chunk_uv->v.vio_base +
+		    xprt->sm_dr.sendsz;
+
+		cbc->data_chunk_uv = data_chunk_uv;
+		__warnx(TIRPC_DEBUG_FLAG_XDR, "data_chunk_uv data %p cbc %p",
+		    data_chunk_uv, cbc);
+	} else {
+		/* For read/readdir without reply/write list, we should not need
+		 * big buffer */
+		struct xdr_ioq_uv *data_chunk_uv = IOQ_(xdr_rdma_ioq_uv_fetch(&cbc->dataq,
+		    &xprt->outbufs_hdr.uvqh,
+		    "sreply data_chunk_S", 1, IOQ_FLAG_NONE));
+
+		/* entry was already added directly to the queue */
+		data_chunk_uv->v.vio_head = data_chunk_uv->v.vio_tail =
+		    data_chunk_uv->v.vio_base;
+		/* tail adjusted below */
+		data_chunk_uv->v.vio_wrap = (char *)data_chunk_uv->v.vio_base +
+		    xprt->sm_dr.send_hdr_sz;
+
+		cbc->data_chunk_uv = data_chunk_uv;
+		__warnx(TIRPC_DEBUG_FLAG_XDR, "data_chunk_uv hdr %p cbc %p",
+		    data_chunk_uv, cbc);
+	}
+
+
+	/* skip past the header for the calling buffer
+	 * xdr_ioq_reset->xdr_ioq_uv_reset set the xdrs point to buf
+	 * Set xdr in sendq for decoding.
+	 * xioq->xdrs[0].x_data = uv->v.vio_head; */
+	xdr_ioq_reset(&cbc->recvq, ((uintptr_t)cbc->call_data
 				  - (uintptr_t)cmsg));
 
-	while (rl(cbc->read_chunk)->present != 0
-	    && rl(cbc->read_chunk)->position == 0) {
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s read chunk %p present %u "
+		"position %u reply chunk %p reply chunk present %d write "
+		"chunk %p write chunk present %d",
+		__func__, cbc->read_chunk, rl(cbc->read_chunk)->present,
+		rl(cbc->read_chunk)->position, cbc->reply_chunk,
+		wl(cbc->reply_chunk)->present, cbc->write_chunk,
+		wl(cbc->write_chunk)->present);
+
+	pthread_mutex_lock(&cbc->recvq.ioq_uv.uvqh.qmutex);
+	TAILQ_REMOVE(&cbc->recvq.ioq_uv.uvqh.qh, &cbc->call_uv->uvq, q);
+	(cbc->recvq.ioq_uv.uvqh.qcount)--;
+	pthread_mutex_unlock(&cbc->recvq.ioq_uv.uvqh.qmutex);
+
+	assert(cbc->recvq.ioq_uv.uvqh.qcount == 0);
+
+	while (rl(cbc->read_chunk)->present && ret) {
 		l = ntohl(rl(cbc->read_chunk)->target.length);
-		k = xdr_rdma_chunk_fetch(&cbc->workq, &xprt->inbufs.uvqh,
-					 "call chunk", l,
-					 xprt->sm_dr.recvsz,
-					 xprt->xa->max_recv_sge,
-					 xdr_rdma_chunk_in);
 
-		xdr_rdma_wait_read_cb(xprt, cbc, k, &rl(cbc->read_chunk)->target);
-		rpcrdma_dump_msg(IOQ_(TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh)),
-				 "call chunk", cmsg->rdma_xid);
+		__warnx(TIRPC_DEBUG_FLAG_XDR,
+			"%s() length %u",
+			__func__, l);
 
-		/* concatenate any additional buffers after the calling message,
-		 * faking there is more call data in the calling buffer.
-		 */
-		TAILQ_CONCAT(&cbc->holdq.ioq_uv.uvqh.qh,
-			     &cbc->workq.ioq_uv.uvqh.qh, q);
-		cbc->holdq.ioq_uv.uvqh.qcount += cbc->workq.ioq_uv.uvqh.qcount;
-		cbc->workq.ioq_uv.uvqh.qcount = 0;
+		assert(l <= xprt->sm_dr.recvsz);
+
+		struct xdr_ioq_uv *data_chunk_uv = IOQ_(xdr_rdma_ioq_uv_fetch(&cbc->recvq,
+		    &xprt->inbufs_data.uvqh,
+		    "sreply rdma_read", 1, IOQ_FLAG_NONE));
+
+		/* entry was already added directly to the queue */
+		data_chunk_uv->v.vio_head = data_chunk_uv->v.vio_tail =
+		    data_chunk_uv->v.vio_base;
+
+		/* tail adjusted below */
+		data_chunk_uv->v.vio_wrap = (char *)data_chunk_uv->v.vio_base + l;
+
+		data_chunk_uv->v.vio_tail = (char *)data_chunk_uv->v.vio_head + l;
+
+		cbc->have = TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh);
+
+		if (xdr_rdma_wait_read_cb(xprt, cbc, 1, &rl(cbc->read_chunk)->target)) {
+			__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: rdma_read failed xprt %p "
+			    "cbc %p", __func__, xprt, cbc);
+			ret = false;
+		}
+
+		pthread_mutex_lock(&cbc->recvq.ioq_uv.uvqh.qmutex);
+		pthread_mutex_lock(&cbc->freeq.ioq_uv.uvqh.qmutex);
+
+		TAILQ_CONCAT(&cbc->freeq.ioq_uv.uvqh.qh, &cbc->recvq.ioq_uv.uvqh.qh, q);
+		cbc->freeq.ioq_uv.uvqh.qcount += cbc->recvq.ioq_uv.uvqh.qcount;
+		cbc->recvq.ioq_uv.uvqh.qcount = 0;
+
+		pthread_mutex_unlock(&cbc->freeq.ioq_uv.uvqh.qmutex);
+		pthread_mutex_unlock(&cbc->recvq.ioq_uv.uvqh.qmutex);
+
 		cbc->read_chunk = (char *)cbc->read_chunk
 						+ sizeof(struct xdr_read_list);
 	}
 
-	return (true);
+	pthread_mutex_lock(&cbc->recvq.ioq_uv.uvqh.qmutex);
+	pthread_mutex_lock(&cbc->freeq.ioq_uv.uvqh.qmutex);
+
+	TAILQ_CONCAT(&cbc->recvq.ioq_uv.uvqh.qh, &cbc->freeq.ioq_uv.uvqh.qh, q);
+	cbc->recvq.ioq_uv.uvqh.qcount += cbc->freeq.ioq_uv.uvqh.qcount;
+	cbc->freeq.ioq_uv.uvqh.qcount = 0;
+
+	TAILQ_INSERT_HEAD(&cbc->recvq.ioq_uv.uvqh.qh, &cbc->call_uv->uvq, q);
+	(cbc->recvq.ioq_uv.uvqh.qcount)++;
+
+	/* Now recvq = req_header buf + rdma_read data bufs
+	 * We use recvq xdrs for decoding */
+
+	pthread_mutex_unlock(&cbc->freeq.ioq_uv.uvqh.qmutex);
+	pthread_mutex_unlock(&cbc->recvq.ioq_uv.uvqh.qmutex);
+
+	rpcrdma_dump_msg(IOQ_(TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh)),
+			 "call chunk", cmsg->rdma_xid);
+
+        __warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc %p recvq %p %d "
+		"sendq %p %d freeq %p %d xd %p ",
+                __func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount, &cbc->sendq,
+                cbc->sendq.ioq_uv.uvqh.qcount, &cbc->freeq,
+		cbc->freeq.ioq_uv.uvqh.qcount, xprt);
+
+	return ret;
 }
 
 /** xdr_rdma_svc_reply
  *
  * Server prepares for a reply
  *
- * potential output buffers are queued in workq.
+ * potential output buffers are queued in recvq.
  *
  * @param[IN] cbc	incoming request
- *			call request is in holdq
+ *			call request is in sendq
  *
  * called by svc_rdma_reply()
  */
 bool
-xdr_rdma_svc_reply(struct rpc_rdma_cbc *cbc, u_int32_t xid)
+xdr_rdma_svc_reply(struct rpc_rdma_cbc *cbc, u_int32_t xid,
+    bool rdma_buf_used)
 {
 	RDMAXPRT *xprt;
 	struct xdr_write_list *reply_array;
 	struct poolq_entry *have;
+	bool allocate_header = 0;
+	int write_chunk = 0;
 
 	if (!cbc) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -1226,33 +1620,65 @@ xdr_rdma_svc_reply(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 			__func__);
 		return (false);
 	}
-	xprt = x_xprt(cbc->workq.xdrs);
+	xprt = x_xprt(cbc->recvq.xdrs);
 
-	/* free call buffers (head will be retained) */
-	xdr_ioq_release(&cbc->holdq.ioq_uv.uvqh);
+	if (xprt->sm_dr.xprt.xp_flags & SVC_XPRT_FLAG_DESTROYED) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, " %s xprt %p cbc %p "
+		    "already destroyed", __func__, xprt, cbc);
+		return false;
+	}
+
+        __warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc %p recvq %p %d sendq %p %d xd %p",
+                __func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount, &cbc->sendq,
+                cbc->sendq.ioq_uv.uvqh.qcount, xprt);
 
 	reply_array = (wl_t *)cbc->reply_chunk;
+	 /* For write_chuks we need to allocate seperate buffer for
+	 * RPC header */
 	if (reply_array->present == 0) {
-		/* no reply array to write, replying inline and hope it works
-		 * (OK on RPC/RDMA Read)
-		 */
-		have = xdr_ioq_uv_fetch(&cbc->holdq, &xprt->outbufs.uvqh,
-					"sreply buffer", 1, IOQ_FLAG_NONE);
+		reply_array = (wl_t *)cbc->write_chunk;
+		if (reply_array->present)
+			write_chunk = 1;
+	}
+
+	if (reply_array->present == 0) {
+		/* no reply array to write, replying inline */
+
+		__warnx(TIRPC_DEBUG_FLAG_XDR,
+			"%s() no reply array to write, "
+			"replying inline and hope it works", __func__);
+
+		have = xdr_rdma_ioq_uv_fetch(&cbc->sendq,
+		    &xprt->outbufs_hdr.uvqh,
+		    "sreply buffer", 1, IOQ_FLAG_NONE);
 
 		/* buffer is limited size */
 		IOQ_(have)->v.vio_head =
 		IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
 		IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base
-					+ RFC5666_BUFFER_SIZE;
+					+ xprt->sm_dr.send_hdr_sz;
 
+		/* Should be only set for read and readdir */
+		if (rdma_buf_used) {
+			have = xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xprt->outbufs_hdr.uvqh,
+						"sreply buffer", 1, IOQ_FLAG_NONE);
+
+			/* buffer is limited size */
+			IOQ_(have)->v.vio_head =
+			IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
+			IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base
+						+ xprt->sm_dr.send_hdr_sz;
+		}
 		/* make room at head for RDMA header */
-		xdr_ioq_reset(&cbc->holdq, (uintptr_t)cbc->call_data
-				  - (uintptr_t)cbc->write_chunk
-				  + offsetof(struct rdma_msg, rdma_body));
+		xdr_ioq_reset(&cbc->sendq, 0);
 	} else {
 		uint32_t i;
 		uint32_t l;
 		uint32_t n = ntohl(reply_array->elements);
+
+		__warnx(TIRPC_DEBUG_FLAG_XDR,
+			"%s() reply array to write n %u ",
+			__func__, n);
 
 		if (!n) {
 			__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -1261,20 +1687,58 @@ xdr_rdma_svc_reply(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 			return (false);
 		}
 
+		allocate_header = 1;
+
+		if (allocate_header) {
+			have = xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xprt->outbufs_hdr.uvqh,
+					"sreply buffer", 1, IOQ_FLAG_NONE);
+
+
+			/* buffer is limited size */
+			IOQ_(have)->v.vio_head =
+			IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
+			IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base
+					+ xprt->sm_dr.send_hdr_sz;
+			/* make room at head for RDMA header */
+			xdr_ioq_reset(&cbc->sendq, 0);
+		}
+
 		/* fetch all reply chunks in advance to avoid deadlock
 		 * (there may be more than one)
 		 */
 		for (i = 0; i < n; i++) {
 			l = ntohl(reply_array->entry[i].target.length);
-			xdr_rdma_chunk_fetch(&cbc->holdq, &xprt->outbufs.uvqh,
-					     "sreply chunk", l,
-					     xprt->sm_dr.sendsz,
-					     xprt->xa->max_send_sge,
-					     xdr_rdma_chunk_out);
-		}
+			if (write_chunk) {
+				/* For write_list we get buffer from protocol,
+				 * we need buffer to refer it */
+				have = xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xprt->outbufs_hdr.uvqh,
+				    "sreply buffer", 1, IOQ_FLAG_NONE);
 
-		xdr_ioq_reset(&cbc->holdq, 0);
+				/* buffer is limited size */
+				IOQ_(have)->v.vio_head =
+				IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
+				IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base
+					+ xprt->sm_dr.send_hdr_sz;
+			} else {
+				/* For reply_list we copy from protocol buffer so allocate bigger
+				 * chunk */
+				assert(l <= xprt->sm_dr.sendsz);
+				have = xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xprt->outbufs_data.uvqh,
+				    "sreply buffer", 1, IOQ_FLAG_NONE);
+
+				/* buffer is limited size */
+				IOQ_(have)->v.vio_head =
+				IOQ_(have)->v.vio_tail = IOQ_(have)->v.vio_base;
+				IOQ_(have)->v.vio_wrap = (char *)IOQ_(have)->v.vio_base + l;
+			}
+		}
+		if (!allocate_header)
+			xdr_ioq_reset(&cbc->sendq, 0);
 	}
+
+        __warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc %p recvq %p %d sendq %p %d xd %p",
+                __func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount, &cbc->sendq,
+                cbc->sendq.ioq_uv.uvqh.qcount, xprt);
 
 	return (true);
 }
@@ -1282,7 +1746,7 @@ xdr_rdma_svc_reply(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 /** xdr_rdma_clnt_flushout
  *
  * @param[IN] cbc	combined callback context
- *			call request is in holdq
+ *			call request is in sendq
  *
  * @return true is message sent, false otherwise
  *
@@ -1294,7 +1758,7 @@ xdr_rdma_clnt_flushout(struct rpc_rdma_cbc *cbc)
 /* FIXME: decide how many buffers we use in argument!!!!!! */
 #define num_chunks (xd->xa->credits - 1)
 
-	RDMAXPRT *xd = x_xprt(cbc->workq.xdrs);
+	RDMAXPRT *xd = x_xprt(cbc->recvq.xdrs);
 	struct rpc_msg *msg;
 	struct rdma_msg *rmsg;
 	struct xdr_write_list *w_array;
@@ -1303,9 +1767,9 @@ xdr_rdma_clnt_flushout(struct rpc_rdma_cbc *cbc)
 	struct poolq_entry *have;
 	int i = 0;
 
-	hold_uv = IOQ_(TAILQ_FIRST(&cbc->holdq.ioq_uv.uvqh.qh));
+	hold_uv = IOQ_(TAILQ_FIRST(&cbc->sendq.ioq_uv.uvqh.qh));
 	msg = (struct rpc_msg *)(hold_uv->v.vio_head);
-	xdr_tail_update(cbc->workq.xdrs);
+	xdr_tail_update(cbc->recvq.xdrs);
 
 	switch(ntohl(msg->rm_direction)) {
 	    case CALL:
@@ -1323,12 +1787,12 @@ xdr_rdma_clnt_flushout(struct rpc_rdma_cbc *cbc)
 		return (false);
 	}
 
-	cbc->workq.ioq_uv.uvq_fetch = xdr_ioq_uv_fetch_nothing;
+	cbc->recvq.ioq_uv.uvq_fetch = xdr_rdma_ioq_uv_fetch_nothing;
 
-	head_uv = IOQ_(xdr_ioq_uv_fetch(&cbc->workq, &xd->outbufs.uvqh,
+	head_uv = IOQ_(xdr_rdma_ioq_uv_fetch(&cbc->recvq, &xd->outbufs_data.uvqh,
 					"c_head buffer", 1, IOQ_FLAG_NONE));
 
-	(void)xdr_ioq_uv_fetch(&cbc->holdq, &xd->inbufs.uvqh,
+	(void)xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xd->inbufs_data.uvqh,
 				"call buffers", num_chunks, IOQ_FLAG_NONE);
 
 	rmsg = m_(head_uv->v.vio_head);
@@ -1346,7 +1810,7 @@ xdr_rdma_clnt_flushout(struct rpc_rdma_cbc *cbc)
 	w_array->present = htonl(1);
 	w_array->elements = htonl(num_chunks);
 
-	TAILQ_FOREACH(have, &cbc->holdq.ioq_uv.uvqh.qh, q) {
+	TAILQ_FOREACH(have, &cbc->sendq.ioq_uv.uvqh.qh, q) {
 		struct xdr_rdma_segment *w_seg =
 			&w_array->entry[i++].target;
 		uint32_t length = ioquv_length(IOQ_(have));
@@ -1373,9 +1837,34 @@ xdr_rdma_clnt_flushout(struct rpc_rdma_cbc *cbc)
  * @param[IN] cbc	combined callback context
  *
  * called by svc_rdma_reply()
+ *
+ * This function mainly populate and send response,
+ * 1> Populate rdma header
+ * 2> Popualte NFS header
+ * 3> Do rdma_writes
+ * 4> Do rdma send for response
+ *
+ * rdma_writes can be done for reply/write list.
+ *
+ * For reply_list we send NFS header as part of rdma_write,
+ * for reply list of 1 with length 1k for compound op
+ * rdma_write = nfs_header + nfs_response + data_chunk
+ * We reply in this sequence
+ * rdma_write(nfs_header + nfs_response + data_chunk)
+ * rdma_send(rdma_header)
+ *
+ * For write_list rdma_writes will be done only for data_chunks
+ * nfs_header will be sent as rdma_send
+ * We reply in this sequence
+ * rdma_write(data_chunks)
+ * rdma_send(nfs_header + nfs_response + rdma_header)
+ *
+ * For no reply_list and write_list, we reply as
+ * rdma_send(nfs_header + nfs_response + rdma_header)
+ *
  */
 bool
-xdr_rdma_svc_flushout(struct rpc_rdma_cbc *cbc)
+xdr_rdma_svc_flushout(struct rpc_rdma_cbc *cbc, bool rdma_buf_used)
 {
 	RDMAXPRT *xprt;
 	struct rpc_msg *msg;
@@ -1383,8 +1872,14 @@ xdr_rdma_svc_flushout(struct rpc_rdma_cbc *cbc)
 	struct rdma_msg *rmsg;
 	struct xdr_write_list *w_array;
 	struct xdr_write_list *reply_array;
-	struct xdr_ioq_uv *head_uv;
-	struct xdr_ioq_uv *work_uv;
+	struct xdr_ioq_uv *rdma_head_uv;
+	struct xdr_ioq_uv *work_uv, *nfs_header_uv;
+	struct xdr_ioq_uv *first_send_buf_uv = NULL;
+	bool write_chunk = 0, add_nfs_header = 1;
+	struct xdr_uio  *uio_refer = NULL;
+	uint8_t *rdma_buf_addr = NULL, *non_registered_buf = NULL;
+	int rdma_buf_len = 0, non_registered_buf_len = 0;
+	bool ret = true;
 
 	if (!cbc) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
@@ -1392,14 +1887,26 @@ xdr_rdma_svc_flushout(struct rpc_rdma_cbc *cbc)
 			__func__);
 		return (false);
 	}
-	xprt = x_xprt(cbc->workq.xdrs);
+	xprt = x_xprt(cbc->recvq.xdrs);
 
-	/* swap reply body from holdq to workq */
-	TAILQ_CONCAT(&cbc->workq.ioq_uv.uvqh.qh, &cbc->holdq.ioq_uv.uvqh.qh, q);
-	cbc->workq.ioq_uv.uvqh.qcount = cbc->holdq.ioq_uv.uvqh.qcount;
-	cbc->holdq.ioq_uv.uvqh.qcount = 0;
+        __warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc %p recvq %p %d sendq %p %d xd %p",
+                __func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount, &cbc->sendq,
+                cbc->sendq.ioq_uv.uvqh.qcount, xprt);
 
-	work_uv = IOQ_(TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh));
+	reply_array = (wl_t *)cbc->reply_chunk;
+
+
+	if (reply_array->present == 0) {
+		reply_array = (wl_t *)cbc->write_chunk;
+		if (reply_array->present)
+			write_chunk = 1;
+	}
+
+	/* Remove NFS rpc header to send it after rdma_writes,
+	 * We allocated seperate header for nfs */
+	nfs_header_uv = IOQ_(TAILQ_FIRST(&cbc->sendq.ioq_uv.uvqh.qh));
+
+	work_uv = nfs_header_uv;
 	msg = (struct rpc_msg *)(work_uv->v.vio_head);
 	/* work_uv->v.vio_tail has been set by xdr_tail_update() */
 
@@ -1427,36 +1934,78 @@ xdr_rdma_svc_flushout(struct rpc_rdma_cbc *cbc)
 		return (false);
 	}
 
-	/* usurp the holdq for the head, move to workq later */
-	head_uv = IOQ_(xdr_ioq_uv_fetch(&cbc->holdq, &xprt->outbufs.uvqh,
+	/* usurp the sendq for the head, move to recvq later */
+	/* Allocate seperate buf to send RPCoRDMA header */
+	rdma_head_uv = IOQ_(xdr_rdma_ioq_uv_fetch(&cbc->sendq, &xprt->outbufs_hdr.uvqh,
 					"sreply head", 1, IOQ_FLAG_NONE));
 
 	/* entry was already added directly to the queue */
-	head_uv->v.vio_head = head_uv->v.vio_base;
+	rdma_head_uv->v.vio_head = rdma_head_uv->v.vio_tail =
+	    rdma_head_uv->v.vio_base;
 	/* tail adjusted below */
-	head_uv->v.vio_wrap = (char *)head_uv->v.vio_base + xprt->sm_dr.sendsz;
+	rdma_head_uv->v.vio_wrap = (char *)rdma_head_uv->v.vio_base +
+	    xprt->sm_dr.send_hdr_sz;
 
 	/* build the header that goes with the data */
-	rmsg = m_(head_uv->v.vio_head);
+	rmsg = m_(rdma_head_uv->v.vio_head);
 	rmsg->rdma_xid = cmsg->rdma_xid;
 	rmsg->rdma_vers = cmsg->rdma_vers;
-	rmsg->rdma_credit = htonl(xprt->xa->credits);
+	rmsg->rdma_credit = htonl(MIN(xprt->xa->credits, MAX_RECV_OUTSTANDING));
 
 	/* no read, write chunks. */
 	rmsg->rdma_body.rdma_msg.rdma_reads = 0; /* htonl(0); */
 	rmsg->rdma_body.rdma_msg.rdma_writes = 0; /* htonl(0); */
+	rmsg->rdma_body.rdma_msg.rdma_reply = 0;
 
-	reply_array = (wl_t *)cbc->reply_chunk;
+	rpcrdma_dump_msg(nfs_header_uv, "sreply nfs head", msg->rm_xid);
+
+	pthread_mutex_lock(&cbc->sendq.ioq_uv.uvqh.qmutex);
+	TAILQ_REMOVE(&cbc->sendq.ioq_uv.uvqh.qh, &rdma_head_uv->uvq, q);
+	(cbc->sendq.ioq_uv.uvqh.qcount)--;
+
+	TAILQ_REMOVE(&cbc->sendq.ioq_uv.uvqh.qh, &nfs_header_uv->uvq, q);
+	(cbc->sendq.ioq_uv.uvqh.qcount)--;
+	pthread_mutex_unlock(&cbc->sendq.ioq_uv.uvqh.qmutex);
+
 	if (reply_array->present == 0) {
 		rmsg->rdma_type = htonl(RDMA_MSG);
 
 		/* no reply chunk either */
 		rmsg->rdma_body.rdma_msg.rdma_reply = 0; /* htonl(0); */
 
-		head_uv->v.vio_tail = head_uv->v.vio_head
+		rdma_head_uv->v.vio_tail = rdma_head_uv->v.vio_head
 					+ xdr_rdma_header_length(rmsg);
 
-		rpcrdma_dump_msg(head_uv, "sreply head", msg->rm_xid);
+		struct poolq_entry *have = TAILQ_FIRST(&cbc->sendq.ioq_uv.uvqh.qh);
+		if (have) {
+			/* We will do rdma_send, so if there is rdma_buf from
+			 * protocol, just copy it, for read/readdir we always
+			 * get rdma_buf even if there are no reply_array/write_array,
+			 * if there is no rdma_buf the it could be compound op with reply_buf,
+			 * So no harm in copying for metadata ops */
+
+			first_send_buf_uv  = IOQ_(have);
+			uint8_t *ptr = first_send_buf_uv->v.vio_head;
+			uint32_t len = ioquv_length(first_send_buf_uv);
+
+			assert(rdma_buf_used);
+			assert(cbc->sendq.ioq_uv.uvqh.qcount == 1);
+			assert(len <= xprt->sm_dr.send_hdr_sz);
+
+			/* If its rdma_buf from protocol we should have
+			 * UIO_FLAG_REFER set. */
+			if (first_send_buf_uv->u.uio_flags & UIO_FLAG_REFER)
+				uio_refer = first_send_buf_uv->u.uio_refer;
+
+			first_send_buf_uv->v = first_send_buf_uv->rdma_v;
+			first_send_buf_uv->u = first_send_buf_uv->rdma_u;
+
+			memcpy(first_send_buf_uv->v.vio_head, ptr,
+			    len);
+			first_send_buf_uv->v.vio_tail = first_send_buf_uv->v.vio_head + len;
+		}
+
+		rpcrdma_dump_msg(rdma_head_uv, "sreply head", msg->rm_xid);
 		rpcrdma_dump_msg(work_uv, "sreply body", msg->rm_xid);
 	} else {
 		uint32_t i = 0;
@@ -1464,70 +2013,194 @@ xdr_rdma_svc_flushout(struct rpc_rdma_cbc *cbc)
 
 		rmsg->rdma_type = htonl(RDMA_NOMSG);
 
+		struct poolq_entry *have = TAILQ_FIRST(&cbc->sendq.ioq_uv.uvqh.qh);
+		first_send_buf_uv  = IOQ_(have);
+
 		/* reply chunk */
 		w_array = (wl_t *)&rmsg->rdma_body.rdma_msg.rdma_reply;
+		if (write_chunk) {
+			w_array = (wl_t *)&rmsg->rdma_body.rdma_msg.rdma_writes;
+			rmsg->rdma_type = htonl(RDMA_MSG);
+		}
+
+		/* In case of read/readdir xdr encode xdr_putbufs will
+		 * change the uv vio buffers to point to buffser set by
+		 * protocols and UIO_FLAG_REFER will be set.
+		 * first_buf = nfs_header buf + rdma_write bufs */
+		if (rdma_buf_used) {
+			rdma_buf_addr = first_send_buf_uv->v.vio_head;
+			rdma_buf_len = ioquv_length(first_send_buf_uv);
+			if (first_send_buf_uv->u.uio_flags & UIO_FLAG_REFER)
+				uio_refer = first_send_buf_uv->u.uio_refer;
+
+			/* If no write_list then we do memcpy from rdma_buf passed
+			 * passed from protocol*/
+			if (!write_chunk) {
+				non_registered_buf = mem_zalloc(rdma_buf_len +
+				    ioquv_length(nfs_header_uv));
+				cbc->non_registered_buf = non_registered_buf;
+				memcpy(non_registered_buf, nfs_header_uv->v.vio_head,
+				    ioquv_length(nfs_header_uv));
+				memcpy(non_registered_buf + ioquv_length(nfs_header_uv),
+				    rdma_buf_addr, rdma_buf_len);
+				rdma_buf_addr = non_registered_buf;
+				rdma_buf_len = rdma_buf_len + ioquv_length(nfs_header_uv);
+				non_registered_buf_len = rdma_buf_len;
+				cbc->non_registered_buf_len = non_registered_buf_len;
+				add_nfs_header = 0;
+				xdr_rdma_ioq_uv_release(nfs_header_uv);
+			}
+		} else {
+			memcpy(first_send_buf_uv->v.vio_head, nfs_header_uv->v.vio_head,
+			    ioquv_length(nfs_header_uv));
+			memcpy(first_send_buf_uv->v.vio_head + ioquv_length(nfs_header_uv),
+			    rdma_buf_addr, rdma_buf_len);
+			first_send_buf_uv->v.vio_tail = first_send_buf_uv->v.vio_head +
+			    ioquv_length(nfs_header_uv) + rdma_buf_len;
+			add_nfs_header = 0;
+			xdr_rdma_ioq_uv_release(nfs_header_uv);
+		}
+
+		__warnx(TIRPC_DEBUG_FLAG_XDR, "first_send_buf_uv %d write_chunk %d",
+			ioquv_length(first_send_buf_uv), write_chunk);
+
 		w_array->present = htonl(1);
 
-		while (i < n) {
+		rdma_head_uv->v.vio_tail = rdma_head_uv->v.vio_head
+					+ 64;
+
+		cbc->have = TAILQ_FIRST(&cbc->sendq.ioq_uv.uvqh.qh);
+		while (ret && (i < n)) {
 			struct xdr_rdma_segment *c_seg =
 				&reply_array->entry[i].target;
 			struct xdr_rdma_segment *w_seg =
 				&w_array->entry[i++].target;
+			struct xdr_ioq_uv *send_uv = NULL;
 			uint32_t length = ntohl(c_seg->length);
-			uint32_t k = length / xprt->sm_dr.sendsz;
-			uint32_t m = length % xprt->sm_dr.sendsz;
+			uint32_t nfs_header_len = ioquv_length(nfs_header_uv);
 
-			if (m) {
-				/* need fractional buffer */
-				k++;
-			}
-
-			/* ensure never asking for more buffers than allowed */
-			if (k > xprt->xa->max_send_sge) {
-				__warnx(TIRPC_DEBUG_FLAG_XDR,
-					"%s() requested chunk %" PRIu32
-					" is too long (%" PRIu32 ">%" PRIu32 ")",
-					__func__, length, k,
-					xprt->xa->max_send_sge);
-				k = xprt->xa->max_send_sge;
-			}
+			assert(length <= xprt->sm_dr.sendsz);
 
 			*w_seg = *c_seg;
 
-			/* sometimes, back-to-back buffers could be sent
-			 * together.  releases of unused buffers and
-			 * other events eventually scramble the buffers
-			 * enough that there's no gain in efficiency.
-			 */
-			xdr_rdma_wait_write_cb(xprt, cbc, k, w_seg);
+			__warnx(TIRPC_DEBUG_FLAG_XDR,
+				"%s() requested chunk length %u offset %llx handle %x length %x"
+				" nfs_header_len %u rdma_buf_addr %p rdma_buf_len %u",
+				__func__, length, w_seg->offset, w_seg->handle, w_seg->length,
+				nfs_header_len, rdma_buf_addr, rdma_buf_len);
 
-			while (0 < k--) {
-				struct poolq_entry *have =
-					TAILQ_FIRST(&cbc->workq.ioq_uv.uvqh.qh);
+			send_uv  = IOQ_(cbc->have);
+			assert(send_uv->rdma_uv);
 
-				TAILQ_REMOVE(&cbc->workq.ioq_uv.uvqh.qh, have, q);
-				(cbc->workq.ioq_uv.uvqh.qcount)--;
+			if (rdma_buf_used) {
+				uint32_t write_len = (rdma_buf_len > length) ? length : rdma_buf_len;
 
-				rpcrdma_dump_msg(IOQ_(have), "sreply body",
-						 msg->rm_xid);
-				xdr_ioq_uv_release(IOQ_(have));
+				if (non_registered_buf) {
+					/* Copy allocated buffer to registered buffer */
+					send_uv->v = send_uv->rdma_v;
+					send_uv->u = send_uv->rdma_u;
+					memcpy(send_uv->v.vio_head, rdma_buf_addr,
+					    write_len);
+				} else {
+					/* If its protocol rdma buffer, we need to set uv vio addr to
+					 * point to protocol rdma buf, this is zero copy */
+					send_uv->v.vio_head = rdma_buf_addr;
+					/* mr could be different if its extra added buffer
+					 * protocol buffer will always be from preallocate mr */
+					send_uv->u.uio_p2 = cbc->data_chunk_uv->u.uio_p2;
+				}
+				send_uv->v.vio_tail = send_uv->v.vio_head + write_len;
+				rdma_buf_addr = rdma_buf_addr + write_len;
+				rdma_buf_len = rdma_buf_len - write_len;
 			}
+
+			if (xdr_rdma_wait_write_cb(xprt, cbc, 1, w_seg)) {
+				__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s rdma_write failed xprt %p "
+				    "cbc %p", __func__, xprt, cbc);
+				ret = false;
+			}
+
+			rpcrdma_dump_msg(IOQ_(have), "sreply rdma write",
+					 msg->rm_xid);
+
+			/* Reset uv vio back to rdma buf, so that we don't release protocol
+			 * rdma_buf */
+			if (rdma_buf_addr) {
+				send_uv->v = send_uv->rdma_v;
+				send_uv->u = send_uv->rdma_u;
+			}
+			cbc->have = TAILQ_NEXT(cbc->have, q);
 		}
+
 		w_array->elements = htonl(i);
 
-		head_uv->v.vio_tail = head_uv->v.vio_head
+		rdma_head_uv->v.vio_tail = rdma_head_uv->v.vio_head
+						+ 64;
+		if (write_chunk) {
+			wl_t * reply_array1 = (wl_t *)xdr_rdma_get_reply_array(rdma_head_uv->v.vio_head);
+			uint32_t * iptr = (uint32_t * )reply_array1;
+			iptr--;
+			*iptr = 0;
+			reply_array1->present = 0;
+		}
+
+		assert(cbc->freeq.ioq_uv.uvqh.qcount == 0);
+
+		pthread_mutex_lock(&cbc->freeq.ioq_uv.uvqh.qmutex);
+		pthread_mutex_lock(&cbc->sendq.ioq_uv.uvqh.qmutex);
+
+		TAILQ_CONCAT(&cbc->freeq.ioq_uv.uvqh.qh, &cbc->sendq.ioq_uv.uvqh.qh, q);
+		cbc->freeq.ioq_uv.uvqh.qcount += cbc->sendq.ioq_uv.uvqh.qcount;
+		cbc->sendq.ioq_uv.uvqh.qcount = 0;
+
+		pthread_mutex_unlock(&cbc->sendq.ioq_uv.uvqh.qmutex);
+		pthread_mutex_unlock(&cbc->freeq.ioq_uv.uvqh.qmutex);
+
+		rdma_head_uv->v.vio_tail = rdma_head_uv->v.vio_head
 					+ xdr_rdma_header_length(rmsg);
-		rpcrdma_dump_msg(head_uv, "sreply head", msg->rm_xid);
+
 	}
 
-	/* actual send, callback will take care of cleanup */
-	TAILQ_REMOVE(&cbc->holdq.ioq_uv.uvqh.qh, &head_uv->uvq, q);
-	(cbc->holdq.ioq_uv.uvqh.qcount)--;
-	(cbc->workq.ioq_uv.uvqh.qcount)++;
-	TAILQ_INSERT_HEAD(&cbc->workq.ioq_uv.uvqh.qh, &head_uv->uvq, q);
-	xdr_rdma_post_send_cb(xprt, cbc, cbc->workq.ioq_uv.uvqh.qcount);
+	rpcrdma_dump_msg(rdma_head_uv, "sreply rdma head", msg->rm_xid);
+	rpcrdma_dump_msg(nfs_header_uv, "sreply nfs head", msg->rm_xid);
 
-	/* free the old inbuf we only kept for header */
-	xdr_ioq_uv_release(cbc->call_uv);
-	return (true);
+	pthread_mutex_lock(&cbc->sendq.ioq_uv.uvqh.qmutex);
+
+	if (add_nfs_header) {
+		TAILQ_INSERT_HEAD(&cbc->sendq.ioq_uv.uvqh.qh, &nfs_header_uv->uvq, q);
+		(cbc->sendq.ioq_uv.uvqh.qcount)++;
+	}
+
+	TAILQ_INSERT_HEAD(&cbc->sendq.ioq_uv.uvqh.qh, &rdma_head_uv->uvq, q);
+	(cbc->sendq.ioq_uv.uvqh.qcount)++;
+
+	pthread_mutex_unlock(&cbc->sendq.ioq_uv.uvqh.qmutex);
+
+	/* recvq = request_header buf + rdma_read bufs */
+	/* sendq = response_header_buf + rdma_write_bufs */
+	/* dataq = protocol_buf */
+
+	assert(cbc->dataq.ioq_uv.uvqh.qcount == 1);
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s() sendq %d recvq %d", __func__,
+		cbc->sendq.ioq_uv.uvqh.qcount, cbc->recvq.ioq_uv.uvqh.qcount);
+
+	cbc->have = TAILQ_FIRST(&cbc->sendq.ioq_uv.uvqh.qh);
+
+	if (xdr_rdma_post_send_cb(xprt, cbc, cbc->sendq.ioq_uv.uvqh.qcount)) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s rdma_send failed xprt %p "
+		    "cbc %p", __func__, xprt, cbc);
+		ret = false;
+	}
+
+	/* Release uio for read/readdir */
+	if (uio_refer) {
+		uio_refer->uio_release(uio_refer, UIO_FLAG_NONE);
+	}
+
+	__warnx(TIRPC_DEBUG_FLAG_XDR, "%s: cbc %p recvq %p %d sendq %p %d xd %p",
+		__func__, cbc, &cbc->recvq, cbc->recvq.ioq_uv.uvqh.qcount, &cbc->sendq,
+		cbc->sendq.ioq_uv.uvqh.qcount, xprt);
+
+	return ret;
 }


### PR DESCRIPTION
This patch Enable NFSoRDMA with following fixes

```
1.     Connection management.
2.     Scalable per connection buffer management to use/reuse rdma registered buffers for NFS request/responses/data buffers.
3.     Granular buffer sizes for headers and data.
4.     Rdma credit management based on outstanding recv buffers.
5.     Async rdma_send/rdma_write callbacks.
6.     Fixes to make rdma_read and rdma_write work.
7.     Fixes to make reply_list and write_list work.
8.     Limit rdma connections.
9.     Connection disconnect handling to cleanup posted buffers.
10.    cbc ref management.
11.    rdma xprt ref management.
```

We have supporting patch in Ganesha to use rdma registered buffers for read and readdir responses.
With this patch and supporting Ganesha patch, we should be able to use NFSv3 and NFSv4.0 over RDMA.
Delegation has to be disabled for NFSv4.0, since callback channel is not yet supported over RDMA.

We tested NFSoRDMA with both hardware and SoftROCE 

Hardware:
Ethernet controller: Mellanox Technologies ConnectX Family mlx5Gen Virtual Function Rocky Linux release 8.9 (Green Obsidian)
Linux kernel version 5.10

SoftROCE:
Rocky Linux release 8.9 (Green Obsidian)
Linux kernel version 5.4.275-1.el8.elrepo.x86_64
Tested with fsal=MEM