### PR TITLE
ntirpc/rpc/svc.h: Fix SEGV.

### DIFF
--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -557,7 +557,8 @@ static inline void svc_destroy_it(SVCXPRT *xprt,
 	};
 
 	/* unlink before dropping last ref */
-	(*(xprt)->xp_ops->xp_unlink)(xprt, flags, tag, line);
+	if ((xprt)->xp_ops->xp_unlink)
+		(*(xprt)->xp_ops->xp_unlink)(xprt, flags, tag, line);
 
 	/* Remove references: of xprt from user-data; of user-data from xprt */
 	if ((xprt)->xp_ops->xp_unref_user_data) {

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -1373,15 +1373,7 @@ svc_rqst_xprt_task_send(struct work_pool_entry *wpe)
 	XPRT_AUTO_TRACEPOINT(&rec->xprt, task_send, TRACE_DEBUG,
 		"Task send");
 
-	/* atomic barrier (above) should protect following values */
-	if (rec->xprt.xp_refcnt > 1
-	    && !(rec->xprt.xp_flags & SVC_XPRT_FLAG_DESTROYED)) {
-		/* (idempotent) xp_flags and xp_refcnt are set atomic.
-		 * xp_refcnt need more than 1 (this task).
-		 */
-		svc_ioq_write(&rec->xprt);
-	}
-
+	svc_ioq_write(&rec->xprt);
 	SVC_RELEASE(&rec->xprt, SVC_RELEASE_FLAG_NONE);
 }
 


### PR DESCRIPTION
This can happen if SVC_DESTROY is called before svc_vc_override_ops.