### PR TITLE
Expose thread utilization parameters as metrics.

### DIFF
--- a/src/metrics_libntirpc.c
+++ b/src/metrics_libntirpc.c
@@ -30,6 +30,11 @@ get_generic_op_status_name(generic_op_status_t op_status)
 
 /* Concurrent TCP Connections */
 static gauge_metric_handle_t concurrent_tcp_metric;
+
+/* Thread utilization metrics */
+static gauge_metric_handle_t threads_scheduled;
+static gauge_metric_handle_t threads_schedulable;
+
 static bool initialized = false;
 
 /* For each security-flavor as an array index, assign a serial number to be
@@ -215,6 +220,19 @@ static const char *get_svc_auth_op_string(svc_auth_op_t op)
 	}
 }
 
+void register_gss_threads_metrics(void)
+{
+	const metric_label_t empty_labels[] = {};
+	threads_scheduled = monitoring__register_gauge(
+		"Threads_currently_scheduled",
+		METRIC_METADATA("no.of threads in usage", METRIC_UNIT_NONE),
+		empty_labels, ARRAY_SIZE(empty_labels));
+	threads_schedulable = monitoring__register_gauge(
+		"threads_schedulable",
+		METRIC_METADATA("no.of threads schedulable", METRIC_UNIT_NONE),
+		empty_labels, ARRAY_SIZE(empty_labels));
+}
+
 static void register_svc_auth_request_latency_metric(void)
 {
 	int sf, as;
@@ -326,6 +344,13 @@ static void register_gss_svc_auth_ops_latency_metric(void)
 #endif
 }
 
+void metrics_libntirpc_update_threads_info_gauge(
+	uint32_t under_utilization_thrds, uint32_t schedulable_thrds_count)
+{
+	monitoring__gauge_set(threads_scheduled, under_utilization_thrds);
+	monitoring__gauge_set(threads_schedulable, schedulable_thrds_count);
+}
+
 void metrics_libntirpc_observe_svc_auth_request_latency(
 	int sec_flavor, enum auth_stat auth_status,
 	const struct timespec *latency)
@@ -339,6 +364,7 @@ void metrics_libntirpc_observe_svc_auth_request_latency(
 }
 
 #ifdef _HAVE_GSSAPI
+
 void metrics_libntirpc_observe_gss_svc_auth_step_latency(
 	gss_svc_auth_step_t step, rpc_gss_svc_t svc, bool step_succeeded,
 	const struct timespec *latency)
@@ -376,10 +402,9 @@ void metrics_libntirpc_init(void)
 		"libntirpc__tcp_connections_count",
 		METRIC_METADATA("TCP connections count", METRIC_UNIT_NONE),
 		empty_labels, ARRAY_SIZE(empty_labels));
-
+	register_gss_threads_metrics();
 	register_svc_auth_request_latency_metric();
 	register_gss_svc_auth_steps_latency_metric();
 	register_gss_svc_auth_ops_latency_metric();
-
 	initialized = true;
 }

--- a/src/metrics_libntirpc.h
+++ b/src/metrics_libntirpc.h
@@ -25,6 +25,9 @@ typedef enum svc_auth_op {
 void metrics_libntirpc_update_tcp_connection_count(int connection_count);
 void metrics_libntirpc_observe_svc_auth_request_latency(
 	int sec_flavor, enum auth_stat, const struct timespec *latency);
+void register_gss_threads_metrics(void);
+void metrics_libntirpc_update_threads_info_gauge(uint32_t under_utilization_thrds, uint32_t schedulable_thrds_count);
+
 #ifdef _HAVE_GSSAPI
 void metrics_libntirpc_observe_gss_svc_auth_step_latency(
 	gss_svc_auth_step_t, rpc_gss_svc_t, bool step_succeeded,

--- a/src/work_pool.c
+++ b/src/work_pool.c
@@ -59,6 +59,9 @@
 #include <urcu-bp.h>
 
 #include <rpc/work_pool.h>
+#ifdef USE_MONITORING
+#include "metrics_libntirpc.h"
+#endif
 
 #define WORK_POOL_STACK_SIZE MAX(1 * 1024 * 1024, PTHREAD_STACK_MIN)
 #define WORK_POOL_TIMEOUT_MS (31 /* seconds (prime) */ * 1000)
@@ -174,6 +177,9 @@ work_pool_thread(void *arg)
 			      && pool->n_threads < pool->params.thrd_max;
 			if (spawn)
 				pool->n_threads++;
+#ifdef USE_MONITORING
+			metrics_libntirpc_update_threads_info_gauge(pool->n_threads,pool->params.thrd_max);
+#endif
 			pthread_mutex_unlock(&pool->pqh.qmutex);
 
 			if (spawn) {
@@ -251,6 +257,9 @@ work_pool_thread(void *arg)
 		 pool->pqh.qcount < pool->params.thrd_min);
 
 	pool->n_threads--;
+#ifdef USE_MONITORING
+	metrics_libntirpc_update_threads_info_gauge(pool->n_threads,pool->params.thrd_max);
+#endif
 	pthread_mutex_unlock(&pool->pqh.qmutex);
 
 	__warnx(TIRPC_DEBUG_FLAG_WORKER,


### PR DESCRIPTION
This change will add a new metrics which shows the
1)no.of threads which are under usage
2) max no.of threads can be scheduled and also 
