### PR TITLE
Reset sx_fbtbc to 0 once we are sure it's haproxy v2 header

### DIFF
--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -1029,6 +1029,7 @@ again:
 					return SVC_STAT(xprt);
 				}
 				/* Now look to see if there's more... */
+	                        xd->sx_fbtbc = 0;
 				hap_again = true;
 				goto again;
 			case HAPROXY_RET_CODE__FAILURE:


### PR DESCRIPTION
When receiving a haproxy v2 message, after processing the first fragment which only contain the proxy header, the ::recv might return EGAIN if the next fragment is not ready to read yet, then the function svc_vc_recv would return, but left xd->sx_fbtbx == 0x0d0a0d0a (PP2_SIG_UINT32), which was set when parsing the haproxy v2 header. When the next fragment is ready, the epoll event for the same xprt will be trigged, then a non-zero xd->sx_fbtbc would deceit sv_vc_recv into derefrencing a NULL uv pointer.

Stack trace:
Thread 76 "ganesha.nfsd" received signal SIGSEGV, Segmentation fault. [Switching to Thread 0x7fc9937ee640 (LWP 2931)]
0x00007fc9f3e30fa6 in svc_vc_recv (xprt=0x7fc9dc00e3b0) at /git/nfs-ganesha/src/libntirpc/src/svc_vc.c:1070 1070 flags = uv->u.uio_flags;
(gdb) bt
#0 0x00007fc9f3e30fa6 in svc_vc_recv (xprt=0x7fc9dc00e3b0) at /git/nfs-ganesha/src/libntirpc/src/svc_vc.c:1070
https://github.com/nfs-ganesha/ntirpc/pull/1 0x00007fc9f3e2baab in svc_rqst_xprt_task_recv (wpe=0x7fc9dc00e680) at /git/nfs-ganesha/src/libntirpc/src/svc_rqst.c:1210
https://github.com/nfs-ganesha/ntirpc/pull/2 0x00007fc9f3e2c740 in svc_rqst_epoll_loop (wpe=0x3003cb8) at /git/nfs-ganesha/src/libntirpc/src/svc_rqst.c:1585
https://github.com/nfs-ganesha/ntirpc/pull/3 0x00007fc9f3e39be8 in work_pool_thread (arg=0x7fc9e007e030) at /git/nfs-ganesha/src/libntirpc/src/work_pool.c:187
https://github.com/nfs-ganesha/ntirpc/pull/4 0x00007fc9f3aa0c52 in start_thread () from /lib64/libc.so.6
https://github.com/nfs-ganesha/ntirpc/pull/5 0x00007fc9f3b24f74 in clone () from /lib64/libc.so.6
(gdb) p uv
$1 = (struct xdr_ioq_uv *) 0x0
(gdb) p xd->sx_fbtbc
$2 = 218762506