### PR TITLE
Proposed fix for coverity issue 502059.

### DIFF
--- a/src/getnetconfig.c
+++ b/src/getnetconfig.c
@@ -231,12 +231,13 @@ getnetconfig(void *handlep)
 	/*
 	 * Verify that handle is valid
 	 */
+	mutex_lock(&nc_mtx);
+
 	if (ncp == NULL || nc_file == NULL) {
 		nc_error = NC_NOTINIT;
+		mutex_unlock(&nc_mtx);
 		return (NULL);
 	}
-
-	mutex_lock(&nc_mtx);
 
 	switch (ncp->valid) {
 	case NC_VALID:


### PR DESCRIPTION
The race condition which might arise due to access of nc_file without acquiring lock on nc_mtx mutex have been fixed by taking lock before access.