### PR TITLE
TiRPC Updates for NFSoRDMA

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -145,15 +145,12 @@ typedef struct svc_init_params {
 	u_int gss_max_idle_gen;
 	u_int gss_max_gc;
 	uint32_t channels;
-
+	int32_t idle_timeout;
+	uint32_t thr_stack_size;
 #if defined(_USE_NFS_RDMA) || defined(USE_RPC_RDMA)
 	uint16_t nfs_rdma_port; /* Shared with Ganesha */
 	uint32_t max_rdma_connections;
-	bool enable_rdma_dump;
 #endif
-
-	int32_t idle_timeout;
-	uint32_t thr_stack_size;
 } svc_init_params;
 
 /* Svc param flags */

--- a/ntirpc/rpc/xdr_ioq.h
+++ b/ntirpc/rpc/xdr_ioq.h
@@ -158,14 +158,14 @@ extern void xdr_rdma_ioq_release(struct poolq_head *ioqh, bool xioq_recycle,
 extern void xdr_rdma_buf_pool_destroy(struct poolq_head *ioqh);
 
 extern struct poolq_entry *xdr_rdma_ioq_uv_fetch(struct xdr_ioq *xioq,
-					     struct poolq_head *ioqh,
-					     char *comment,
-					     u_int count,
-					     u_int ioq_flags);
+						 struct poolq_head *ioqh,
+						 char *comment,
+						 u_int count,
+						 u_int ioq_flags);
 extern struct poolq_entry *xdr_rdma_ioq_uv_fetch_nothing(struct xdr_ioq *xioq,
-						     struct poolq_head *ioqh,
-						     char *comment,
-						     u_int count,
-						     u_int ioq_flags);
+							 struct poolq_head *ioqh,
+							 char *comment,
+							 u_int count,
+							 u_int ioq_flags);
 #endif
 #endif				/* XDR_IOQ_H */

--- a/src/svc.c
+++ b/src/svc.c
@@ -130,11 +130,6 @@ svc_init(svc_init_params *params)
 	struct work_pool_params work_pool_params = {0,};
 	uint32_t channels = params->channels ? params->channels : 8;
 
-#ifdef USE_RPC_RDMA
-	__svc_params->nfs_rdma_port = params->nfs_rdma_port;
-	__svc_params->enable_rdma_dump = params->enable_rdma_dump;
-#endif
-
 	mutex_lock(&__svc_params->mtx);
 	if (__svc_params->initialized) {
 		__warnx(TIRPC_DEBUG_FLAG_WARN,
@@ -237,6 +232,7 @@ svc_init(svc_init_params *params)
 
 #ifdef USE_RPC_RDMA
 	rpc_rdma_internals_init();
+	__svc_params->nfs_rdma_port = params->nfs_rdma_port;
 	__svc_params->max_rdma_connections = params->max_rdma_connections;
 #endif
 

--- a/src/svc_internal.h
+++ b/src/svc_internal.h
@@ -82,13 +82,10 @@ struct svc_params {
 	u_long flags;
 	u_int max_connections;
 	int32_t idle_timeout;
-
 #if defined(_USE_NFS_RDMA) || defined(USE_RPC_RDMA)
 	uint16_t nfs_rdma_port;
 	u_int max_rdma_connections;
-	bool enable_rdma_dump;
 #endif
-
 };
 
 enum xprt_stat svc_request(SVCXPRT *xprt, XDR *xdrs);

--- a/src/xdr_ioq.c
+++ b/src/xdr_ioq.c
@@ -192,21 +192,20 @@ xdr_ioq_uv_recycle(struct poolq_head *ioqh, struct poolq_entry *have)
 }
 
 #ifdef USE_RPC_RDMA
-
 struct poolq_entry *
 xdr_rdma_ioq_uv_fetch(struct xdr_ioq *xioq, struct poolq_head *ioqh,
 		 char *comment, u_int count, u_int ioq_flags)
 {
 	struct poolq_entry *have = NULL;
-	RDMAXPRT *xd = NULL;
+	RDMAXPRT *rdma_xprt = NULL;
 
 	if (xioq->rdma_ioq) {
-		xd = xioq->xdrs[0].x_lib[1];
+		rdma_xprt = xioq->xdrs[0].x_lib[1];
 	}
 
 	__warnx(TIRPC_DEBUG_FLAG_XDR,
-		"%s() %u %s xd %p",
-		__func__, count, comment, xd);
+		"%s() %u %s rdma_xprt %p",
+		__func__, count, comment, rdma_xprt);
 
 	pthread_mutex_lock(&ioqh->qmutex);
 
@@ -235,32 +234,29 @@ xdr_rdma_ioq_uv_fetch(struct xdr_ioq *xioq, struct poolq_head *ioqh,
 			if(count == 0)
 				break;
 		} else {
-			if (xd) {
-				pthread_mutex_unlock(&ioqh->qmutex);
-
-				if (ioqh == &xd->inbufs_data.uvqh) {
-					xdr_rdma_add_inbufs_data(xd);
+			if (rdma_xprt) {
+				if (ioqh == &rdma_xprt->inbufs_data.uvqh) {
+					xdr_rdma_add_inbufs_data(rdma_xprt);
 				}
 
-				if (ioqh == &xd->outbufs_data.uvqh) {
-					xdr_rdma_add_outbufs_data(xd);
+				if (ioqh == &rdma_xprt->outbufs_data.uvqh) {
+					xdr_rdma_add_outbufs_data(rdma_xprt);
 				}
 
-				if (ioqh == &xd->inbufs_hdr.uvqh) {
-					xdr_rdma_add_inbufs_hdr(xd);
+				if (ioqh == &rdma_xprt->inbufs_hdr.uvqh) {
+					xdr_rdma_add_inbufs_hdr(rdma_xprt);
 				}
 
-				if (ioqh == &xd->outbufs_hdr.uvqh) {
-					xdr_rdma_add_outbufs_hdr(xd);
+				if (ioqh == &rdma_xprt->outbufs_hdr.uvqh) {
+					xdr_rdma_add_outbufs_hdr(rdma_xprt);
 				}
 
-				if (unlikely(ioqh == &xd->cbqh)) {
-					__warnx(TIRPC_DEBUG_FLAG_EVENT, "cbc buffers exhausetd xd %p "
-						"ioqh %p qcount %d", xd, ioqh, ioqh->qcount);
+				if (unlikely(ioqh == &rdma_xprt->cbqh)) {
+					__warnx(TIRPC_DEBUG_FLAG_EVENT, "cbc buffers exhausetd rdma_xprt %p "
+						"ioqh %p qcount %d", rdma_xprt, ioqh, ioqh->qcount);
 					rpc_rdma_allocate_cbc_locked(ioqh);
 				}
 
-				pthread_mutex_lock(&ioqh->qmutex);
 			}
 		}
 	}


### PR DESCRIPTION
This commit fixes below items
    1) Rename RDMA XPRTs named as rdma_xprt
    2) Few code cleanups
    3) Updating codes to use unified compile flags
    4) Remove enable_rdma_dump config & header updation