### PR TITLE
Fix crash for HAPROXY_RET_CODE__IGNORE_LOCAL

### DIFF
--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -828,7 +828,7 @@ static enum haproxy_ret_code handle_haproxy_header(SVCXPRT *xprt)
 	rlen = recv(xprt->xp_fd, rest, sizeof(rest), MSG_WAITALL | MSG_PEEK);
 	if (rlen != sizeof(rest)) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
-			"%s: %p fd %d proxy header failed rest rlen = %z "
+			"%s: %p fd %d proxy header failed rest rlen = %zd "
 			"(will set dead)",
 			__func__, xprt, xprt->xp_fd, rlen);
 		return HAPROXY_RET_CODE__FAILURE;
@@ -850,7 +850,7 @@ static enum haproxy_ret_code handle_haproxy_header(SVCXPRT *xprt)
 	rlen = recv(xprt->xp_fd, rest, sizeof(rest), MSG_WAITALL);
 	if (rlen != sizeof(rest)) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
-			"%s: %p fd %d proxy header failed rest rlen = %z "
+			"%s: %p fd %d proxy header failed rest rlen = %zd "
 			"(will set dead)",
 			__func__, xprt, xprt->xp_fd, rlen);
 		return HAPROXY_RET_CODE__FAILURE;
@@ -860,7 +860,7 @@ static enum haproxy_ret_code handle_haproxy_header(SVCXPRT *xprt)
 
 	if (rlen != sizeof(s)) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
-			"%s: %p fd %d proxy header failed header rlen = %z "
+			"%s: %p fd %d proxy header failed header rlen = %zd "
 			"(will set dead)",
 			__func__, xprt, xprt->xp_fd, rlen);
 		return HAPROXY_RET_CODE__FAILURE;
@@ -870,7 +870,7 @@ static enum haproxy_ret_code handle_haproxy_header(SVCXPRT *xprt)
 	if (unlikely(s.len > sizeof(pa))) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s: %p fd %d incorrect proxy header "
-			"addr len = %z (will set dead)",
+			"addr len = %zd (will set dead)",
 			__func__, xprt, xprt->xp_fd, s.len);
 		return HAPROXY_RET_CODE__FAILURE;
 	}
@@ -880,7 +880,7 @@ static enum haproxy_ret_code handle_haproxy_header(SVCXPRT *xprt)
 	if (rlen != s.len) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s: %p fd %d proxy header rest len failed header "
-			"rlen = %z (will set dead)",
+			"rlen = %zd (will set dead)",
 			__func__, xprt, xprt->xp_fd, rlen);
 		return HAPROXY_RET_CODE__FAILURE;
 	}
@@ -902,7 +902,7 @@ static enum haproxy_ret_code handle_haproxy_header(SVCXPRT *xprt)
 			if (unlikely(s.len < sizeof(pa.ip4))) {
 				__warnx(TIRPC_DEBUG_FLAG_ERROR,
 					"%s: %p fd %d incorrect proxy header "
-					"ipv4 addr len = %z (will set dead)",
+					"ipv4 addr len = %zd (will set dead)",
 					__func__, xprt, xprt->xp_fd, s.len);
 				return HAPROXY_RET_CODE__FAILURE;
 			}
@@ -922,7 +922,7 @@ static enum haproxy_ret_code handle_haproxy_header(SVCXPRT *xprt)
 			if (unlikely(s.len < sizeof(pa.ip6))) {
 				__warnx(TIRPC_DEBUG_FLAG_ERROR,
 					"%s: %p fd %d incorrect proxy header "
-					"ipv6 addr len = %z (will set dead)",
+					"ipv6 addr len = %zd (will set dead)",
 					__func__, xprt, xprt->xp_fd, s.len);
 				return HAPROXY_RET_CODE__FAILURE;
 			}
@@ -1080,6 +1080,8 @@ again:
 				SVC_DESTROY(xprt);
 				return SVC_STAT(xprt);
 			case HAPROXY_RET_CODE__IGNORE_LOCAL:
+				/* clear off sx_fbtbc */
+	                        xd->sx_fbtbc = 0;
 				return SVC_STAT(xprt);
 			case HAPROXY_RET_CODE__NOT_HAPROXY:
 				break;


### PR DESCRIPTION
Ganesha is crashing with backtrace
(gdb) bt
#0  svc_vc_recv (xprt=0x7fa07c003d20) at /usr/src/debug/libntirpc-6.3-2.el9cp.x86_64/src/svc_vc.c:1071
#1  0x00007fa17cf7ce5a in svc_rqst_xprt_task_recv (wpe=<optimized out>) at /usr/src/debug/libntirpc-6.3-2.el9cp.x86_64/src/svc_rqst.c:1210
#2  0x00007fa17cf7f91b in svc_rqst_epoll_loop (wpe=0x55b0ab7385a8) at /usr/src/debug/libntirpc-6.3-2.el9cp.x86_64/src/svc_rqst.c:1585
#3  0x00007fa17cf88cbc in work_pool_thread (arg=0x7fa090015a80) at /usr/src/debug/libntirpc-6.3-2.el9cp.x86_64/src/work_pool.c:187
#4  0x00007fa17d0287fa in start_thread () from /lib64/libc.so.6
#5  0x00007fa17d0ad820 in clone3 () from /lib64/libc.so.6
(gdb) f 0
#0  svc_vc_recv (xprt=0x7fa07c003d20) at /usr/src/debug/libntirpc-6.3-2.el9cp.x86_64/src/svc_vc.c:1071
1071			flags = uv->u.uio_flags;

The crash is observed after below log entry
rpc :TIRPC :EVENT :handle_haproxy_header: 0x7f64ec001670 fd 66 proxy ignored for local

So need to handle case of HAPROXY_RET_CODE__IGNORE_LOCAL. Basically need to clear of "xd->sx_fbtbc", so that next invocation of svc_vc_recv will not try to deference NULL uv pointer.

Also corrected printing of ssize_t type.