### PR TITLE
Fix rpcsec_gss sequence window processing

### DIFF
--- a/ntirpc/rpc/gss_internal.h
+++ b/ntirpc/rpc/gss_internal.h
@@ -72,8 +72,21 @@ typedef gss_union_ctx_id_desc *gss_union_ctx_id_t;
  * Due to the way we store the sequence window mask, this number MUST always
  * be a multiple of CHAR_BIT.
  */
+#define SVC_GSS_SEQ_WIN 256
+
+/* We additionally maintain an internal sequence window, that is double the
+ * size of the sequence window that is published to the client. This is done
+ * because, due to the asynchronous (= unordered) nature of request processing
+ * at the server, it is possible that in a window of N, assuming sequence
+ * numbers from 1 to N, the server processes and responds to the request with
+ * (N+1) sequence number before the request with sequence number `1` (that is,
+ * the server responds to `N`th request, then the client sends `N+1`th request,
+ * which also gets processed before the older request with sequence number `1`)
+ * In such a scenario, the request with sequence number `1` will fall outside
+ * the sequence window, and will be dropped. In order to reduce the chances of
+ * such a situation, we maintain a larger sequence window on the server
  */
-#define SVC_GSS_SEQ_WIN 512
+#define SVC_GSS_SEQ_WIN_INTERNAL (SVC_GSS_SEQ_WIN * 2)
 
 struct svc_rpc_gss_data {
 	struct opr_rbtree_node node_k;
@@ -90,7 +103,7 @@ struct svc_rpc_gss_data {
 	struct rpc_gss_sec sec;	/* security triple */
 	gss_buffer_desc cname;	/* GSS client name */
 	u_int seqlast;
-	uint8_t seqmask[SVC_GSS_SEQ_WIN / CHAR_BIT];
+	uint8_t seqmask[SVC_GSS_SEQ_WIN_INTERNAL / CHAR_BIT];
 	gss_name_t client_name;
 	gss_buffer_desc checksum;
 	struct {

--- a/ntirpc/rpc/gss_internal.h
+++ b/ntirpc/rpc/gss_internal.h
@@ -68,6 +68,13 @@ typedef gss_union_ctx_id_desc *gss_union_ctx_id_t;
 #define SVC_RPC_GSS_FLAG_NONE    0x0000
 #define SVC_RPC_GSS_FLAG_MSPAC   0x0001
 
+/* This defines the sequence window for SVC-GSS implementation.
+ * Due to the way we store the sequence window mask, this number MUST always
+ * be a multiple of CHAR_BIT.
+ */
+ */
+#define SVC_GSS_SEQ_WIN 512
+
 struct svc_rpc_gss_data {
 	struct opr_rbtree_node node_k;
 	TAILQ_ENTRY(svc_rpc_gss_data) lru_q;
@@ -82,10 +89,8 @@ struct svc_rpc_gss_data {
 	gss_ctx_id_t ctx;	/* context id */
 	struct rpc_gss_sec sec;	/* security triple */
 	gss_buffer_desc cname;	/* GSS client name */
-	u_int seq;
-	u_int win;
 	u_int seqlast;
-	uint32_t seqmask;
+	uint8_t seqmask[SVC_GSS_SEQ_WIN / CHAR_BIT];
 	gss_name_t client_name;
 	gss_buffer_desc checksum;
 	struct {

--- a/src/svc_auth_gss.c
+++ b/src/svc_auth_gss.c
@@ -385,13 +385,12 @@ svcauth_gss_accept_sec_context(struct svc_req *req,
 	/* ANDROS: change for debugging linux kernel version...
 	   gr->gr_win = 0x00000005;
 	 */
-	gr->gr_win = sizeof(gd->seqmask) * 8;
+	gr->gr_win = SVC_GSS_SEQ_WIN;
 
 	/* Save client info. */
 	gd->sec.mech = mech;
 	gd->sec.qop = GSS_C_QOP_DEFAULT;
 	gd->sec.svc = gc->gc_svc;
-	gd->win = gr->gr_win;
 
 	if (time_rec == GSS_C_INDEFINITE) time_rec = INDEF_EXPIRE;
 	if (time_rec > 10) time_rec -= 5;
@@ -540,6 +539,64 @@ svcauth_gss_nextverf(struct svc_req *req, struct svc_rpc_gss_data *gd,
 	return (true);
 }
 
+static bool
+svcauth_gss_is_seq_num_valid(struct svc_rpc_gss_data *gd, u_int32_t seq_num)
+{
+	int next_unseen_seq_num_bit;
+	int seq_num_bit_in_window = seq_num % SVC_GSS_SEQ_WIN;
+
+	/* Handle sequence number lesser than the max seen sequence number */
+	if (seq_num < gd->seqlast) {
+
+		/* Return false if current sequence number is outside the
+		 * window.
+		 */
+		if ((gd->seqlast - seq_num) >= SVC_GSS_SEQ_WIN) {
+			__warnx(TIRPC_DEBUG_FLAG_AUTH,
+				"%s: sequence number: %u is outside the sequence window. Max seen sequence number: %u Sequence window: %d",
+				__func__, seq_num, gd->seqlast,
+				SVC_GSS_SEQ_WIN);
+			return false;
+		}
+
+		/* Return false if current sequence number is already seen */
+		if (isset(gd->seqmask, seq_num_bit_in_window)) {
+			__warnx(TIRPC_DEBUG_FLAG_AUTH,
+				"%s: sequence number: %u is already seen. ",
+				__func__, seq_num);
+			return false;
+		}
+
+		/* Set the bit to mark the current sequence number as seen */
+		setbit(gd->seqmask, seq_num_bit_in_window);
+		return true;
+	}
+
+	/* Handle sequence number greater than the max seen sequence number */
+
+	/* Unset the sequence mask if current sequence number is greater than
+	 * the max seen sequence number by N (where N >= sequence-window)
+	 */
+	if ((seq_num - gd->seqlast) >= SVC_GSS_SEQ_WIN) {
+		memset(gd->seqmask, 0, sizeof(gd->seqmask));
+		gd->seqlast = seq_num;
+	} else {
+		/* In this case, we clear the next unseen sequence number bits
+		 * upto the new max sequence number
+		 */
+		while (gd->seqlast < seq_num) {
+			gd->seqlast++;
+			next_unseen_seq_num_bit = gd->seqlast % SVC_GSS_SEQ_WIN;
+			clrbit(gd->seqmask, next_unseen_seq_num_bit);
+		}
+	}
+
+	/* Set the bit to mark the current sequence number as seen */
+	setbit(gd->seqmask, seq_num_bit_in_window);
+	return true;
+}
+
+
 enum auth_stat
 _svcauth_gss(struct svc_req *req, bool *no_dispatch)
 {
@@ -548,7 +605,7 @@ _svcauth_gss(struct svc_req *req, bool *no_dispatch)
 	struct svc_rpc_gss_data *gd = NULL;
 	struct rpc_gss_cred *gc = NULL;
 	struct rpc_gss_init_res gr;
-	int call_stat, offset;
+	int call_stat;
 	OM_uint32 min_stat;
 	enum auth_stat rc = AUTH_OK;
 
@@ -635,19 +692,10 @@ _svcauth_gss(struct svc_req *req, bool *no_dispatch)
 			 goto gd_free;
 		}
 
-		/* XXX implied serialization?  or just fudging?  advance if
-		 * greater? */
-		offset = gd->seqlast - gc->gc_seq;
-		if (offset < 0) {
-			gd->seqlast = gc->gc_seq;
-			offset = 0 - offset;
-			gd->seqmask <<= offset;
-			offset = 0;
-		} else if (offset >= gd->win || (gd->seqmask & (1 << offset))) {
-			*no_dispatch = true;
+		*no_dispatch = !svcauth_gss_is_seq_num_valid(gd, gc->gc_seq);
+		if (*no_dispatch) {
 			goto gd_free;
 		}
-		gd->seqmask |= (1 << offset);	/* XXX harmless */
 
 		req->rq_ap1 = (void *)(uintptr_t) gc->gc_seq; /* GCC casts */
 		req->rq_clntname = (char *) gd->client_name;

--- a/src/svc_auth_gss.c
+++ b/src/svc_auth_gss.c
@@ -543,7 +543,7 @@ static bool
 svcauth_gss_is_seq_num_valid(struct svc_rpc_gss_data *gd, u_int32_t seq_num)
 {
 	int next_unseen_seq_num_bit;
-	int seq_num_bit_in_window = seq_num % SVC_GSS_SEQ_WIN;
+	int seq_num_bit_in_window = seq_num % SVC_GSS_SEQ_WIN_INTERNAL;
 
 	/* Handle sequence number lesser than the max seen sequence number */
 	if (seq_num < gd->seqlast) {
@@ -551,11 +551,11 @@ svcauth_gss_is_seq_num_valid(struct svc_rpc_gss_data *gd, u_int32_t seq_num)
 		/* Return false if current sequence number is outside the
 		 * window.
 		 */
-		if ((gd->seqlast - seq_num) >= SVC_GSS_SEQ_WIN) {
+		if ((gd->seqlast - seq_num) >= SVC_GSS_SEQ_WIN_INTERNAL) {
 			__warnx(TIRPC_DEBUG_FLAG_AUTH,
 				"%s: sequence number: %u is outside the sequence window. Max seen sequence number: %u Sequence window: %d",
 				__func__, seq_num, gd->seqlast,
-				SVC_GSS_SEQ_WIN);
+				SVC_GSS_SEQ_WIN_INTERNAL);
 			return false;
 		}
 
@@ -577,7 +577,7 @@ svcauth_gss_is_seq_num_valid(struct svc_rpc_gss_data *gd, u_int32_t seq_num)
 	/* Unset the sequence mask if current sequence number is greater than
 	 * the max seen sequence number by N (where N >= sequence-window)
 	 */
-	if ((seq_num - gd->seqlast) >= SVC_GSS_SEQ_WIN) {
+	if ((seq_num - gd->seqlast) >= SVC_GSS_SEQ_WIN_INTERNAL) {
 		memset(gd->seqmask, 0, sizeof(gd->seqmask));
 		gd->seqlast = seq_num;
 	} else {
@@ -586,7 +586,8 @@ svcauth_gss_is_seq_num_valid(struct svc_rpc_gss_data *gd, u_int32_t seq_num)
 		 */
 		while (gd->seqlast < seq_num) {
 			gd->seqlast++;
-			next_unseen_seq_num_bit = gd->seqlast % SVC_GSS_SEQ_WIN;
+			next_unseen_seq_num_bit =
+				gd->seqlast % SVC_GSS_SEQ_WIN_INTERNAL;
 			clrbit(gd->seqmask, next_unseen_seq_num_bit);
 		}
 	}


### PR DESCRIPTION
Fix server's rpcsec_gss sequence window processing.

The existing GSS sequence window of size 32 results in frequent issues of incoming request's sequence number falling outside the sequence window, whenever a client sends multiple concurrent rpcsec_gss requests. When that happens, the requests are silently dropped by the server, and there can be scenarios where the rpc client keeps waiting for the response indefinitely.

This change-set increases this sequence window to 512. This number is expected to reduce the chances of the sequence window breach significantly. During experimentation, the issue did not happen when tested with an nfs client using 16 connections and 32k io-depth.

This change-set additionally maintains an internal sequence window, that is double the size of the sequence window that is published to the client. This is done because, due to the asynchronous (= unordered) nature of request processing at the server, it is possible that in a window of N, assuming sequence numbers from 1 to N, the server processes and responds to the request with (N+1) sequence number before the request with sequence number `1` (that is, the server responds to `N`th request, then the client sends `N+1`th request, which also gets processed before the older request with sequence number `1`). In such a scenario, the request with sequence number `1` will fall outside the sequence window, and will be dropped. In order to reduce the chances of such a situation, we maintain a larger sequence window on the server, while shortening the client-published sequence window to 256