### PR TITLE
atomic: remove legacy __sync-based implementations

### DIFF
--- a/ntirpc/misc/abstract_atomic.h
+++ b/ntirpc/misc/abstract_atomic.h
@@ -82,26 +82,6 @@
 #include <stdint.h>
 #include <time.h>
 
-#undef GCC_SYNC_FUNCTIONS
-#undef GCC_ATOMIC_FUNCTIONS
-
-#ifndef __GNUC__
-#error Please edit abstract_atomic.h and implement support for  \
-	non-GNU compilers.
-#else				/* __GNUC__ */
-#define ATOMIC_GCC_VERSION (__GNUC__ * 10000 \
-			    + __GNUC_MINOR__ * 100 \
-			    + __GNUC_PATCHLEVEL__)
-
-#if ((ATOMIC_GCC_VERSION) >= 40700)
-#define GCC_ATOMIC_FUNCTIONS 1
-#elif ((ATOMIC_GCC_VERSION) >= 40100)
-#define GCC_SYNC_FUNCTIONS 1
-#else
-#error This verison of GCC does not support atomics.
-#endif				/* Version check */
-#endif				/* __GNUC__ */
-
 /*
  * Preaddition, presubtraction, preincrement, predecrement (return the
  * value after the operation, by analogy with the ++n preincrement
@@ -119,17 +99,10 @@
  * @return The value after addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int64_t atomic_add_int64_t(int64_t *augend, int64_t addend)
 {
 	return __atomic_add_fetch(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int64_t atomic_add_int64_t(int64_t *augend, int64_t addend)
-{
-	return __sync_add_and_fetch(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment an int64_t
@@ -157,17 +130,10 @@ static inline int64_t atomic_inc_int64_t(int64_t *var)
  * @return The value after subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int64_t atomic_sub_int64_t(int64_t *minuend, int64_t subtrahend)
 {
 	return __atomic_sub_fetch(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int64_t atomic_sub_int64_t(int64_t *minuend, int64_t subtrahend)
-{
-	return __sync_sub_and_fetch(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement an int64_t
@@ -193,17 +159,10 @@ static inline int64_t atomic_dec_int64_t(int64_t *var)
  * @return The value after addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint64_t atomic_add_uint64_t(uint64_t *augend, uint64_t addend)
 {
 	return __atomic_add_fetch(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint64_t atomic_add_uint64_t(uint64_t *augend, uint64_t addend)
-{
-	return __sync_add_and_fetch(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment a uint64_t
@@ -231,19 +190,11 @@ static inline uint64_t atomic_inc_uint64_t(uint64_t *var)
  * @return The value after subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint64_t atomic_sub_uint64_t(uint64_t *minuend,
 					   uint64_t subtrahend)
 {
 	return __atomic_sub_fetch(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint64_t atomic_sub_uint64_t(uint64_t *minuend,
-					   uint64_t subtrahend)
-{
-	return __sync_sub_and_fetch(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement a uint64_t
@@ -271,17 +222,10 @@ static inline uint64_t atomic_dec_uint64_t(uint64_t *var)
  * @return The value after addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int32_t atomic_add_int32_t(int32_t *augend, int32_t addend)
 {
 	return __atomic_add_fetch(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int32_t atomic_add_int32_t(int32_t *augend, int32_t addend)
-{
-	return __sync_add_and_fetch(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment an int32_t
@@ -309,17 +253,10 @@ static inline int32_t atomic_inc_int32_t(int32_t *var)
  * @return The value after subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int32_t atomic_sub_int32_t(int32_t *minuend, int32_t subtrahend)
 {
 	return __atomic_sub_fetch(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int32_t atomic_sub_int32_t(int32_t *minuend, int32_t subtrahend)
-{
-	return __sync_sub_and_fetch(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement an int32_t
@@ -347,17 +284,10 @@ static inline int32_t atomic_dec_int32_t(int32_t *var)
  * @return The value after addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint32_t atomic_add_uint32_t(uint32_t *augend, uint32_t addend)
 {
 	return __atomic_add_fetch(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint32_t atomic_add_uint32_t(uint32_t *augend, uint32_t addend)
-{
-	return __sync_add_and_fetch(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment a uint32_t
@@ -384,17 +314,10 @@ static inline uint32_t atomic_inc_uint32_t(uint32_t *var)
  * @return The value after subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint32_t atomic_sub_uint32_t(uint32_t *var, uint32_t sub)
 {
 	return __atomic_sub_fetch(var, sub, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint32_t atomic_sub_uint32_t(uint32_t *var, uint32_t sub)
-{
-	return __sync_sub_and_fetch(var, sub);
-}
-#endif
 
 /**
  * @brief Atomically decrement a uint32_t
@@ -422,17 +345,10 @@ static inline uint32_t atomic_dec_uint32_t(uint32_t *var)
  * @return The value after addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int16_t atomic_add_int16_t(int16_t *augend, int16_t addend)
 {
 	return __atomic_add_fetch(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int16_t atomic_add_int16_t(int16_t *augend, int16_t addend)
-{
-	return __sync_add_and_fetch(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment an int16_t
@@ -460,17 +376,10 @@ static inline int16_t atomic_inc_int16_t(int16_t *var)
  * @return The value after subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int16_t atomic_sub_int16_t(int16_t *minuend, int16_t subtrahend)
 {
 	return __atomic_sub_fetch(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int16_t atomic_sub_int16_t(int16_t *minuend, int16_t subtrahend)
-{
-	return __sync_sub_and_fetch(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement an int16_t
@@ -498,17 +407,10 @@ static inline int16_t atomic_dec_int16_t(int16_t *var)
  * @return The value after addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint16_t atomic_add_uint16_t(uint16_t *augend, uint16_t addend)
 {
 	return __atomic_add_fetch(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint16_t atomic_add_uint16_t(uint16_t *augend, uint16_t addend)
-{
-	return __sync_add_and_fetch(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment a uint16_t
@@ -536,19 +438,11 @@ static inline uint16_t atomic_inc_uint16_t(uint16_t *var)
  * @return The value after subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint16_t atomic_sub_uint16_t(uint16_t *minuend,
 					   uint16_t subtrahend)
 {
 	return __atomic_sub_fetch(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint16_t atomic_sub_uint16_t(uint16_t *minuend,
-					   uint16_t subtrahend)
-{
-	return __sync_sub_and_fetch(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement a uint16_t
@@ -576,17 +470,10 @@ static inline uint16_t atomic_dec_uint16_t(uint16_t *var)
  * @return The value after addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int8_t atomic_add_int8_t(int8_t *augend, int8_t addend)
 {
 	return __atomic_add_fetch(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int8_t atomic_add_int8_t(int8_t *augend, int8_t addend)
-{
-	return __sync_add_and_fetch(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment an int8_t
@@ -614,17 +501,10 @@ static inline int8_t atomic_inc_int8_t(int8_t *var)
  * @return The value after subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int8_t atomic_sub_int8_t(int8_t *minuend, int8_t subtrahend)
 {
 	return __atomic_sub_fetch(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int8_t atomic_sub_int8_t(int8_t *minuend, int8_t subtrahend)
-{
-	return __sync_sub_and_fetch(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement an int8_t
@@ -652,17 +532,10 @@ static inline int8_t atomic_dec_int8_t(int8_t *var)
  * @return The value after addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint8_t atomic_add_uint8_t(uint8_t *augend, int8_t addend)
 {
 	return __atomic_add_fetch(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint8_t atomic_add_uint8_t(uint8_t *augend, int8_t addend)
-{
-	return __sync_add_and_fetch(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment a uint8_t
@@ -690,17 +563,10 @@ static inline uint8_t atomic_inc_uint8_t(uint8_t *var)
  * @return The value after subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint8_t atomic_sub_uint8_t(uint8_t *minuend, uint8_t subtrahend)
 {
 	return __atomic_sub_fetch(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint8_t atomic_sub_uint8_t(uint8_t *minuend, uint8_t subtrahend)
-{
-	return __sync_sub_and_fetch(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement a uint8_t
@@ -728,17 +594,10 @@ static inline uint8_t atomic_dec_uint8_t(uint8_t *var)
  * @return The value after addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline size_t atomic_add_size_t(size_t *augend, size_t addend)
 {
 	return __atomic_add_fetch(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline size_t atomic_add_size_t(size_t *augend, size_t addend)
-{
-	return __sync_add_and_fetch(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment a size_t
@@ -766,17 +625,10 @@ static inline size_t atomic_inc_size_t(size_t *var)
  * @return The value after subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline size_t atomic_sub_size_t(size_t *minuend, size_t subtrahend)
 {
 	return __atomic_sub_fetch(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline size_t atomic_sub_size_t(size_t *minuend, size_t subtrahend)
-{
-	return __sync_sub_and_fetch(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement a size_t
@@ -810,17 +662,10 @@ static inline size_t atomic_dec_size_t(size_t *var)
  * @return The value before addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int64_t atomic_postadd_int64_t(int64_t *augend, int64_t addend)
 {
 	return __atomic_fetch_add(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int64_t atomic_postadd_int64_t(int64_t *augend, int64_t addend)
-{
-	return __sync_fetch_and_add(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment an int64_t
@@ -848,19 +693,11 @@ static inline int64_t atomic_postinc_int64_t(int64_t *var)
  * @return The value before subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int64_t atomic_postsub_int64_t(int64_t *minuend,
 					     int64_t subtrahend)
 {
 	return __atomic_fetch_sub(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int64_t atomic_postsub_int64_t(int64_t *minuend,
-					     int64_t subtrahend)
-{
-	return __sync_fetch_and_sub(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement an int64_t
@@ -886,19 +723,11 @@ static inline int64_t atomic_postdec_int64_t(int64_t *var)
  * @return The value before addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint64_t atomic_postadd_uint64_t(uint64_t *augend,
 					       uint64_t addend)
 {
 	return __atomic_fetch_add(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint64_t atomic_postadd_uint64_t(uint64_t *augend,
-					       uint64_t addend)
-{
-	return __sync_fetch_and_add(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment a uint64_t
@@ -926,19 +755,11 @@ static inline uint64_t atomic_postinc_uint64_t(uint64_t *var)
  * @return The value before subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint64_t atomic_postsub_uint64_t(uint64_t *minuend,
 					       uint64_t subtrahend)
 {
 	return __atomic_fetch_sub(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint64_t atomic_postsub_uint64_t(uint64_t *minuend,
-					       uint64_t subtrahend)
-{
-	return __sync_fetch_and_sub(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement a uint64_t
@@ -966,17 +787,10 @@ static inline uint64_t atomic_postdec_uint64_t(uint64_t *var)
  * @return The value before addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int32_t atomic_postadd_int32_t(int32_t *augend, int32_t addend)
 {
 	return __atomic_fetch_add(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int32_t atomic_postadd_int32_t(int32_t *augend, int32_t addend)
-{
-	return __sync_fetch_and_add(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment an int32_t
@@ -1004,19 +818,11 @@ static inline int32_t atomic_postinc_int32_t(int32_t *var)
  * @return The value before subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int32_t atomic_postsub_int32_t(int32_t *minuend,
 					     int32_t subtrahend)
 {
 	return __atomic_fetch_sub(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int32_t atomic_postsub_int32_t(int32_t *minuend,
-					     int32_t subtrahend)
-{
-	return __sync_fetch_and_sub(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement an int32_t
@@ -1044,19 +850,11 @@ static inline int32_t atomic_postdec_int32_t(int32_t *var)
  * @return The value before addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint32_t atomic_postadd_uint32_t(uint32_t *augend,
 					       uint32_t addend)
 {
 	return __atomic_fetch_add(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint32_t atomic_postadd_uint32_t(uint32_t *augend,
-					       uint32_t addend)
-{
-	return __sync_fetch_and_add(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment a uint32_t
@@ -1083,17 +881,10 @@ static inline uint32_t atomic_postinc_uint32_t(uint32_t *var)
  * @return The value before subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint32_t atomic_postsub_uint32_t(uint32_t *var, uint32_t sub)
 {
 	return __atomic_fetch_sub(var, sub, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint32_t atomic_postsub_uint32_t(uint32_t *var, uint32_t sub)
-{
-	return __sync_fetch_and_sub(var, sub);
-}
-#endif
 
 /**
  * @brief Atomically decrement a uint32_t
@@ -1121,17 +912,10 @@ static inline uint32_t atomic_postdec_uint32_t(uint32_t *var)
  * @return The value before addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int16_t atomic_postadd_int16_t(int16_t *augend, int16_t addend)
 {
 	return __atomic_fetch_add(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int16_t atomic_postadd_int16_t(int16_t *augend, int16_t addend)
-{
-	return __sync_fetch_and_add(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment an int16_t
@@ -1159,19 +943,11 @@ static inline int16_t atomic_postinc_int16_t(int16_t *var)
  * @return The value before subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int16_t atomic_postsub_int16_t(int16_t *minuend,
 					     int16_t subtrahend)
 {
 	return __atomic_fetch_sub(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int16_t atomic_postsub_int16_t(int16_t *minuend,
-					     int16_t subtrahend)
-{
-	return __sync_fetch_and_sub(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement an int16_t
@@ -1199,19 +975,11 @@ static inline int16_t atomic_postdec_int16_t(int16_t *var)
  * @return The value before addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint16_t atomic_postadd_uint16_t(uint16_t *augend,
 					       uint16_t addend)
 {
 	return __atomic_fetch_add(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint16_t atomic_postadd_uint16_t(uint16_t *augend,
-					       uint16_t addend)
-{
-	return __sync_fetch_and_add(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment a uint16_t
@@ -1239,19 +1007,11 @@ static inline uint16_t atomic_postinc_uint16_t(uint16_t *var)
  * @return The value before subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint16_t atomic_postsub_uint16_t(uint16_t *minuend,
 					       uint16_t subtrahend)
 {
 	return __atomic_fetch_sub(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint16_t atomic_postsub_uint16_t(uint16_t *minuend,
-					       uint16_t subtrahend)
-{
-	return __sync_fetch_and_sub(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement a uint16_t
@@ -1279,17 +1039,10 @@ static inline uint16_t atomic_postdec_uint16_t(uint16_t *var)
  * @return The value before addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int8_t atomic_postadd_int8_t(int8_t *augend, int8_t addend)
 {
 	return __atomic_fetch_add(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int8_t atomic_postadd_int8_t(int8_t *augend, int8_t addend)
-{
-	return __sync_fetch_and_add(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment an int8_t
@@ -1317,17 +1070,10 @@ static inline int8_t atomic_postinc_int8_t(int8_t *var)
  * @return The value before subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int8_t atomic_postsub_int8_t(int8_t *minuend, int8_t subtrahend)
 {
 	return __atomic_fetch_sub(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int8_t atomic_postsub_int8_t(int8_t *minuend, int8_t subtrahend)
-{
-	return __sync_fetch_and_sub(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement an int8_t
@@ -1355,17 +1101,10 @@ static inline int8_t atomic_postdec_int8_t(int8_t *var)
  * @return The value before addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint8_t atomic_postadd_uint8_t(uint8_t *augend, uint8_t addend)
 {
 	return __atomic_fetch_add(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint8_t atomic_postadd_uint8_t(uint8_t *augend, uint8_t addend)
-{
-	return __sync_fetch_and_add(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment a uint8_t
@@ -1393,19 +1132,11 @@ static inline uint8_t atomic_postinc_uint8_t(uint8_t *var)
  * @return The value before subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint8_t atomic_postsub_uint8_t(uint8_t *minuend,
 					     uint8_t subtrahend)
 {
 	return __atomic_fetch_sub(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint8_t atomic_postsub_uint8_t(uint8_t *minuend,
-					     uint8_t subtrahend)
-{
-	return __sync_fetch_and_sub(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement a uint8_t
@@ -1433,17 +1164,10 @@ static inline uint8_t atomic_postdec_uint8_t(uint8_t *var)
  * @return The value before addition.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline size_t atomic_postadd_size_t(size_t *augend, size_t addend)
 {
 	return __atomic_fetch_add(augend, addend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline size_t atomic_postadd_size_t(size_t *augend, size_t addend)
-{
-	return __sync_fetch_and_add(augend, addend);
-}
-#endif
 
 /**
  * @brief Atomically increment a size_t
@@ -1471,17 +1195,10 @@ static inline size_t atomic_postinc_size_t(size_t *var)
  * @return The value before subtraction.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline size_t atomic_postsub_size_t(size_t *minuend, size_t subtrahend)
 {
 	return __atomic_fetch_sub(minuend, subtrahend, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline size_t atomic_postsub_size_t(size_t *minuend, size_t subtrahend)
-{
-	return __sync_fetch_and_sub(minuend, subtrahend);
-}
-#endif
 
 /**
  * @brief Atomically decrement a size_t
@@ -1514,17 +1231,10 @@ static inline size_t atomic_postdec_size_t(size_t *var)
  * @return The value after clearing.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint64_t atomic_clear_uint64_t_bits(uint64_t *var, uint64_t bits)
 {
 	return __atomic_and_fetch(var, ~bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint64_t atomic_clear_uint64_t_bits(uint64_t *var, uint64_t bits)
-{
-	return __sync_and_and_fetch(var, ~bits);
-}
-#endif
 
 /**
  * @brief Atomically set bits in a uint64_t
@@ -1537,17 +1247,10 @@ static inline uint64_t atomic_clear_uint64_t_bits(uint64_t *var, uint64_t bits)
  * @return The value after setting.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint64_t atomic_set_uint64_t_bits(uint64_t *var, uint64_t bits)
 {
 	return __atomic_or_fetch(var, bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint64_t atomic_set_uint64_t_bits(uint64_t *var, uint64_t bits)
-{
-	return __sync_or_and_fetch(var, bits);
-}
-#endif
 
 /**
  * @brief Atomically clear bits in a uint32_t
@@ -1560,17 +1263,10 @@ static inline uint64_t atomic_set_uint64_t_bits(uint64_t *var, uint64_t bits)
  * @return The value after clearing.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint32_t atomic_clear_uint32_t_bits(uint32_t *var, uint32_t bits)
 {
 	return __atomic_and_fetch(var, ~bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint32_t atomic_clear_uint32_t_bits(uint32_t *var, uint32_t bits)
-{
-	return __sync_and_and_fetch(var, ~bits);
-}
-#endif
 
 /**
  * @brief Atomically set bits in a uint32_t
@@ -1583,17 +1279,10 @@ static inline uint32_t atomic_clear_uint32_t_bits(uint32_t *var, uint32_t bits)
  * @return The value after setting.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint32_t atomic_set_uint32_t_bits(uint32_t *var, uint32_t bits)
 {
 	return __atomic_or_fetch(var, bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint32_t atomic_set_uint32_t_bits(uint32_t *var, uint32_t bits)
-{
-	return __sync_or_and_fetch(var, bits);
-}
-#endif
 
 /**
  * @brief Atomically clear bits in a uint16_t
@@ -1606,17 +1295,10 @@ static inline uint32_t atomic_set_uint32_t_bits(uint32_t *var, uint32_t bits)
  * @return The value after clearing.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint16_t atomic_clear_uint16_t_bits(uint16_t *var, uint16_t bits)
 {
 	return __atomic_and_fetch(var, ~bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint16_t atomic_clear_uint16_t_bits(uint16_t *var, uint16_t bits)
-{
-	return __sync_and_and_fetch(var, ~bits);
-}
-#endif
 
 /**
  * @brief Atomically set bits in a uint16_t
@@ -1629,17 +1311,10 @@ static inline uint16_t atomic_clear_uint16_t_bits(uint16_t *var, uint16_t bits)
  * @return The value after setting.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint16_t atomic_set_uint16_t_bits(uint16_t *var, uint16_t bits)
 {
 	return __atomic_or_fetch(var, bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint16_t atomic_set_uint16_t_bits(uint16_t *var, uint16_t bits)
-{
-	return __sync_or_and_fetch(var, bits);
-}
-#endif
 
 /**
  * @brief Atomically clear bits in a uint8_t
@@ -1652,17 +1327,10 @@ static inline uint16_t atomic_set_uint16_t_bits(uint16_t *var, uint16_t bits)
  * @return The value after clearing.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint8_t atomic_clear_uint8_t_bits(uint8_t *var, uint8_t bits)
 {
 	return __atomic_and_fetch(var, ~bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint8_t atomic_clear_uint8_t_bits(uint8_t *var, uint8_t bits)
-{
-	return __sync_and_and_fetch(var, ~bits);
-}
-#endif
 
 /**
  * @brief Atomically set bits in a uint8_t
@@ -1675,17 +1343,10 @@ static inline uint8_t atomic_clear_uint8_t_bits(uint8_t *var, uint8_t bits)
  * @return The value after setting.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint8_t atomic_set_uint8_t_bits(uint8_t *var, uint8_t bits)
 {
 	return __atomic_or_fetch(var, bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint8_t atomic_set_uint8_t_bits(uint8_t *var, uint8_t bits)
-{
-	return __sync_or_and_fetch(var, bits);
-}
-#endif
 
 /*
  * Postclear and postset bits (return the value before the operation,
@@ -1703,19 +1364,11 @@ static inline uint8_t atomic_set_uint8_t_bits(uint8_t *var, uint8_t bits)
  * @return The value before clearing.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint64_t atomic_postclear_uint64_t_bits(uint64_t *var,
 						      uint64_t bits)
 {
 	return __atomic_fetch_and(var, ~bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint64_t atomic_postclear_uint64_t_bits(uint64_t *var,
-						      uint64_t bits)
-{
-	return __sync_fetch_and_and(var, ~bits);
-}
-#endif
 
 /**
  * @brief Atomically set bits in a uint64_t
@@ -1728,19 +1381,11 @@ static inline uint64_t atomic_postclear_uint64_t_bits(uint64_t *var,
  * @return The value before setting.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint64_t atomic_postset_uint64_t_bits(uint64_t *var,
 						    uint64_t bits)
 {
 	return __atomic_fetch_or(var, bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint64_t atomic_postset_uint64_t_bits(uint64_t *var,
-						    uint64_t bits)
-{
-	return __sync_fetch_and_or(var, bits);
-}
-#endif
 
 /**
  * @brief Atomically clear bits in a uint32_t
@@ -1753,19 +1398,11 @@ static inline uint64_t atomic_postset_uint64_t_bits(uint64_t *var,
  * @return The value before clearing.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint32_t atomic_postclear_uint32_t_bits(uint32_t *var,
 						      uint32_t bits)
 {
 	return __atomic_fetch_and(var, ~bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint32_t atomic_postclear_uint32_t_bits(uint32_t *var,
-						      uint32_t bits)
-{
-	return __sync_fetch_and_and(var, ~bits);
-}
-#endif
 
 /**
  * @brief Atomically set bits in a uint32_t
@@ -1778,19 +1415,11 @@ static inline uint32_t atomic_postclear_uint32_t_bits(uint32_t *var,
  * @return The value before setting.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint32_t atomic_postset_uint32_t_bits(uint32_t *var,
 						    uint32_t bits)
 {
 	return __atomic_fetch_or(var, bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint32_t atomic_postset_uint32_t_bits(uint32_t *var,
-						    uint32_t bits)
-{
-	return __sync_fetch_and_or(var, bits);
-}
-#endif
 
 /**
  * @brief Atomically clear bits in a uint16_t
@@ -1803,19 +1432,11 @@ static inline uint32_t atomic_postset_uint32_t_bits(uint32_t *var,
  * @return The value before clearing.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint16_t atomic_postclear_uint16_t_bits(uint16_t *var,
 						      uint16_t bits)
 {
 	return __atomic_fetch_and(var, ~bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint16_t atomic_postclear_uint16_t_bits(uint16_t *var,
-						      uint16_t bits)
-{
-	return __sync_fetch_and_and(var, ~bits);
-}
-#endif
 
 /**
  * @brief Atomically set bits in a uint16_t
@@ -1828,19 +1449,11 @@ static inline uint16_t atomic_postclear_uint16_t_bits(uint16_t *var,
  * @return The value before setting.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint16_t atomic_postset_uint16_t_bits(uint16_t *var,
 						    uint16_t bits)
 {
 	return __atomic_fetch_or(var, bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint16_t atomic_postset_uint16_t_bits(uint16_t *var,
-						    uint16_t bits)
-{
-	return __sync_fetch_and_or(var, bits);
-}
-#endif
 
 /**
  * @brief Atomically clear bits in a uint8_t
@@ -1853,17 +1466,10 @@ static inline uint16_t atomic_postset_uint16_t_bits(uint16_t *var,
  * @return The value before clearing.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint8_t atomic_postclear_uint8_t_bits(uint8_t *var, uint8_t bits)
 {
 	return __atomic_fetch_and(var, ~bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint8_t atomic_postclear_uint8_t_bits(uint8_t *var, uint8_t bits)
-{
-	return __sync_fetch_and_and(var, ~bits);
-}
-#endif
 
 /**
  * @brief Atomically set bits in a uint8_t
@@ -1876,17 +1482,10 @@ static inline uint8_t atomic_postclear_uint8_t_bits(uint8_t *var, uint8_t bits)
  * @return The value before setting.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint8_t atomic_postset_uint8_t_bits(uint8_t *var, uint8_t bits)
 {
 	return __atomic_fetch_or(var, bits, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint8_t atomic_postset_uint8_t_bits(uint8_t *var, uint8_t bits)
-{
-	return __sync_fetch_and_or(var, bits);
-}
-#endif
 
 /*
  * Fetch and store
@@ -1903,17 +1502,10 @@ static inline uint8_t atomic_postset_uint8_t_bits(uint8_t *var, uint8_t bits)
  * @return the value pointed to by var.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline size_t atomic_fetch_size_t(size_t *var)
 {
 	return __atomic_load_n(var, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline size_t atomic_fetch_size_t(size_t *var)
-{
-	return __sync_fetch_and_add(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically store a size_t
@@ -1925,17 +1517,10 @@ static inline size_t atomic_fetch_size_t(size_t *var)
  * @param[in]     val The value to store
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void atomic_store_size_t(size_t *var, size_t val)
 {
 	__atomic_store_n(var, val, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void atomic_store_size_t(size_t *var, size_t val)
-{
-	(void)__sync_lock_test_and_set(var, val);
-}
-#endif
 
 /**
  * @brief Atomically fetch a ptrdiff_t
@@ -1948,17 +1533,10 @@ static inline void atomic_store_size_t(size_t *var, size_t val)
  * @return the value pointed to by var.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline ptrdiff_t atomic_fetch_ptrdiff_t(ptrdiff_t *var)
 {
 	return __atomic_load_n(var, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline ptrdiff_t atomic_fetch_ptrdiff_t(ptrdiff_t *var)
-{
-	return __sync_fetch_and_add(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically store a ptrdiff_t
@@ -1970,17 +1548,10 @@ static inline ptrdiff_t atomic_fetch_ptrdiff_t(ptrdiff_t *var)
  * @param[in]     val The value to store
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void atomic_store_ptrdiff_t(ptrdiff_t *var, ptrdiff_t val)
 {
 	__atomic_store_n(var, val, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void atomic_store_ptrdiff_t(ptrdiff_t *var, ptrdiff_t val)
-{
-	(void)__sync_lock_test_and_set(var, val);
-}
-#endif
 
 /**
  * @brief Atomically fetch a time_t
@@ -1993,17 +1564,10 @@ static inline void atomic_store_ptrdiff_t(ptrdiff_t *var, ptrdiff_t val)
  * @return the value pointed to by var.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline time_t atomic_fetch_time_t(time_t *var)
 {
 	return __atomic_load_n(var, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline time_t atomic_fetch_time_t(time_t *var)
-{
-	return __sync_fetch_and_add(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically store a time_t
@@ -2015,17 +1579,10 @@ static inline time_t atomic_fetch_time_t(time_t *var)
  * @param[in]     val The value to store
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void atomic_store_time_t(time_t *var, time_t val)
 {
 	__atomic_store_n(var, val, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void atomic_store_time_t(time_t *var, time_t val)
-{
-	(void)__sync_lock_test_and_set(var, val);
-}
-#endif
 
 /**
  * @brief Atomically fetch a uintptr_t
@@ -2038,17 +1595,10 @@ static inline void atomic_store_time_t(time_t *var, time_t val)
  * @return the value pointed to by var.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uintptr_t atomic_fetch_uintptr_t(uintptr_t *var)
 {
 	return __atomic_load_n(var, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uintptr_t atomic_fetch_uintptr_t(uintptr_t *var)
-{
-	return __sync_fetch_and_add(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically store a uintptr_t
@@ -2060,17 +1610,10 @@ static inline uintptr_t atomic_fetch_uintptr_t(uintptr_t *var)
  * @param[in]     val The value to store
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void atomic_store_uintptr_t(uintptr_t *var, uintptr_t val)
 {
 	__atomic_store_n(var, val, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void atomic_store_uintptr_t(uintptr_t *var, uintptr_t val)
-{
-	(void)__sync_lock_test_and_set(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically fetch a void *
@@ -2083,17 +1626,10 @@ static inline void atomic_store_uintptr_t(uintptr_t *var, uintptr_t val)
  * @return the value pointed to by var.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void *atomic_fetch_voidptr(void **var)
 {
 	return __atomic_load_n(var, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void *atomic_fetch_voidptr(void **var)
-{
-	return __sync_fetch_and_add(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically store a void *
@@ -2105,17 +1641,10 @@ static inline void *atomic_fetch_voidptr(void **var)
  * @param[in]     val The value to store
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void atomic_store_voidptr(void **var, void *val)
 {
 	__atomic_store_n(var, val, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void atomic_store_voidptr(void **var, void *val)
-{
-	(void)__sync_lock_test_and_set(var, val);
-}
-#endif
 
 /**
  * @brief Atomically fetch an int64_t
@@ -2128,17 +1657,10 @@ static inline void atomic_store_voidptr(void **var, void *val)
  * @return the value pointed to by var.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int64_t atomic_fetch_int64_t(int64_t *var)
 {
 	return __atomic_load_n(var, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int64_t atomic_fetch_int64_t(int64_t *var)
-{
-	return __sync_fetch_and_add(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically store an int64_t
@@ -2150,17 +1672,10 @@ static inline int64_t atomic_fetch_int64_t(int64_t *var)
  * @param[in]     val The value to store
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void atomic_store_int64_t(int64_t *var, int64_t val)
 {
 	__atomic_store_n(var, val, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void atomic_store_int64_t(int64_t *var, int64_t val)
-{
-	(void)__sync_lock_test_and_set(var, val);
-}
-#endif
 
 /**
  * @brief Atomically fetch a uint64_t
@@ -2173,17 +1688,10 @@ static inline void atomic_store_int64_t(int64_t *var, int64_t val)
  * @return the value pointed to by var.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint64_t atomic_fetch_uint64_t(uint64_t *var)
 {
 	return __atomic_load_n(var, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint64_t atomic_fetch_uint64_t(uint64_t *var)
-{
-	return __sync_fetch_and_add(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically store a uint64_t
@@ -2195,17 +1703,10 @@ static inline uint64_t atomic_fetch_uint64_t(uint64_t *var)
  * @param[in]     val The value to store
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void atomic_store_uint64_t(uint64_t *var, uint64_t val)
 {
 	__atomic_store_n(var, val, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void atomic_store_uint64_t(uint64_t *var, uint64_t val)
-{
-	(void)__sync_lock_test_and_set(var, val);
-}
-#endif
 
 /**
  * @brief Atomically fetch an int32_t
@@ -2218,17 +1719,10 @@ static inline void atomic_store_uint64_t(uint64_t *var, uint64_t val)
  * @return the value pointed to by var.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int32_t atomic_fetch_int32_t(int32_t *var)
 {
 	return __atomic_load_n(var, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int32_t atomic_fetch_int32_t(int32_t *var)
-{
-	return __sync_fetch_and_add(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically store an int32_t
@@ -2240,17 +1734,10 @@ static inline int32_t atomic_fetch_int32_t(int32_t *var)
  * @param[in]     val The value to store
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void atomic_store_int32_t(int32_t *var, int32_t val)
 {
 	__atomic_store_n(var, val, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void atomic_store_int32_t(int32_t *var, int32_t val)
-{
-	(void)__sync_lock_test_and_set(var, val);
-}
-#endif
 
 /**
  * @brief Atomically fetch a uint32_t
@@ -2263,17 +1750,10 @@ static inline void atomic_store_int32_t(int32_t *var, int32_t val)
  * @return the value pointed to by var.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint32_t atomic_fetch_uint32_t(uint32_t *var)
 {
 	return __atomic_load_n(var, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint32_t atomic_fetch_uint32_t(uint32_t *var)
-{
-	return __sync_fetch_and_add(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically store a uint32_t
@@ -2285,17 +1765,10 @@ static inline uint32_t atomic_fetch_uint32_t(uint32_t *var)
  * @param[in]     val The value to store
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void atomic_store_uint32_t(uint32_t *var, uint32_t val)
 {
 	__atomic_store_n(var, val, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void atomic_store_uint32_t(uint32_t *var, uint32_t val)
-{
-	(void)__sync_lock_test_and_set(var, val);
-}
-#endif
 
 /**
  * @brief Atomically fetch an int16_t
@@ -2308,17 +1781,10 @@ static inline void atomic_store_uint32_t(uint32_t *var, uint32_t val)
  * @return the value pointed to by var.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int16_t atomic_fetch_int16_t(int16_t *var)
 {
 	return __atomic_load_n(var, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int16_t atomic_fetch_int16_t(int16_t *var)
-{
-	return __sync_fetch_and_add(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically store an int16_t
@@ -2330,17 +1796,10 @@ static inline int16_t atomic_fetch_int16_t(int16_t *var)
  * @param[in]     val The value to store
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void atomic_store_int16_t(int16_t *var, int16_t val)
 {
 	__atomic_store_n(var, val, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void atomic_store_int16_t(int16_t *var, int16_t val)
-{
-	(void)__sync_lock_test_and_set(var, val);
-}
-#endif
 
 /**
  * @brief Atomically fetch a uint16_t
@@ -2353,17 +1812,10 @@ static inline void atomic_store_int16_t(int16_t *var, int16_t val)
  * @return the value pointed to by var.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint16_t atomic_fetch_uint16_t(uint16_t *var)
 {
 	return __atomic_load_n(var, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint16_t atomic_fetch_uint16_t(uint16_t *var)
-{
-	return __sync_fetch_and_add(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically store a uint16_t
@@ -2375,17 +1827,10 @@ static inline uint16_t atomic_fetch_uint16_t(uint16_t *var)
  * @param[in]     val The value to store
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void atomic_store_uint16_t(uint16_t *var, uint16_t val)
 {
 	__atomic_store_n(var, val, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void atomic_store_uint16_t(uint16_t *var, uint16_t val)
-{
-	(void)__sync_lock_test_and_set(var, val);
-}
-#endif
 
 /**
  * @brief Atomically fetch a int8_t
@@ -2398,17 +1843,10 @@ static inline void atomic_store_uint16_t(uint16_t *var, uint16_t val)
  * @return the value pointed to by var.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline int8_t atomic_fetch_int8_t(int8_t *var)
 {
 	return __atomic_load_n(var, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline int8_t atomic_fetch_int8_t(int8_t *var)
-{
-	return __sync_fetch_and_add(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically store a int8_t
@@ -2420,17 +1858,10 @@ static inline int8_t atomic_fetch_int8_t(int8_t *var)
  * @param[in]     val The value to store
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void atomic_store_int8_t(int8_t *var, int8_t val)
 {
 	__atomic_store_n(var, val, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void atomic_store_int8_t(int8_t *var, int8_t val)
-{
-	(void)__sync_lock_test_and_set(var, val);
-}
-#endif
 
 /**
  * @brief Atomically fetch a uint8_t
@@ -2443,17 +1874,10 @@ static inline void atomic_store_int8_t(int8_t *var, int8_t val)
  * @return the value pointed to by var.
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline uint8_t atomic_fetch_uint8_t(uint8_t *var)
 {
 	return __atomic_load_n(var, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline uint8_t atomic_fetch_uint8_t(uint8_t *var)
-{
-	return __sync_fetch_and_add(var, 0);
-}
-#endif
 
 /**
  * @brief Atomically store a uint8_t
@@ -2465,15 +1889,8 @@ static inline uint8_t atomic_fetch_uint8_t(uint8_t *var)
  * @param[in]     val The value to store
  */
 
-#ifdef GCC_ATOMIC_FUNCTIONS
 static inline void atomic_store_uint8_t(uint8_t *var, uint8_t val)
 {
 	__atomic_store_n(var, val, __ATOMIC_SEQ_CST);
 }
-#elif defined(GCC_SYNC_FUNCTIONS)
-static inline void atomic_store_uint8_t(uint8_t *var, uint8_t val)
-{
-	(void)__sync_lock_test_and_set(var, val);
-}
-#endif
 #endif				/* !_ABSTRACT_ATOMIC_H */


### PR DESCRIPTION
This is effectively the same change as in
https://review.gerrithub.io/c/ffilz/nfs-ganesha/+/1199063, but the urgency is much less for ntirpc, as there's no proof that the __sync versions of the functions we have in ntirpc are actually broken. The problematic functions in nfs-ganesha were the ones that had an `unless` variant, and those aren't present in ntirpc's copy.

So this change is purely a code cleanup change: the newer functions, the ones that start with `__atomic`, are over 12 years old and broadly supported. Instead of maintaining two separate implementations, let's just maintain a single one.