### PR TITLE
We hit this crash recently, due to existing xprt using same fd, which…

### DIFF
--- a/src/svc_xprt.c
+++ b/src/svc_xprt.c
@@ -243,8 +243,17 @@ svc_xprt_lookup(int fd, svc_xprt_setup_t setup)
 	 * (obviating extra atomic fetch).
 	 */
 	rpc_dplx_rli(rec);
-	xp_flags = atomic_clear_uint16_t_bits(&xprt->xp_flags,
-					      SVC_XPRT_FLAG_INITIAL);
+
+	/* We could end up here while xprt is not initialized yet,
+	 * So clear SVC_XPRT_FLAG_INITIAL only if xprt is initialized */
+
+	xp_flags = atomic_fetch_uint16_t(&xprt->xp_flags);
+
+	if (xp_flags & SVC_XPRT_FLAG_READY) {
+		xp_flags = atomic_clear_uint16_t_bits(&xprt->xp_flags,
+		    SVC_XPRT_FLAG_INITIAL);
+	}
+
 	rpc_dplx_rui(rec);
 
 	if (!(xp_flags & SVC_XPRT_FLAG_DESTROYED)) {


### PR DESCRIPTION
… means

rbtree have some xprt for which xp_fd is closed.
Which should not happen since as per code,
if any xprt is part of rbtree xp_fd should be valid, we close xp_fd only after svc_rqst_xprt_unregister which should remove it from rbtree.

(gdb) bt
(gdb) f 3
613             (*(xprt)->xp_ops->xp_unlink)(xprt, flags, tag, line);
(gdb) p xprt->xp_ops
$31 = (struct xp_ops *) 0x0
(gdb) p /x xprt->xp_flags
$32 = 0x38
(gdb) p /x xprt->xp_refcnt
$33 = 0x2<======================refcnt=2 means this xprt is new and not the existing one,
but some how SVC_XPRT_FLAG_INITIAL is cleared
(gdb) p xprt->xp_fd
$34 = 81
(gdb) f 4
479                             SVC_DESTROY(newxprt);
(gdb) list
474             newxprt = makefd_xprt(fd, req_xd->sx_dr.sendsz, req_xd->sx_dr.recvsz,
475                                   &si, SVC_XPRT_FLAG_CLOSE);
476             if ((!newxprt) || (!(newxprt->xp_flags & SVC_XPRT_FLAG_INITIAL))) {<==========================This is the problem.
477
478                     if (newxprt) {
479                             SVC_DESTROY(newxprt);<==============We don't have xprt fully initialized yet so it crashed.
480                             /* Was never added to epoll */
481                             SVC_RELEASE(newxprt, SVC_RELEASE_FLAG_NONE);
482                     } else {
483                             close(fd);
(gdb)

We could also see lot of these failures around same time 12/02/2025 04:22:21Z : ntnx-10-46-110-46-a-fsvm 3607243[::ffff:10.51.0.112] [io_528] rpc :TIRPC :EVENT :svc_ioq_flushv: 0x7f45635cc800 fd 51 msg_iov 0x7f44b9ed25d0 sendmsg remaining 112 result -1 error Broken pipe (32)

This could be scenario where xp_fd=x for xprt_a
Thread1 at t1:
There is failure in sendmsg path and we did release of xprt_a, which should close xp_fd=x

Thread2 at t2:
xp_fd=x got reused for xprt_b initialisation

Thread3 at t3:
Processing epoll events received before t1, which could have event for xp_fd=x added as part of xprt_a But now as part of svc_xprt_lookup it will get xprt_b for xp_fd=x Now we will clear the SVC_XPRT_INITIAL_FLAG for xprt_b which may not be initialised yet. xp_unique_id will help to not process this event further.

So Thread2 could get the xprt_b from makers_xprt without SVC_XPRT_INITIAL_FLAG and we will hit this issue. So we should not clean SVC_XPRT_INITIAL_FLAG unless xprt is ready.