### PR TITLE
Free up memory allocations in case of failures

### DIFF
--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -283,6 +283,7 @@ svc_dg_rendezvous(SVCXPRT *xprt)
                 __warnx(TIRPC_DEBUG_FLAG_ERROR,
                         "%s: Bad message sa_family is 0xffff",
                         __func__);
+		svc_dg_xprt_free(su);
                 return SVC_STAT(xprt);
         }
 
@@ -290,6 +291,7 @@ svc_dg_rendezvous(SVCXPRT *xprt)
                 __warnx(TIRPC_DEBUG_FLAG_ERROR,
                         "%s: Bad message rlen: %d",
                         __func__, rlen);
+		svc_dg_xprt_free(su);
                 return SVC_STAT(xprt);
         }
 


### PR DESCRIPTION
Ganesha got killed by OOM. Ganesha log file was flooded with below
   
Sep 16 01:39:14 ceph-d0azq5-node2 ceph-2c8e7f60-7392-11ef-bf12-fa163e196fcb-nfs-nfsganesha-1-0-ceph-d0azq5-node2-nnfvgl[63204]: 16/09/2024 05:39:14 : epoch 66e73bbf : ceph-d0azq5-node2 : ganesha.nfsd-2[svc_866] rpc :TIRPC :EVENT :svc_dg_rendezvous: Bad message sa_family is 0xffff    

In case of failures like above in "svc_dg_rendezvous", allocated memory was not released.