### PR TITLE
Add external svc_work_pool variable for thread utilization tracking.

### DIFF
--- a/src/libntirpc.map.in.cmake
+++ b/src/libntirpc.map.in.cmake
@@ -167,6 +167,7 @@ NTIRPC_${NTIRPC_VERSION_BASE} {
     svcerr_progvers;
     svcerr_systemerr;
     svcerr_weakauth;
+    svc_work_pool;
 
     # t*
     taddr2uaddr;


### PR DESCRIPTION
This commit introduces a new structure variable named svc_work_pool within the libntirpc.map.in.cmake file. This variable is designed to be reusable by various projects, including nfs-ganesha. By leveraging svc_work_pool, these projects can effectively extract information regarding threads associated with RPC calls. 
This enhancement facilitates improved thread utilization monitoring across projects that interact with libntirpc