### PR TITLE
Libntirpc code changes for QoS.

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -314,6 +314,7 @@ struct svc_xprt {
 	int32_t xp_refcnt;	/* handle reference count */
 	uint16_t xp_flags;	/* flags */
 	uint32_t xp_unique_id;
+	bool recv_rearm_allowed;
 
 	union {
 		struct in_pktinfo in;
@@ -406,6 +407,10 @@ struct svc_req {
 #define svc_getrpclocal(x) (&(x)->xp_local.ss)
 
 extern void svc_resume(struct svc_req *req);
+
+extern void svc_rqst_qos_suspend_socket(struct svc_xprt *xprt);
+
+extern void svc_rqst_qos_resume_socket(struct svc_xprt *xprt);
 
 /*
  * Ganesha.  Get connected transport type.

--- a/src/libntirpc.map.in.cmake
+++ b/src/libntirpc.map.in.cmake
@@ -138,6 +138,8 @@ NTIRPC_${NTIRPC_VERSION_BASE} {
     svc_raw_ncreate;
     svc_reg;
     svc_resume;
+    svc_rqst_qos_suspend_socket;
+    svc_rqst_qos_resume_socket;
     svc_rqst_new_evchan;
     svc_rqst_evchan_reg;
     svc_rqst_evchan_unreg;

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -674,6 +674,14 @@ svc_rqst_rearm_events_locked(SVCXPRT *xprt, uint16_t ev_flags)
 	struct svc_rqst_rec *sr_rec = rec->ev_p;
 	int code = EINVAL;
 
+	if (!xprt->recv_rearm_allowed
+	    && (ev_flags & SVC_XPRT_FLAG_ADDED_RECV)) {
+		__warnx(TIRPC_DEBUG_FLAG_SVC_RQST,
+				"Failed to rearm as fd %d is suspended",
+				rec->xprt.xp_fd);
+		return 0;
+	}
+
 	XPRT_AUTO_TRACEPOINT(xprt, rearm, TRACE_DEBUG,
 		"Rearm. ev_flags: {}", ev_flags);
 
@@ -1797,6 +1805,22 @@ svc_rqst_delete_evchan(uint32_t chan_id)
 
 	svc_rqst_release(sr_rec);
 	return (code);
+}
+
+void svc_rqst_qos_suspend_socket(struct svc_xprt *xprt)
+{
+	xprt->recv_rearm_allowed = false;
+}
+
+void svc_rqst_qos_resume_socket(struct svc_xprt *xprt)
+{
+	xprt->recv_rearm_allowed = true;
+	if (unlikely(svc_rqst_rearm_events(xprt, SVC_XPRT_FLAG_ADDED_RECV))) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				"%s: %p fd %d svc_rqst_rearm_events failed",
+				__func__, xprt, xprt->xp_fd);
+	}
+	SVC_STAT(xprt);
 }
 
 void

--- a/src/svc_xprt.c
+++ b/src/svc_xprt.c
@@ -192,7 +192,7 @@ svc_xprt_lookup(int fd, svc_xprt_setup_t setup)
 			xprt->xp_dispatch.remote_addr_set_cb = NULL;
 			xprt->xp_unique_id =
 					atomic_inc_uint32_t(&xprt_unique_id);
-
+			xprt->recv_rearm_allowed = true;
 			/* Get ref for caller */
 			SVC_REF(xprt, SVC_REF_FLAG_NONE);
 


### PR DESCRIPTION
For QoS, two callbacks are added in libntirpc so that these callbacks can be called by nfs-ganesha to disable or enable RECEIVE events on a socket. 