### PR TITLE
Ofirvins/next

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -179,6 +179,7 @@ typedef struct svc_init_params {
 #define SVC_XPRT_TREE_LOCKED		0x0100
 #define SVC_XPRT_FLAG_REMOTE_ADDR_SET	0x0200	/* remote addr was final set */
 #define SVC_XPRT_FLAG_READY		0x0400	/* ready to use */
+#define SVC_XPRT_FLAG_IOQ_WRITING	0x0800	/* xprt is used by svc_ioq_write */
 
 #define SVC_XPRT_FLAG_DESTROYED (SVC_XPRT_FLAG_DESTROYING \
 				| SVC_XPRT_FLAG_RELEASING)
@@ -532,7 +533,7 @@ static inline void svc_destroy_it(SVCXPRT *xprt,
 
 	XPRT_TRACE(xprt, __func__, tag, line);
 
-	XPRT_AUTO_TRACEPOINT(xprt, destroy_it, TRACE_DEBUG, "Destroy XPRT");
+	XPRT_AUTO_TRACEPOINT(xprt, destroy_it, TRACE_INFO, "Destroy XPRT");
 
 	if (flags & SVC_XPRT_FLAG_DESTROYING) {
 		/* previously set, do nothing */

--- a/src/clnt_vc.c
+++ b/src/clnt_vc.c
@@ -244,6 +244,7 @@ clnt_vc_ncreatef(const int fd,	/* open file descriptor */
 			__func__, fd);
 		clnt->cl_error.re_status = RPC_CANTENCODEARGS;
 		XDR_DESTROY(ct_xdrs);
+		SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 		goto err;
 	}
 	ct->ct_cx.cx_mpos = XDR_GETPOS(ct_xdrs);

--- a/src/rpcb_clnt.c
+++ b/src/rpcb_clnt.c
@@ -1193,7 +1193,7 @@ char *rpcb_taddr2uaddr(struct netconfig *nconf, struct netbuf *taddr)
 	client = local_rpcb(__func__);
 	if (CLNT_FAILURE(client)) {
 		CLNT_DESTROY(client);
-		return (false);
+		return (NULL);
 	}
 
 	cc = mem_alloc(sizeof(*cc));
@@ -1242,7 +1242,7 @@ struct netbuf *rpcb_uaddr2taddr(struct netconfig *nconf, char *uaddr)
 	client = local_rpcb(__func__);
 	if (CLNT_FAILURE(client)) {
 		CLNT_DESTROY(client);
-		return (false);
+		return (NULL);
 	}
 
 	cc = mem_alloc(sizeof(*cc));

--- a/src/svc_ioq.c
+++ b/src/svc_ioq.c
@@ -318,6 +318,24 @@ void svc_ioq_write(SVCXPRT *xprt)
 	struct rpc_dplx_rec *rec = REC_XPRT(xprt);
 	struct xdr_ioq *xioq;
 	struct poolq_entry *have;
+	bool destroy_xprt = false;
+	struct timespec ts = {
+		.tv_sec = 0,
+		.tv_nsec = 0,
+	};
+	while (atomic_postset_uint16_t_bits(&xprt->xp_flags,
+				SVC_XPRT_FLAG_IOQ_WRITING)
+		       & SVC_XPRT_FLAG_IOQ_WRITING) {
+			nanosleep(&ts, NULL);
+			if (xprt->xp_flags & SVC_XPRT_FLAG_DESTROYED) {
+				XPRT_UNIQUE_AUTO_TRACEPOINT(xprt, ioq_working, TRACE_INFO,
+					"xprt is being cleared, no need for transmit");
+				return;
+			}
+			XPRT_UNIQUE_AUTO_TRACEPOINT(xprt, ioq_working, TRACE_INFO,
+				"xprt is being transmitted by another thread ");
+
+	}
 
 	mutex_lock(&rec->writeq.qmutex);
 	XPRT_UNIQUE_AUTO_TRACEPOINT(xprt, mutex_lock, TRACE_DEBUG,
@@ -349,13 +367,17 @@ void svc_ioq_write(SVCXPRT *xprt)
 		XPRT_UNIQUE_AUTO_TRACEPOINT(xprt, mutex_lock,
 			TRACE_DEBUG, "Locked mutex");
 
-		if (rc < 0) {
+		if (rc < 0 || (xprt->xp_flags & SVC_XPRT_FLAG_DESTROYED)) {
 			/* IO failed, destroy the XPRT but continue the loop in order to
 			   release resources */
 			__warnx(TIRPC_DEBUG_FLAG_SVC_VC,
 				"%s: %p fd %d About to destroy - rc = %d",
 				__func__, xprt, xprt->xp_fd, rc);
-			SVC_DESTROY(xprt);
+			destroy_xprt = true;
+			XPRT_AUTO_TRACEPOINT(xprt, destroy_xprt,
+				TRACE_INFO, "IO failed, destroy xprt.");
+			mutex_unlock(&rec->writeq.qmutex);
+			break;
 		} else if (rc == EWOULDBLOCK){
 			__warnx(TIRPC_DEBUG_FLAG_SVC_VC,
 				"%s: %p fd %d EWOULDBLOCK",
@@ -410,6 +432,12 @@ void svc_ioq_write(SVCXPRT *xprt)
 		SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 		XDR_DESTROY(xioq->xdrs);
 	}
+	atomic_postclear_uint16_t_bits(&xprt->xp_flags,
+				SVC_XPRT_FLAG_IOQ_WRITING);
+
+	if (destroy_xprt) {
+		SVC_DESTROY(xprt);
+	}
 }
 
 static void
@@ -420,33 +448,38 @@ svc_ioq_write_callback(struct work_pool_entry *wpe)
 	svc_ioq_write(xioq->xdrs[0].x_lib[1]);
 }
 
-void
-svc_ioq_write_now(SVCXPRT *xprt, struct xdr_ioq *xioq)
-{
+
+static bool add_ioq_to_write_queue(SVCXPRT *xprt, struct xdr_ioq *xioq) {
 	struct rpc_dplx_rec *rec = REC_XPRT(xprt);
-	bool was_empty;
-
-	SVC_REF(xprt, SVC_REF_FLAG_NONE);
-
+	bool need_processing;
 
 	XPRT_UNIQUE_AUTO_TRACEPOINT(xprt, mutex_lock,
 		TRACE_DEBUG, "Locking mutex");
 	mutex_lock(&rec->writeq.qmutex);
-
-	was_empty = TAILQ_FIRST(&rec->writeq.qh) == NULL;
-
+	if (xprt->xp_flags & SVC_XPRT_FLAG_DESTROYED) {
+		//Queue already cleared, do not add more requests
+		XPRT_UNIQUE_AUTO_TRACEPOINT(xprt, mutex_unlock,
+			TRACE_DEBUG, "Unlocking mutex");
+		mutex_unlock(&rec->writeq.qmutex);
+		XDR_DESTROY(xioq->xdrs);
+		return false;
+	}
+	SVC_REF(xprt, SVC_REF_FLAG_NONE);
+	need_processing = TAILQ_FIRST(&rec->writeq.qh) == NULL;
 	/* always queue output requests on the duplex record's writeq */
 	TAILQ_INSERT_TAIL(&rec->writeq.qh, &(xioq->ioq_s), q);
 
 	XPRT_UNIQUE_AUTO_TRACEPOINT(xprt, mutex_unlock,
 		TRACE_DEBUG, "Unlocking mutex");
 	mutex_unlock(&rec->writeq.qmutex);
+	return need_processing;
+}
 
-	if (was_empty) {
-		/* handle this output request without queuing, then any
-		 * additional output requests without a task switch (using this
-		 * thread).
-		 */
+void
+svc_ioq_write_now(SVCXPRT *xprt, struct xdr_ioq *xioq)
+{
+	const bool need_processing = add_ioq_to_write_queue(xprt, xioq);
+	if (need_processing) {
 		svc_ioq_write(xprt);
 	}
 }
@@ -461,25 +494,9 @@ svc_ioq_write_now(SVCXPRT *xprt, struct xdr_ioq *xioq)
 void
 svc_ioq_write_submit(SVCXPRT *xprt, struct xdr_ioq *xioq)
 {
-	struct rpc_dplx_rec *rec = REC_XPRT(xprt);
-	bool was_empty;
+	const bool need_processing = add_ioq_to_write_queue(xprt, xioq);
 
-	SVC_REF(xprt, SVC_REF_FLAG_NONE);
-
-	mutex_lock(&rec->writeq.qmutex);
-	XPRT_UNIQUE_AUTO_TRACEPOINT(xprt, mutex_lock, TRACE_DEBUG,
-		"Locked mutex");
-
-	was_empty = TAILQ_FIRST(&rec->writeq.qh) == NULL;
-
-	/* always queue output requests on the duplex record's writeq */
-	TAILQ_INSERT_TAIL(&rec->writeq.qh, &(xioq->ioq_s), q);
-
-	XPRT_UNIQUE_AUTO_TRACEPOINT(xprt, mutex_unlock,
-		TRACE_DEBUG, "Unlocking mutex");
-	mutex_unlock(&rec->writeq.qmutex);
-
-	if (was_empty) {
+	if (need_processing) {
 		/* Schedule work to process output for this duplex record. */
 		xioq->ioq_wpe.fun = svc_ioq_write_callback;
 		work_pool_submit(&svc_work_pool, &xioq->ioq_wpe);

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -665,7 +665,7 @@ svc_rqst_rearm_events_locked(SVCXPRT *xprt, uint16_t ev_flags)
 		is_rec_shutdown                      ? "sr_rec->ev_flags SHUTDOWN" : "");
 
 	if (is_xprt_destroyed || is_rec_shutdown)
-		return (0);
+		return (1);
 
 	/* Don't take a ref on the xprt.  We take a ref in hook, and release it
 	 * in unhook. */

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -702,7 +702,6 @@ svc_rqst_rearm_events_locked(SVCXPRT *xprt, uint16_t ev_flags)
 					sr_rec, sr_rec->id_k, sr_rec->ev_refcnt,
 					sr_rec->ev_u.epoll.epoll_fd,
 					sr_rec->sv[0], sr_rec->sv[1], code);
-				SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 			} else {
 				__warnx(TIRPC_DEBUG_FLAG_SVC_RQST |
 					TIRPC_DEBUG_FLAG_REFCNT,
@@ -742,7 +741,6 @@ svc_rqst_rearm_events_locked(SVCXPRT *xprt, uint16_t ev_flags)
 					sr_rec, sr_rec->id_k, sr_rec->ev_refcnt,
 					sr_rec->ev_u.epoll.epoll_fd,
 					sr_rec->sv[0], sr_rec->sv[1], code);
-				SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 			} else {
 				__warnx(TIRPC_DEBUG_FLAG_SVC_RQST |
 					TIRPC_DEBUG_FLAG_REFCNT,

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -1125,6 +1125,51 @@ svc_rqst_xprt_register(SVCXPRT *newxprt, SVCXPRT *xprt)
 	return svc_rqst_evchan_reg(sr_rec->id_k, newxprt, SVC_RQST_FLAG_NONE);
 }
 
+
+/*
+ *  need to clear these requests as they are waiting for epoll, which will
+ *   never be triggered after destroy as it unregisters all events
+ */
+static void clear_requests(struct rpc_dplx_rec *rec) {
+	struct poolq_entry *have;
+	struct xdr_ioq *xioq;
+	struct timespec ts = {
+		.tv_sec = 0,
+		.tv_nsec = 0,
+	};
+
+	while (atomic_postset_uint16_t_bits(&rec->xprt.xp_flags,
+			SVC_XPRT_FLAG_IOQ_WRITING)
+	       & SVC_XPRT_FLAG_IOQ_WRITING) {
+		nanosleep(&ts, NULL);
+		XPRT_UNIQUE_AUTO_TRACEPOINT(&rec->xprt, ioq_clearing, TRACE_INFO,
+			"xprt is being transmitted by another thread, can't clear");
+	}
+
+	int release_count = 0;
+	mutex_lock(&rec->writeq.qmutex);
+	have = TAILQ_FIRST(&rec->writeq.qh);
+	while(have != NULL) {
+		xioq = _IOQ(have);
+		while (atomic_postset_uint16_t_bits(&(xioq->ioq_s.qflags),
+						    IOQ_FLAG_WORKING)
+		       & IOQ_FLAG_WORKING) {
+			nanosleep(&ts, NULL);
+			/* We can't clear request when it is in work pool */
+		}
+
+		release_count++;
+		TAILQ_REMOVE(&rec->writeq.qh, have, q);
+		XDR_DESTROY(xioq->xdrs);
+		have = TAILQ_FIRST(&rec->writeq.qh);
+	}
+	mutex_unlock(&rec->writeq.qmutex);
+
+	for(int i = 0; i < release_count; i++) {
+		SVC_RELEASE(&rec->xprt, SVC_RELEASE_FLAG_NONE);
+	}
+}
+
 /*
  * flags indicate locking state
  *
@@ -1154,6 +1199,7 @@ svc_rqst_xprt_unregister(SVCXPRT *xprt, uint32_t flags)
 		return;
 	}
 	svc_rqst_unreg(rec, sr_rec);
+	clear_requests(rec);
 }
 
 #if defined(USE_RPC_RDMA)
@@ -1396,6 +1442,7 @@ svc_rqst_epoll_event(struct svc_rqst_rec *sr_rec, struct epoll_event *ev)
 
 	xprt = svc_xprt_lookup(ev->data.fd, NULL);
 	if (!xprt) {
+		NTIRPC_AUTO_TRACEPOINT(xprt, epoll_fail_lookup, TRACE_INFO, "no xprt found fd = {}",ev->data.fd);
 		__warnx(TIRPC_DEBUG_FLAG_SVC_RQST,
 			"%s: fd %d no associated xprt",
 			__func__, ev->data.fd);
@@ -1422,6 +1469,8 @@ svc_rqst_epoll_event(struct svc_rqst_rec *sr_rec, struct epoll_event *ev)
 		ioq = rec->ev_u.epoll.xioq_send;
 		fun = svc_rqst_xprt_task_send;
 	} else {
+		XPRT_UNIQUE_AUTO_TRACEPOINT(&rec->xprt, epoll_event, TRACE_INFO,
+			"Unhandled epoll event. ev_flag: {}", ev->events);
 		/* This is some other event... */
 		SVC_RELEASE(&rec->xprt, SVC_RELEASE_FLAG_NONE);
 		return NULL;
@@ -1443,7 +1492,7 @@ svc_rqst_epoll_event(struct svc_rqst_rec *sr_rec, struct epoll_event *ev)
 		ev_flag & SVC_XPRT_FLAG_ADDED_RECV ? " ADDED_RECV" : "",
 		ev_flag & SVC_XPRT_FLAG_ADDED_SEND ? " ADDED_SEND" : "");
 
-	XPRT_AUTO_TRACEPOINT(&rec->xprt, epoll_event, TRACE_DEBUG,
+	XPRT_UNIQUE_AUTO_TRACEPOINT(&rec->xprt, epoll_event, TRACE_DEBUG,
 		"Epoll event. ev_flag: {}", ev_flag);
 
 	if (rec->xprt.xp_refcnt > 1
@@ -1459,7 +1508,8 @@ svc_rqst_epoll_event(struct svc_rqst_rec *sr_rec, struct epoll_event *ev)
 		ioq->rec = rec;
 		return ioq;
 	}
-
+	XPRT_UNIQUE_AUTO_TRACEPOINT(&rec->xprt, epoll_event, TRACE_INFO,
+		"irrelevant epoll event. ev_flag: {}", ev_flag);
 	/* Do not return destroyed transports.
 	 * Probably log non-fatal "WARNING! already destroying!"
 	 */

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -186,6 +186,7 @@ svc_vc_ncreatef(const int fd, const u_int sendsz, const u_int recvsz,
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s: fd %d could not get transport information",
 			__func__, fd);
+		SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 		return (NULL);
 	}
 
@@ -196,6 +197,7 @@ svc_vc_ncreatef(const int fd, const u_int sendsz, const u_int recvsz,
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s: fd %d could not get network information",
 			__func__, fd);
+		SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 		return (NULL);
 	}
 
@@ -239,6 +241,7 @@ svc_vc_ncreatef(const int fd, const u_int sendsz, const u_int recvsz,
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s: fd %d getsockname failed (%d)",
 			 __func__, fd, rc);
+		SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 		return (NULL);
 	}
 
@@ -316,6 +319,7 @@ makefd_xprt(const int fd, const u_int sendsz, const u_int recvsz,
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s: fd %d could not get transport information",
 			__func__, fd);
+		SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 		return (NULL);
 	}
 
@@ -326,6 +330,7 @@ makefd_xprt(const int fd, const u_int sendsz, const u_int recvsz,
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s: fd %d could not get network information",
 			__func__, fd);
+		SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 		return (NULL);
 	}
 
@@ -387,6 +392,7 @@ svc_fd_ncreatef(const int fd, const u_int sendsize, const u_int recvsize,
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s: fd %d getsockname failed (%d)",
 			 __func__, fd, rc);
+		SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 		return (NULL);
 	}
 
@@ -398,6 +404,7 @@ svc_fd_ncreatef(const int fd, const u_int sendsize, const u_int recvsize,
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s: fd %d getpeername failed (%d)",
 			 __func__, fd, rc);
+		SVC_RELEASE(xprt, SVC_RELEASE_FLAG_NONE);
 		return (NULL);
 	}
 	XPRT_TRACE(xprt, __func__, __func__, __LINE__);


### PR DESCRIPTION
Fix XPRT memory leaks.

in cases where XPRT is shutdown when there are requests in queue, xprt will never be released as requests keep reference for xprt but no logic will clear them