### PR TITLE
Shutdown only if CLOSE has been set to xprt->xp_flags

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -562,9 +562,12 @@ static inline void svc_destroy_it(SVCXPRT *xprt,
 		(*(xprt)->xp_ops->xp_unref_user_data)(xprt);
 	}
 
-	/* Let's shutdown the sockets so that FIN-ACK could be sent to the
-	 * client immediately. */
-	if (xprt->xp_fd != RPC_ANYFD) {
+	/* Check if the connection was already set as dead or closed,
+	 * If set, let's cleanup and close the FDs, so that FIN-ACK
+	 * could be sent to the client immediately.
+	 * Also for UDP xprt, this is never set, needn't enter here */
+	if ((atomic_fetch_uint16_t(&xprt->xp_flags) & SVC_XPRT_FLAG_CLOSE)
+	    && xprt->xp_fd != RPC_ANYFD) {
 		(void)shutdown(xprt->xp_fd, SHUT_RDWR);
 		if (xprt->xp_fd_send != RPC_ANYFD)
 			(void)shutdown(xprt->xp_fd_send, SHUT_RDWR);

--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -255,7 +255,7 @@ svc_dg_rendezvous(SVCXPRT *xprt)
 	su->su_dr.maxrec = req_su->su_dr.maxrec;
 	svc_dg_override_ops(newxprt, xprt);
 
- again:
+again:
 	iov.iov_base = &su[1];
 	iov.iov_len = su->su_dr.maxrec;
 	mesgp = &su->su_msghdr;
@@ -281,21 +281,21 @@ svc_dg_rendezvous(SVCXPRT *xprt)
 		return (XPRT_DIED);
 	}
 
-        if (sp->sa_family == (sa_family_t) 0xffff) {
-                __warnx(TIRPC_DEBUG_FLAG_ERROR,
-                        "%s: Bad message sa_family is 0xffff",
-                        __func__);
+	if (sp->sa_family == (sa_family_t) 0xffff) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			"%s: xprt(%p) newxprt(%p) fd %d Bad message sa_family is 0xffff",
+			__func__, xprt, newxprt, newxprt->xp_fd);
 		svc_dg_xprt_free(su);
-                return SVC_STAT(xprt);
-        }
+		return SVC_STAT(xprt);
+	}
 
-        if (rlen == -1 || (rlen < (ssize_t) (4 * sizeof(u_int32_t)))) {
-                __warnx(TIRPC_DEBUG_FLAG_ERROR,
-                        "%s: Bad message rlen: %d",
-                        __func__, rlen);
+	if (rlen == -1 || (rlen < (ssize_t) (4 * sizeof(u_int32_t)))) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				"%s: xprt(%p) newxprt(%p) fd %d Bad message rlen: %d",
+				__func__, xprt, newxprt, newxprt->xp_fd, rlen);
 		svc_dg_xprt_free(su);
-                return SVC_STAT(xprt);
-        }
+		return SVC_STAT(xprt);
+	}
 
 	__rpc_address_setup(&newxprt->xp_local);
 	__rpc_address_setup(&newxprt->xp_remote);
@@ -315,13 +315,13 @@ svc_dg_rendezvous(SVCXPRT *xprt)
 #endif
 
 	xdrmem_create(su->su_dr.ioq.xdrs, iov.iov_base, iov.iov_len,
-		      XDR_DECODE);
+		XDR_DECODE);
 
 	SVC_REF(xprt, SVC_REF_FLAG_NONE);
 	newxprt->xp_parent = xprt;
 
 	atomic_set_uint16_t_bits(&newxprt->xp_flags,
-	    SVC_XPRT_FLAG_READY);
+		SVC_XPRT_FLAG_READY);
 
 	return (xprt->xp_dispatch.rendezvous_cb(newxprt));
 }


### PR DESCRIPTION
This commit fixes a Hung issue, when we try to mount using NFSv3.

FDs getting shutdown/closed was causing issues post rearming the events...This got opened up as part of the changes made in [16daff0c1999c158dec9ad026902401b8ea7a64f](https://github.com/nfs-ganesha/ntirpc/pull/302/commits/16daff0c1999c158dec9ad026902401b8ea7a64f)...Old check put was removed in this patch...If the above changes were reverted, then all works fine...

```
27/08/2024 05:26:26Z : 271645[::ffff:10.46.185.45] [io_10] nfs_rpc_process_request :DISP :DEBUG :Request from ::ffff:10.46.185.45 for Program 100005, Version 3, Function 0 has xid=817545599

...

27/08/2024 05:26:26Z : 271645[::ffff:10.46.185.45] [io_10] rpc :TIRPC :F_DBG :xdr_reply_encode:109 SUCCESS
27/08/2024 05:26:26Z : 271645[none] [io_11] rpc :TIRPC :F_DBG :Trace svc_ref_it() 0x7f0c25279500 fd 0 fd_send 0 xp_refcnt 2 af 0 port 4294967295 xp_flags  @svc_dg_xprt_zalloc:108
27/08/2024 05:26:26Z : 271645[::ffff:10.46.185.45] [io_10] rpc :TIRPC :F_DBG :svc_dg_reply: 0x7f0c261afa80 fd 17 err 32 sendmsg failed (will set dead)
27/08/2024 05:26:26Z : 271645[none] [io_11] rpc :TIRPC :F_DBG :svc_rqst_rearm_events:198 locking
27/08/2024 05:26:26Z : 271645[::ffff:10.46.185.45] [io_10] complete_request :DISP :DEBUG :NFS DISPATCHER: FAILURE: Error while calling svc_sendreply on a new request. rpcxid=817545599 socket=17 function:MNT_NULL client:::ffff:10.46.185.45 program:100005 nfs version:3 proc:0 errno: 32
27/08/2024 05:26:26Z : 271645[none] [io_11] rpc :TIRPC :F_DBG :svc_rqst_rearm_events_locked: xprt 0x7f0c2d869000 fd 17 ev_flags ADDED_RECV
27/08/2024 05:26:26Z : 271645[::ffff:10.46.185.45] [io_10] rpc :TIRPC :F_DBG :Trace svc_destroy_it() 0x7f0c261afa80 fd 17 fd_send 0 xp_refcnt 3 af 10 port 716 xp_flags  INITIAL INITIALIZED DESTROYING @complete_request:1323
27/08/2024 05:26:26Z : 271645[none] [io_11] rpc :TIRPC :F_DBG :svc_rqst_rearm_events_locked: 0x7f0c2d869000 fd 17 xp_refcnt 6 sr_rec 0x7f0c31cb76c0 evchan 8 ev_refcnt 5 epoll_fd 9 control fd pair (7:8) rearm event 0x7f0c2d869528
27/08/2024 05:26:26Z : 271645[none] [io_11] rpc :TIRPC :F_DBG :svc_rqst_rearm_events:202 unlocking @svc_rqst_rearm_events:198
27/08/2024 05:26:26Z : 271645[::ffff:10.46.185.45] [io_10] rpc :TIRPC :F_DBG :Trace svc_release_it() 0x7f0c261afa80 fd 17 fd_send 0 xp_refcnt 2 af 10 port 716 xp_flags  INITIAL INITIALIZED DESTROYING @complete_request:1323
27/08/2024 05:26:26Z : 271645[none] [io_11] rpc :TIRPC :F_DBG :svc_dg_rendezvous: 0x7f0c25279500 fd 17 Bad message sa_family is 0xffff




27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_14] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
27/08/2024 04:53:15Z : 271645[none] [io_13] rpc :TIRPC :F_DBG :svc_dg_rendezvous: Bad message sa_family is 0xffff
```