### PR TITLE
Handle race with SVC_DESTROY and xprt initialization.

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -178,6 +178,7 @@ typedef struct svc_init_params {
 #define SVC_XPRT_FLAG_UREG		0x0080
 #define SVC_XPRT_TREE_LOCKED		0x0100
 #define SVC_XPRT_FLAG_REMOTE_ADDR_SET	0x0200	/* remote addr was final set */
+#define SVC_XPRT_FLAG_READY		0x0400	/* ready to use */
 
 #define SVC_XPRT_FLAG_DESTROYED (SVC_XPRT_FLAG_DESTROYING \
 				| SVC_XPRT_FLAG_RELEASING)
@@ -547,7 +548,8 @@ static inline void svc_destroy_it(SVCXPRT *xprt,
 	 * initialization to be done
 	 */
 	retry = 0;
-	while (xprt->xp_ops == NULL && retry < SVC_DESTROY_RETRY) {
+	while (!(xprt->xp_flags & SVC_XPRT_FLAG_READY)
+	    && (retry < SVC_DESTROY_RETRY)) {
 		sched_yield();
 		retry += 1;
 	};

--- a/src/svc_dg.c
+++ b/src/svc_dg.c
@@ -213,6 +213,8 @@ svc_dg_ncreatef(const int fd, const u_int sendsz, const u_int recvsz,
 				    RPC_DPLX_LOCKED |
 				    SVC_RQST_FLAG_CHAN_AFFINITY);
 
+	atomic_set_uint16_t_bits(&xprt->xp_flags, SVC_XPRT_FLAG_READY);
+
 	/* release */
 	rpc_dplx_rui(rec);
 	XPRT_TRACE(xprt, __func__, __func__, __LINE__);
@@ -317,6 +319,10 @@ svc_dg_rendezvous(SVCXPRT *xprt)
 
 	SVC_REF(xprt, SVC_REF_FLAG_NONE);
 	newxprt->xp_parent = xprt;
+
+	atomic_set_uint16_t_bits(&newxprt->xp_flags,
+	    SVC_XPRT_FLAG_READY);
+
 	return (xprt->xp_dispatch.rendezvous_cb(newxprt));
 }
 

--- a/src/svc_rdma.c
+++ b/src/svc_rdma.c
@@ -149,6 +149,9 @@ svc_rdma_rendezvous(SVCXPRT *xprt)
 		return (XPRT_DESTROYED);
 	}
 
+	atomic_set_uint16_t_bits(&rdma_xprt->sm_dr.xprt.xp_flags,
+	    SVC_XPRT_FLAG_READY);
+
 	__warnx(TIRPC_DEBUG_FLAG_EVENT,
 		"%s:%u New RDMA client connected xprt %p, xp_fd %d, "
 		"qp_num %d, xp_fd %d is_rdma_enabled %d to local port %d "

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -1322,7 +1322,9 @@ svc_rqst_clean_func(SVCXPRT *xprt, void *arg)
 	if (xprt->xp_flags & (SVC_XPRT_FLAG_DESTROYED | SVC_XPRT_FLAG_UREG))
 		return (false);
 
-	if ((acc->ts.tv_sec - REC_XPRT(xprt)->recv.ts.tv_sec) < acc->timeout)
+	/* Make sure recv.ts is initialized */
+	if (REC_XPRT(xprt)->recv.ts.tv_sec &&
+	    ((acc->ts.tv_sec - REC_XPRT(xprt)->recv.ts.tv_sec) < acc->timeout))
 		return (false);
 
 	SVC_DESTROY(xprt);

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -252,6 +252,9 @@ svc_vc_ncreatef(const int fd, const u_int sendsz, const u_int recvsz,
 				    RPC_DPLX_LOCKED |
 				    SVC_RQST_FLAG_CHAN_AFFINITY);
 
+	atomic_set_uint16_t_bits(&xprt->xp_flags,
+	    SVC_XPRT_FLAG_READY);
+
 	/* release */
 	rpc_dplx_rui(rec);
 	XPRT_TRACE(xprt, __func__, __func__, __LINE__);
@@ -538,6 +541,9 @@ svc_vc_rendezvous(SVCXPRT *xprt)
 		SVC_RELEASE(newxprt, SVC_RELEASE_FLAG_NONE);
 		return (XPRT_DESTROYED);
 	}
+
+	atomic_set_uint16_t_bits(&newxprt->xp_flags,
+	    SVC_XPRT_FLAG_READY);
 
 	__warnx(TIRPC_DEBUG_FLAG_SVC_VC,
 		"New client connected "


### PR DESCRIPTION
We have found couple of issues where svc_rqst_clean_idle trying to SVC_DESTROY xprt which is not completely initialized yet. Hit this stack trace

State is SVC_XPRT_FLAG_INITIAL, which means its not initialized yet.

(gdb) p xprt->xp_flags
$13 = 104

(gdb) p ((struct svc_rqst_clean_arg *)arg)->ts.tv_sec $11 = 1189262
(gdb) p ((struct rpc_dplx_rec *)xprt)->recv.ts.tv_sec $12 = 1189262
(gdb)

recv.ts is same as current time which means it got set after this check

if ((acc->ts.tv_sec - REC_XPRT(xprt)->recv.ts.tv_sec) < acc->timeout)
                return (false);

One fix is to check recv.ts > 0.

Also added new state SVC_XPRT_FLAG_READY to make xprt is ready to use. We have SVC_XPRT_FLAG_INITIALIZED, but xprt is still not completely initialized even with SVC_XPRT_FLAG_INITIALIZED.