### PR TITLE
    Fix for Inline Data Issue in RDMA Write

### DIFF
--- a/src/xdr_ioq.c
+++ b/src/xdr_ioq.c
@@ -994,9 +994,16 @@ xdr_ioq_getstartdatapos_rdma(XDR *xdrs, u_int start, u_int datalen)
 	 * nfs_buffer, so calculate offset for end of nfs_buffer */
 	if (datalen > ((uintptr_t)xdrs->x_v.vio_tail - (uintptr_t)xdrs->x_data)) {
 		offset = (uintptr_t)xdrs->x_v.vio_tail - (uintptr_t)xdrs->x_data;
+		return start + offset;
 	}
 
-	return start + offset;
+	/*
+	 * Small RDMA Writes
+	 * If data is inline, it should be part of nfs_buffer itself.
+	 * So, to avoid the ILLEGAL_OP, start should advance by datalen
+	 * to pick the correct OP while decoding the COMPOUND ops.
+	 */
+	return start + datalen;
 
 }
 


### PR DESCRIPTION
    During small RDMA writes, an ILLEGAL_OP was encountered immediately
    after the WRITE operation while decoding the COMPOUND operations.
    The following log entry was captured in the ganesha.log file.

    nfs4_Compound :NFS4 :F_DBG :COMPOUND: There are 4 operations
    nfs4 operations {SEQUENCE, PUTFH, WRITE, ILLEGAL}.

    To address this issue, the function xdr_ioq_getstartdatapos_rdma() has
    been updated with logic to handle scenarios where data is inlined. When
    data is inline, it must be included as part of the nfs_buffer itself.
    Therefore, to prevent an ILLEGAL_OP, the starting offset should be
    advanced by datalen to correctly identify the next operation during
    the decoding of COMPOUND operations.