### PR TITLE
build: bump cmake_minimum_required to 3.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 # Current version as of Fedora 16.  Not tested with earlier.
 
-cmake_minimum_required(VERSION 2.6.3)
+cmake_minimum_required(VERSION 3.5.0)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 


### PR DESCRIPTION
This PR updates the minimum CMake version required to ensure compatibility with newer build features.