### PR TITLE
lttng: Cast all pointer types to intptr_t

### DIFF
--- a/ntirpc/netconfig.h
+++ b/ntirpc/netconfig.h
@@ -12,6 +12,9 @@
 #endif
 #define NETPATH	  "NETPATH"
 
+/* Environment variable to override the location of NETCONFIG */
+#define ENV_NETCONFIG_OVERRIDE "NETCONFIG_OVERRIDE"
+
 struct netconfig {
 	char *nc_netid;		/* Network ID */
 	unsigned long nc_semantics;	/* Semantics (see below) */

--- a/src/getnetconfig.c
+++ b/src/getnetconfig.c
@@ -162,6 +162,13 @@ __nc_error(void)
 	return (nc_addr);
 }
 
+static inline const char* getnetconfig_path(void)
+{
+	/* Overriding netconfig path is used for unit testing */
+	const char *const override = getenv(ENV_NETCONFIG_OVERRIDE);
+	return override != NULL ? override : NETCONFIG;
+}
+
 #define nc_error        (*(__nc_error()))
 /*
  * A call to setnetconfig() establishes a /etc/netconfig "session".  A session
@@ -196,7 +203,7 @@ setnetconfig(void)
 	ni.ref++;
 
 	if (!nc_file) {
-		nc_file = fopen(NETCONFIG, "r");
+		nc_file = fopen(getnetconfig_path(), "r");
 		if (!nc_file) {
 			ni.ref--;
 			mutex_unlock(&nc_mtx);
@@ -437,7 +444,7 @@ getnetconfigent(const char *netid)
 		}
 	}
 
-	file = fopen(NETCONFIG, "r");
+	file = fopen(getnetconfig_path(), "r");
 	if (!file) {
 		nc_error = NC_NONETCONFIG;
 		mutex_unlock(&nc_mtx);

--- a/src/lttng/generator/TracepointArgument.h
+++ b/src/lttng/generator/TracepointArgument.h
@@ -142,7 +142,7 @@ public:
 
     if (argType_->isPointerType()) {
       return std::string("ctf_integer_hex(") + "intptr_t" + ", " + argName_ +
-             ", " + argName_ + ")";
+             ", (intptr_t)" + argName_ + ")";
     }
 
     auto enumType = llvm::dyn_cast<clang::EnumType>(argType_);

--- a/src/xdr_mem.c
+++ b/src/xdr_mem.c
@@ -85,13 +85,19 @@ xdrmem_ncreate(XDR *xdrs, char *addr, u_int size, enum xdr_op op)
 		xdrs->x_v.vio_tail = addr;
 		break;
 	case XDR_DECODE:
-		xdrs->x_v.vio_tail = addr + size;
+		if (addr)
+			xdrs->x_v.vio_tail = addr + size;
+		else
+			xdrs->x_v.vio_tail = NULL;
 		break;
 	default:
 		abort();
 		break;
 	};
-	xdrs->x_v.vio_wrap = addr + size;
+	if (addr)
+		xdrs->x_v.vio_wrap = addr + size;
+	else
+		xdrs->x_v.vio_wrap = NULL;
 	xdrs->x_base = &xdrs->x_v;
 }
 


### PR DESCRIPTION
Solves a compilation error of-
error: initialization of ‘intptr_t’ {aka ‘long int’} from ‘const void *’ makes integer from pointer without a cast [-Wint-conversion]

When trying to compile with LTTNG traces for libntirpc