### PR TITLE
Switch from MD5 to SAH512

### DIFF
--- a/src/lttng/generator/generate_cmake_rules.py
+++ b/src/lttng/generator/generate_cmake_rules.py
@@ -435,7 +435,7 @@ class CmakeRulesGenerator:
 
   def _get_file_hash(self, file: str) -> str:
     hash_len = 6
-    return hashlib.md5(file.encode()).hexdigest()[:hash_len]
+    return hashlib.sha512(file.encode()).hexdigest()[:hash_len]
 
   def _generate_file_properties(self, dependant_files: Iterable[str]) -> str:
     out = ""


### PR DESCRIPTION
Some Static Analysis tools consider use of MD5 a security issue, and raise warnings when it's used. This PR removes a use of MD5 and replaces it with SHA512, which is not considered a security issue.

The use of MD5 in this file is not (and never was) a security issue - this is used for detecting file changes, not for any authentication/cryptographic purposes, and so a cryptographically secure hash is not required - MD5 is safe and fine. But SHA512 also works for us here, so switching doesn't inconvenience us much, and makes these static analysis tools happier.