### PR TITLE
Registered function for accessing thread utilization parameters

### DIFF
--- a/ntirpc/rpc/types.h
+++ b/ntirpc/rpc/types.h
@@ -168,7 +168,7 @@ typedef void *(*mem_p_size_t) (void *, size_t,
 typedef void (*mem_free_size_t) (void *, size_t);
 typedef void (*mem_format_t) (const char *fmt, ...);
 typedef void (*mem_char_t) (const char *);
-
+typedef void (*mem_int_t) (uint32_t ,int32_t );
 /*
  * Package params support
  */
@@ -182,6 +182,8 @@ typedef struct tirpc_pkg_params {
 	mem_2_size_t	aligned_;
 	mem_2_size_t	calloc_;
 	mem_p_size_t	realloc_;
+	mem_int_t       mon_thread_name_;
+
 } tirpc_pkg_params;
 
 extern tirpc_pkg_params __ntirpc_pkg_params;

--- a/ntirpc/rpc/types.h
+++ b/ntirpc/rpc/types.h
@@ -182,7 +182,7 @@ typedef struct tirpc_pkg_params {
 	mem_2_size_t	aligned_;
 	mem_2_size_t	calloc_;
 	mem_p_size_t	realloc_;
-	mem_int_t       mon_thread_name_;
+	mem_int_t       monitor_threads;
 
 } tirpc_pkg_params;
 

--- a/src/rpc_generic.c
+++ b/src/rpc_generic.c
@@ -77,6 +77,10 @@ tirpc_thread_name(const char *p)
 	/* do nothing */
 }
 
+void tirpc_mon_thread_name(uint32_t p,int32_t q)
+{
+	/* do nothing */
+}
 static void
 tirpc_free(void *p, size_t unused)
 {
@@ -137,6 +141,7 @@ tirpc_pkg_params __ntirpc_pkg_params = {
 	tirpc_aligned,
 	tirpc_calloc,
 	tirpc_realloc,
+	tirpc_mon_thread_name,
 };
 
 bool

--- a/src/rpc_generic.c
+++ b/src/rpc_generic.c
@@ -77,7 +77,7 @@ tirpc_thread_name(const char *p)
 	/* do nothing */
 }
 
-void tirpc_mon_thread_name(uint32_t p,int32_t q)
+void tirpc_mon_thread_name(uint32_t p, int32_t q)
 {
 	/* do nothing */
 }

--- a/src/work_pool.c
+++ b/src/work_pool.c
@@ -174,6 +174,7 @@ work_pool_thread(void *arg)
 			      && pool->n_threads < pool->params.thrd_max;
 			if (spawn)
 				pool->n_threads++;
+			__ntirpc_pkg_params.mon_thread_name_(pool->n_threads,pool->params.thrd_max);
 			pthread_mutex_unlock(&pool->pqh.qmutex);
 
 			if (spawn) {
@@ -251,6 +252,7 @@ work_pool_thread(void *arg)
 		 pool->pqh.qcount < pool->params.thrd_min);
 
 	pool->n_threads--;
+	__ntirpc_pkg_params.mon_thread_name_(pool->n_threads,pool->params.thrd_max);
 	pthread_mutex_unlock(&pool->pqh.qmutex);
 
 	__warnx(TIRPC_DEBUG_FLAG_WORKER,

--- a/src/work_pool.c
+++ b/src/work_pool.c
@@ -252,7 +252,7 @@ work_pool_thread(void *arg)
 		 pool->pqh.qcount < pool->params.thrd_min);
 
 	pool->n_threads--;
-	__ntirpc_pkg_params.mon_thread_name_(pool->n_threads,pool->params.thrd_max);
+	__ntirpc_pkg_params.monitor_threads(pool->n_threads,pool->params.thrd_max);
 	pthread_mutex_unlock(&pool->pqh.qmutex);
 
 	__warnx(TIRPC_DEBUG_FLAG_WORKER,

--- a/src/work_pool.c
+++ b/src/work_pool.c
@@ -174,7 +174,7 @@ work_pool_thread(void *arg)
 			      && pool->n_threads < pool->params.thrd_max;
 			if (spawn)
 				pool->n_threads++;
-			__ntirpc_pkg_params.mon_thread_name_(pool->n_threads,pool->params.thrd_max);
+			__ntirpc_pkg_params.monitor_threads(pool->n_threads, pool->params.thrd_max);
 			pthread_mutex_unlock(&pool->pqh.qmutex);
 
 			if (spawn) {


### PR DESCRIPTION
This change introduces a new function that provides access to thread utilization parameters. This information is dynamically updated whenever a thread is spawned or released. The updates are triggered by calling the function registered with mon_thread_name holder/ function pointer.
