### PR TITLE
fix monitoring lib loading multiple times

### DIFF
--- a/src/monitoring/CMakeLists.txt
+++ b/src/monitoring/CMakeLists.txt
@@ -6,7 +6,7 @@ SET(ntirpcmonitoring_SRCS
   monitoring.cc
 )
 
-add_library(ntirpcmonitoring ${ntirpcmonitoring_SRCS})
+add_library(ntirpcmonitoring SHARED ${ntirpcmonitoring_SRCS})
 add_sanitizers(ntirpcmonitoring)
 set_target_properties(ntirpcmonitoring PROPERTIES COMPILE_FLAGS "-fPIC")
 target_include_directories(ntirpcmonitoring     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/prometheus-cpp-lite/core/include)


### PR DESCRIPTION
Before this fix the library would have loaded multiple times - from libntirpc, libganesha_nfsd, ganesha.nfsd. This resulted in multiple instances of the promethues registry.

This commit fixes the issue so the library will only load once in ganesha.