### PR TITLE
Rdma fixes

### DIFF
--- a/src/clnt_rdma.c
+++ b/src/clnt_rdma.c
@@ -231,6 +231,19 @@ clnt_rdma_call(struct clnt_req *cc)
 	struct cx_data *cx = CX_DATA(cl);
 	struct rpc_dplx_rec *rec = cx->cx_rec;
 	RDMAXPRT *rdma_xprt = RDMA_DR(rec);
+
+	/* Check if adding this callback would exceed MAX_RDMA_CALLBACKS
+	 * before allocating any resources to avoid cleanup overhead */
+	uint32_t active_callbacks = atomic_fetch_uint32_t(&rdma_xprt->active_client_callbacks);
+	if (active_callbacks >= MAX_RDMA_CALLBACKS) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		    "%s: active_client_callbacks %u >= MAX_RDMA_CALLBACKS %u, "
+		    "cannot post new RDMA callback",
+		    __func__, active_callbacks, MAX_RDMA_CALLBACKS);
+		cl->cl_error.re_errno = EAGAIN;
+		return (RPC_CANTSEND);
+	}
+
 	struct poolq_entry *have =
 		xdr_rdma_ioq_uv_fetch(&rdma_xprt->sm_dr.ioq, &rdma_xprt->cbqh,
 				 "call context", 1, IOQ_FLAG_NONE);
@@ -247,7 +260,7 @@ clnt_rdma_call(struct clnt_req *cc)
         cbc->data_chunk_uv = NULL;
         cbc->refcnt = 1; // Sentinel ref
 	SVC_REF(&rdma_xprt->sm_dr.xprt, SVC_REF_FLAG_NONE); // for cbc ref
-        cbc->cbc_flags = CBC_FLAG_RELEASE;
+        cbc->cbc_flags = CBC_FLAG_RELEASE | CBC_FLAG_CLIENT;
         cbc->read_waits = 0;
         cbc->write_waits = 0;
         cbc->active = false;
@@ -256,6 +269,8 @@ clnt_rdma_call(struct clnt_req *cc)
 
         TAILQ_INSERT_TAIL(&rdma_xprt->cbclist.qh, &cbc->cbc_list, q);
         rdma_xprt->cbclist.qcount++;
+	/* Increment active_client_callbacks counter */
+	atomic_inc_uint32_t(&rdma_xprt->active_client_callbacks);
         pthread_mutex_unlock(&rdma_xprt->cbclist.qmutex);
 
 	XDR *xdrs;

--- a/src/clnt_rdma.c
+++ b/src/clnt_rdma.c
@@ -235,11 +235,12 @@ clnt_rdma_call(struct clnt_req *cc)
 	/* Check if adding this callback would exceed MAX_RDMA_CALLBACKS
 	 * before allocating any resources to avoid cleanup overhead */
 	uint32_t active_callbacks = atomic_fetch_uint32_t(&rdma_xprt->active_client_callbacks);
-	if (active_callbacks >= MAX_RDMA_CALLBACKS) {
+	uint32_t max_rdma_callbacks = MAX_RDMA_CALLBACKS(rdma_xprt);
+	if (active_callbacks >= max_rdma_callbacks) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
-		    "%s: active_client_callbacks %u >= MAX_RDMA_CALLBACKS %u, "
+		    "%s: active_client_callbacks %u >= max_rdma_callbacks %u, "
 		    "cannot post new RDMA callback",
-		    __func__, active_callbacks, MAX_RDMA_CALLBACKS);
+		    __func__, active_callbacks, max_rdma_callbacks);
 		cl->cl_error.re_errno = EAGAIN;
 		return (RPC_CANTSEND);
 	}
@@ -301,6 +302,8 @@ clnt_rdma_call(struct clnt_req *cc)
 		__warnx(TIRPC_DEBUG_FLAG_CLNT_RDMA,
 			"%s: %p@%p failed",
 			__func__, cl, cx->cx_rec);
+		/* Decrement active_client_callbacks on error */
+		atomic_dec_uint32_t(&rdma_xprt->active_client_callbacks);
 		cbc_release_it(cbc);
 		return (RPC_CANTENCODEARGS);
 	}
@@ -308,6 +311,8 @@ clnt_rdma_call(struct clnt_req *cc)
 
 	/* send request and recv response */
 	if (!xdr_rdma_clnt_flushout(cbc)) {
+		/* Decrement active_client_callbacks on error */
+		atomic_dec_uint32_t(&rdma_xprt->active_client_callbacks);
 		cbc_release_it(cbc);
 		cl->cl_error.re_errno = errno;
 		return (RPC_CANTSEND);

--- a/src/clnt_vc.c
+++ b/src/clnt_vc.c
@@ -157,6 +157,7 @@ clnt_rdma_create(int fd, char *host, int port, int recv_sz, int send_sz,
 	}
 	RDMAXPRT *rdma_xprt = (RDMAXPRT *)xprt;
 	rdma_xprt->xa = use_xa;
+	rdma_xprt->client_credits = use_xa->credits;
 	struct rpc_dplx_rec *rec = REC_XPRT(xprt);
 	rec->recvsz = RDMA_DATA_CHUNK_SZ;
 	rec->sendsz = RDMA_DATA_CHUNK_SZ;

--- a/src/rpc_rdma.c
+++ b/src/rpc_rdma.c
@@ -1743,6 +1743,7 @@ rpc_rdma_allocate(const struct rpc_rdma_attr *xa)
 	rdma_xprt->sm_dr.ioq.rdma_ioq = true;
 	rdma_xprt->sm_dr.ioq.xdrs[0].x_lib[1] = rdma_xprt;
 	rdma_xprt->active_requests = 0;
+	rdma_xprt->active_client_callbacks = 0;
 
 	rc = mutex_init(&rdma_xprt->cm_lock, NULL);
 	if (rc) {

--- a/src/rpc_rdma.c
+++ b/src/rpc_rdma.c
@@ -838,6 +838,217 @@ rpc_rdma_stats_thread(void *arg)
 }
 
 /**
+ * rpc_rdma_process_single_wc: process a single work completion event.
+ *
+ * Processes one work completion from the completion queue,
+ * updates statistics, and invokes appropriate callbacks.
+ *
+ * @param[IN] rdma_xprt RDMA transport
+ * @param[IN] wc work completion event to process
+ *
+ * @return 0 on success, error code on failure
+ */
+static int
+rpc_rdma_process_single_wc(RDMAXPRT *rdma_xprt, struct ibv_wc *wc)
+{
+	struct rpc_rdma_cbc *cbc;
+	struct xdr_ioq_uv *data;
+	int rc = 0;
+	uint32_t len;
+
+	if (rdma_xprt->bad_recv_wr) {
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
+			"%s() Something was bad on that recv",
+			__func__);
+		rc = -1;
+	}
+
+	if (rdma_xprt->bad_send_wr) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			"%s() Something was bad on that send",
+			__func__);
+		rc = -1;
+	}
+
+	cbc = (struct rpc_rdma_cbc *)wc->wr_id;
+	cbc->opcode = wc->opcode;
+	cbc->status = wc->status;
+	cbc->wpe.arg = rdma_xprt;
+	cbc->active = true;
+
+	if (wc->status) {
+		rc = -1;
+
+		switch (wc->opcode) {
+			case IBV_WC_SEND:
+			case IBV_WC_RDMA_WRITE:
+			case IBV_WC_RDMA_READ:
+				rdma_xprt->stats.tx_err++;
+				break;
+			case IBV_WC_RECV:
+			case IBV_WC_RECV_RDMA_WITH_IMM:
+				rdma_xprt->stats.rx_err++;
+				break;
+			default:
+				break;
+		}
+
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			"%s() cq completion status: %s (%d) rdma_xprt state %x opcode %d cbc %p "
+			"inline %d",
+			__func__, ibv_wc_status_str(wc->status), wc->status,
+			rdma_xprt->state, wc->opcode, cbc, cbc->call_inline);
+
+		cbc->call_inline = 1;
+
+		if (cbc->call_inline) {
+			rpc_rdma_worker_callback(&cbc->wpe);
+		} else {
+			SVC_REF(&rdma_xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
+			work_pool_submit(&svc_work_pool, &cbc->wpe);
+		}
+
+		return rc;
+	}
+
+	switch (wc->opcode) {
+	case IBV_WC_SEND:
+	case IBV_WC_RDMA_WRITE:
+	case IBV_WC_RDMA_READ:
+		len = wc->byte_len;
+		rdma_xprt->stats.tx_bytes += len;
+		rdma_xprt->stats.tx_pkt++;
+
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
+			"%s() WC_SEND/RDMA_WRITE/RDMA_READ: %d len %u",
+			__func__,
+			wc->opcode,
+			len);
+
+		if (wc->wc_flags & IBV_WC_WITH_IMM) {
+			//FIXME cbc->data->imm_data = ntohl(wc.imm_data);
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
+				"%s() imm_data: %d",
+				__func__,
+				ntohl(wc->imm_data));
+		}
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s:%d submit cbc %p wpe %p inline %d",
+			__func__, __LINE__, cbc, &cbc->wpe, cbc->call_inline);
+		if (cbc->call_inline) {
+			rpc_rdma_worker_callback(&cbc->wpe);
+		} else {
+			SVC_REF(&rdma_xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
+			work_pool_submit(&svc_work_pool, &cbc->wpe);
+		}
+		break;
+
+	case IBV_WC_RECV:
+	case IBV_WC_RECV_RDMA_WITH_IMM:
+		len = wc->byte_len;
+		rdma_xprt->stats.rx_bytes += len;
+		rdma_xprt->stats.rx_pkt++;
+
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
+			"%s() WC_RECV: %d len %u",
+			__func__,
+			wc->opcode,
+			len);
+
+		if (wc->wc_flags & IBV_WC_WITH_IMM) {
+			//FIXME cbc->data->imm_data = ntohl(wc.imm_data);
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
+				"%s() imm_data: %d",
+				__func__,
+				ntohl(wc->imm_data));
+		}
+
+		/* fill all the sizes in case of multiple sge
+		 * assumes _tail was set to _wrap before call
+		 */
+		data = IOQ_(TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh));
+		while (data && ioquv_length(data) < len) {
+			VALGRIND_MAKE_MEM_DEFINED(data->v.vio_head, ioquv_length(data));
+			len -= ioquv_length(data);
+			data = IOQ_(TAILQ_NEXT(&data->uvq, q));
+		}
+		if (data) {
+			data->v.vio_tail = data->v.vio_head + len;
+			VALGRIND_MAKE_MEM_DEFINED(data->v.vio_head, ioquv_length(data));
+		} else if (len) {
+			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				"%s() ERROR %d leftover bytes?",
+				__func__, len);
+		}
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s:%d submit cbc %p wpe %p inline %d",
+			__func__, __LINE__, cbc, &cbc->wpe, cbc->call_inline);
+		if (cbc->call_inline) {
+			rpc_rdma_worker_callback(&cbc->wpe);
+		} else {
+			SVC_REF(&rdma_xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
+			work_pool_submit(&svc_work_pool, &cbc->wpe);
+		}
+		break;
+
+	default:
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			"%s() unknown opcode: %d",
+			__func__, wc->opcode);
+		rc = EINVAL;
+	}
+
+	return rc;
+}
+
+/**
+ * rpc_rdma_process_cq_events: process completion queue events.
+ *
+ * Processes work completions from the completion queue,
+ * updates statistics, and invokes appropriate callbacks.
+ *
+ * @param[IN] rdma_xprt RDMA transport
+ * @param[IN] poll_count maximum number of poll iterations
+ * @param[OUT] events_processed total number of events processed
+ *
+ * @return 0 on success, error code on failure
+ */
+static int
+rpc_rdma_process_cq_events(RDMAXPRT *rdma_xprt, int poll_count,
+    int *events_processed)
+{
+	struct ibv_wc wc[IBV_POLL_EVENTS];
+	int i;
+	int rc = 0;
+
+	int npoll = 0;
+	*events_processed = 0;
+
+	while (poll_count-- &&
+	    ((npoll = ibv_poll_cq(rdma_xprt->cq, IBV_POLL_EVENTS, wc)) > 0)) {
+
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s: npoll %d "
+		    "poll_count %d xprt %p",
+		    __func__, npoll, poll_count);
+
+		for (i = 0; i < npoll; i++) {
+			int wc_rc = rpc_rdma_process_single_wc(rdma_xprt, &wc[i]);
+			if (wc_rc && !rc)
+				rc = wc_rc;
+		}
+
+		*events_processed += npoll;
+	}
+
+	if (npoll < 0) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			"%s() %p[%u] ibv_poll_cq failed: %s (%d)",
+			__func__, rdma_xprt, rdma_xprt->state, strerror(-npoll), -npoll);
+		rc = -npoll;
+	}
+
+	return rc;
+}
+
+/**
  * rpc_rdma_cq_event_handler: completion queue event handler.
  *
  * marks contexts back out of use,
@@ -848,20 +1059,17 @@ rpc_rdma_stats_thread(void *arg)
 int
 rpc_rdma_cq_event_handler(RDMAXPRT *rdma_xprt, int expected_poll_count)
 {
-	struct ibv_wc wc[IBV_POLL_EVENTS];
 	struct ibv_cq *ev_cq;
 	void *ev_ctx;
-	struct rpc_rdma_cbc *cbc;
-	struct xdr_ioq_uv *data;
-	int i;
 	int rc;
-	int npoll = 0;
-	uint32_t len;
 	int poll_count = IBV_POLL_COUNT;
+	int total_events_processed = 0, retry_count = 0;
 
 	if (expected_poll_count)
-		poll_count = expected_poll_count;
+		retry_count = poll_count = expected_poll_count;
 
+retry:
+	retry_count--;
 	rc = ibv_get_cq_event(rdma_xprt->comp_channel, &ev_cq, &ev_ctx);
 	if (rc) {
 		rc = errno;
@@ -888,164 +1096,29 @@ rpc_rdma_cq_event_handler(RDMAXPRT *rdma_xprt, int expected_poll_count)
 		return rc;
 	}
 
-	while (poll_count-- &&
-	    ((npoll = ibv_poll_cq(rdma_xprt->cq, IBV_POLL_EVENTS, wc)) > 0)) {
+	int events_processed = 0;
+	rc = rpc_rdma_process_cq_events(rdma_xprt, poll_count,
+					&events_processed);
 
-		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s: npoll %d "
-		    "poll_count %d xprt %p",
-		    __func__, npoll, poll_count);
-
-		for (i = 0; i < npoll; i++) {
-			if (rdma_xprt->bad_recv_wr) {
-				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
-					"%s() Something was bad on that recv",
-					__func__);
-				rc = -1;
-			}
-
-			if (rdma_xprt->bad_send_wr) {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
-					"%s() Something was bad on that send",
-					__func__);
-				rc = -1;
-			}
-
-			cbc = (struct rpc_rdma_cbc *)wc[i].wr_id;
-			cbc->opcode = wc[i].opcode;
-			cbc->status = wc[i].status;
-			cbc->wpe.arg = rdma_xprt;
-			cbc->active = true;
-
-			if (wc[i].status) {
-				rc = -1;
-
-				switch (wc[i].opcode) {
-					case IBV_WC_SEND:
-					case IBV_WC_RDMA_WRITE:
-					case IBV_WC_RDMA_READ:
-						rdma_xprt->stats.tx_err++;
-						break;
-					case IBV_WC_RECV:
-					case IBV_WC_RECV_RDMA_WITH_IMM:
-						rdma_xprt->stats.rx_err++;
-						break;
-					default:
-						break;
-				}
-
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
-					"%s() cq completion status: %s (%d) rdma_xprt state %x opcode %d cbc %p "
-					"inline %d",
-					__func__, ibv_wc_status_str(wc[i].status), wc[i].status,
-					rdma_xprt->state, wc[i].opcode, cbc, cbc->call_inline);
-
-				cbc->call_inline = 1;
-
-				if (cbc->call_inline) {
-					rpc_rdma_worker_callback(&cbc->wpe);
-				} else {
-					SVC_REF(&rdma_xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
-					work_pool_submit(&svc_work_pool, &cbc->wpe);
-				}
-
-				continue;
-			}
-
-			switch (wc[i].opcode) {
-			case IBV_WC_SEND:
-			case IBV_WC_RDMA_WRITE:
-			case IBV_WC_RDMA_READ:
-				len = wc[i].byte_len;
-				rdma_xprt->stats.tx_bytes += len;
-				rdma_xprt->stats.tx_pkt++;
-
-				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
-					"%s() WC_SEND/RDMA_WRITE/RDMA_READ: %d len %u",
-					__func__,
-					wc[i].opcode,
-					len);
-
-				if (wc[i].wc_flags & IBV_WC_WITH_IMM) {
-					//FIXME cbc->data->imm_data = ntohl(wc.imm_data);
-					__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
-						"%s() imm_data: %d",
-						__func__,
-						ntohl(wc[i].imm_data));
-				}
-				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s:%d submit cbc %p wpe %p inline %d",
-					__func__, __LINE__, cbc, &cbc->wpe, cbc->call_inline);
-				if (cbc->call_inline) {
-					rpc_rdma_worker_callback(&cbc->wpe);
-				} else {
-					SVC_REF(&rdma_xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
-					work_pool_submit(&svc_work_pool, &cbc->wpe);
-				}
-				break;
-
-			case IBV_WC_RECV:
-			case IBV_WC_RECV_RDMA_WITH_IMM:
-				len = wc[i].byte_len;
-				rdma_xprt->stats.rx_bytes += len;
-				rdma_xprt->stats.rx_pkt++;
-
-				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
-					"%s() WC_RECV: %d len %u",
-					__func__,
-					wc[i].opcode,
-					len);
-
-				if (wc[i].wc_flags & IBV_WC_WITH_IMM) {
-					//FIXME cbc->data->imm_data = ntohl(wc.imm_data);
-					__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
-						"%s() imm_data: %d",
-						__func__,
-						ntohl(wc[i].imm_data));
-				}
-
-				/* fill all the sizes in case of multiple sge
-				 * assumes _tail was set to _wrap before call
-				 */
-				data = IOQ_(TAILQ_FIRST(&cbc->recvq.ioq_uv.uvqh.qh));
-				while (data && ioquv_length(data) < len) {
-					VALGRIND_MAKE_MEM_DEFINED(data->v.vio_head, ioquv_length(data));
-					len -= ioquv_length(data);
-					data = IOQ_(TAILQ_NEXT(&data->uvq, q));
-				}
-				if (data) {
-					data->v.vio_tail = data->v.vio_head + len;
-					VALGRIND_MAKE_MEM_DEFINED(data->v.vio_head, ioquv_length(data));
-				} else if (len) {
-					__warnx(TIRPC_DEBUG_FLAG_ERROR,
-						"%s() ERROR %d leftover bytes?",
-						__func__, len);
-				}
-				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "%s:%d submit cbc %p wpe %p inline %d",
-					__func__, __LINE__, cbc, &cbc->wpe, cbc->call_inline);
-				if (cbc->call_inline) {
-					rpc_rdma_worker_callback(&cbc->wpe);
-				} else {
-					SVC_REF(&rdma_xprt->sm_dr.xprt, SVC_REF_FLAG_NONE);
-					work_pool_submit(&svc_work_pool, &cbc->wpe);
-				}
-				break;
-
-			default:
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
-					"%s() unknown opcode: %d",
-					__func__, wc[i].opcode);
-				rc = EINVAL;
-			}
-		}
-	}
-
-	if (npoll < 0) {
+	if (rc) {
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
-			"%s() %p[%u] ibv_poll_cq failed: %s (%d)",
-			__func__, rdma_xprt, rdma_xprt->state, strerror(-npoll), -npoll);
-		rc = -npoll;
+			"process_cq_events failed rc %d rdma_xprt %p",
+			rc, rdma_xprt);
 	}
 
 	ibv_ack_cq_events(rdma_xprt->cq, 1);
+
+	total_events_processed += events_processed;
+
+	if (expected_poll_count && retry_count &&
+	    (total_events_processed != expected_poll_count)) {
+		__warnx(TIRPC_DEBUG_FLAG_EVENT, "events processed %d, "
+			"expected %d, retrying %d", events_processed,
+			expected_poll_count, retry_count);
+
+		poll_count = expected_poll_count;
+		goto retry;
+	}
 
 	return -rc;
 }
@@ -1185,6 +1258,9 @@ rpc_rdma_cq_thread(void *arg)
 
 			rc = rpc_rdma_cq_event_handler(rdma_xprt, 0);
 			if (rc) {
+				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+					"cq_even_handler failed %d, rdma_xprt %p",
+					rc, rdma_xprt);
 				SVC_DESTROY(&rdma_xprt->sm_dr.xprt);
 			}
 

--- a/src/rpc_rdma.c
+++ b/src/rpc_rdma.c
@@ -1820,6 +1820,7 @@ rpc_rdma_allocate(const struct rpc_rdma_attr *xa)
 	rdma_xprt->sm_dr.ioq.xdrs[0].x_lib[1] = rdma_xprt;
 	rdma_xprt->active_requests = 0;
 	rdma_xprt->active_client_callbacks = 0;
+	rdma_xprt->client_credits = xa->credits;
 
 	rc = mutex_init(&rdma_xprt->cm_lock, NULL);
 	if (rc) {

--- a/src/rpc_rdma.c
+++ b/src/rpc_rdma.c
@@ -1191,6 +1191,9 @@ rpc_rdma_cq_thread(void *arg)
 			mutex_unlock(&rdma_xprt->cm_lock);
 		}
 	}
+	__warnx(TIRPC_DEBUG_FLAG_EVENT,
+		"%s() thread %p exiting, run_count = %d",
+		__func__, pthread_self(), atomic_fetch_int32_t(&rpc_rdma_state.run_count));
 	rcu_unregister_thread();
 	pthread_exit(NULL);
 }
@@ -1263,8 +1266,9 @@ rpc_rdma_cm_event_handler(RDMAXPRT *ep_rdma_xprt, struct rdma_cm_event *event)
 				__warnx(TIRPC_DEBUG_FLAG_ERROR,
 					"%s:%u ERROR (return)",
 					__func__, __LINE__);
+			} else {
+				rpc_rdma_stats_add(rdma_xprt);
 			}
-			rpc_rdma_stats_add(rdma_xprt);
 		}
 		break;
 
@@ -1273,7 +1277,16 @@ rpc_rdma_cm_event_handler(RDMAXPRT *ep_rdma_xprt, struct rdma_cm_event *event)
 			"%s() %p CONNECT_REQUEST",
 			__func__, rdma_xprt);
 		rpc_rdma_state.c_r.id_queue[0] = cm_id;
-		svc_rdma_rendezvous(&rdma_xprt->sm_dr.xprt);
+		enum xprt_stat rendezvous_status = svc_rdma_rendezvous(&rdma_xprt->sm_dr.xprt);
+		if (rendezvous_status == XPRT_DIED || rendezvous_status == XPRT_DESTROYED) {
+			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				"%s() %p CONNECT_REQUEST rendezvous failed with status %d, "
+				"cleaning up connection attempt",
+				__func__, rdma_xprt, rendezvous_status);
+			/* Clean up the connection attempt */
+			rdma_reject(cm_id, NULL, 0);
+			rc = ECONNREFUSED;
+		}
 
 		break;
 
@@ -1417,6 +1430,9 @@ rpc_rdma_cm_thread(void *nullarg)
 				SVC_DESTROY(&rdma_xprt_event->sm_dr.xprt);
 		}
 	}
+	__warnx(TIRPC_DEBUG_FLAG_EVENT,
+		"%s() thread %p exiting, run_count = %d",
+		__func__, pthread_self(), atomic_fetch_int32_t(&rpc_rdma_state.run_count));
 	rcu_unregister_thread();
 	pthread_exit(NULL);
 }

--- a/src/rpc_rdma.h
+++ b/src/rpc_rdma.h
@@ -332,11 +332,6 @@ static inline void cbc_release_it(struct rpc_rdma_cbc *cbc)
 		TAILQ_REMOVE(&rdma_xprt->cbclist.qh, &cbc->cbc_list, q);
 		rdma_xprt->cbclist.qcount--;
 
-		/* Decrement active_client_callbacks if this was a client callback */
-		if (cbc->cbc_flags & CBC_FLAG_CLIENT) {
-			atomic_dec_uint32_t(&rdma_xprt->active_client_callbacks);
-		}
-
 		pthread_mutex_unlock(&rdma_xprt->cbclist.qmutex);
 
 		if (cbc->non_registered_buf) {

--- a/src/rpc_rdma.h
+++ b/src/rpc_rdma.h
@@ -87,6 +87,7 @@ typedef int (*rpc_rdma_callback_t)(struct rpc_rdma_cbc *cbc, RDMAXPRT *rdma_xprt
 #define CBC_FLAG_NONE		0x0000
 #define CBC_FLAG_RELEASE	0x0001
 #define CBC_FLAG_RELEASING	0x0002
+#define CBC_FLAG_CLIENT		0x0004	/**< Client-side callback (from clnt_rdma_call) */
 
 #define RDMA_CB_TIMEOUT_SEC 10
 
@@ -162,6 +163,7 @@ struct rpc_rdma_pd {
 /* Keep enough cbcs to avoid on demand allocation */
 #define MAX_CBC_ALLOCATION(xa) (MAX_CBC_OUTSTANDING(xa) * 3)
 #define MAX_RECV_OUTSTANDING(xa) MAX_CBC_OUTSTANDING(xa)
+#define MAX_RDMA_CALLBACKS 64	/**< Maximum active client RDMA callbacks per connection */
 
 /**
  * \struct rpc_rdma_xprt
@@ -206,6 +208,7 @@ struct rpc_rdma_xprt {
 	u_int io_bufs_count;
 
 	uint32_t active_requests;
+	uint32_t active_client_callbacks;	/**< Active client RDMA callbacks (from clnt_rdma_call) */
 
 	struct poolq_head cbclist;
 
@@ -328,6 +331,11 @@ static inline void cbc_release_it(struct rpc_rdma_cbc *cbc)
 
 		TAILQ_REMOVE(&rdma_xprt->cbclist.qh, &cbc->cbc_list, q);
 		rdma_xprt->cbclist.qcount--;
+
+		/* Decrement active_client_callbacks if this was a client callback */
+		if (cbc->cbc_flags & CBC_FLAG_CLIENT) {
+			atomic_dec_uint32_t(&rdma_xprt->active_client_callbacks);
+		}
 
 		pthread_mutex_unlock(&rdma_xprt->cbclist.qmutex);
 

--- a/src/rpc_rdma.h
+++ b/src/rpc_rdma.h
@@ -163,7 +163,12 @@ struct rpc_rdma_pd {
 /* Keep enough cbcs to avoid on demand allocation */
 #define MAX_CBC_ALLOCATION(xa) (MAX_CBC_OUTSTANDING(xa) * 3)
 #define MAX_RECV_OUTSTANDING(xa) MAX_CBC_OUTSTANDING(xa)
-#define MAX_RDMA_CALLBACKS 64	/**< Maximum active client RDMA callbacks per connection */
+/**< Maximum active client RDMA callbacks per connection.
+ * Use min of client_credits and xa->credits if both are > 0, else xa->credits */
+#define MAX_RDMA_CALLBACKS(rdma_xprt) \
+	(((rdma_xprt)->client_credits > 0 && (rdma_xprt)->xa->credits > 0) ? \
+	 MIN((rdma_xprt)->client_credits, (rdma_xprt)->xa->credits) : \
+	 (rdma_xprt)->xa->credits)
 
 /**
  * \struct rpc_rdma_xprt
@@ -209,6 +214,7 @@ struct rpc_rdma_xprt {
 
 	uint32_t active_requests;
 	uint32_t active_client_callbacks;	/**< Active client RDMA callbacks (from clnt_rdma_call) */
+	uint32_t client_credits;		/**< Client credits from rdma_credit in incoming messages */
 
 	struct poolq_head cbclist;
 

--- a/src/svc_rdma.c
+++ b/src/svc_rdma.c
@@ -238,7 +238,15 @@ svc_rdma_decode(struct svc_req *req)
 		RDMAXPRT *rdma_xprt = (RDMAXPRT *)req->rq_xprt;
 		/* reply header (xprt OK) */
 		/* Decrement active_client_callbacks if this was a client callback */
-		atomic_dec_uint32_t(&rdma_xprt->active_client_callbacks);
+		uint32_t active = atomic_fetch_uint32_t(&rdma_xprt->active_client_callbacks);
+		if (active > 0) {
+			atomic_dec_uint32_t(&rdma_xprt->active_client_callbacks);
+		} else {
+			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				"%s: active_client_callbacks already 0, skipping decrement "
+				"to prevent underflow, xprt %p",
+				__func__, req->rq_xprt);
+		}
 		clnt_req_process_reply(req->rq_xprt, req);
 		return XPRT_IDLE;
 	}

--- a/src/svc_rdma.c
+++ b/src/svc_rdma.c
@@ -235,7 +235,10 @@ svc_rdma_decode(struct svc_req *req)
 	}
 
 	if (req->rq_msg.rm_direction == REPLY) {
+		RDMAXPRT *rdma_xprt = (RDMAXPRT *)req->rq_xprt;
 		/* reply header (xprt OK) */
+		/* Decrement active_client_callbacks if this was a client callback */
+		atomic_dec_uint32_t(&rdma_xprt->active_client_callbacks);
 		clnt_req_process_reply(req->rq_xprt, req);
 		return XPRT_IDLE;
 	}

--- a/src/xdr_rdma.c
+++ b/src/xdr_rdma.c
@@ -1582,6 +1582,9 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 	cmsg = m_(cbc->call_head);
 	rpcrdma_dump_msg(cbc->call_uv, "call", cmsg->rdma_xid);
 
+	/* Update client credits from incoming message */
+	rdma_xprt->client_credits = ntohl(cmsg->rdma_credit);
+
 	switch (ntohl(cmsg->rdma_vers)) {
 	case RPCRDMA_VERSION:
 		break;

--- a/src/xdr_rdma.c
+++ b/src/xdr_rdma.c
@@ -1706,12 +1706,40 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 
 	assert(cbc->recvq.ioq_uv.uvqh.qcount == 0);
 
+	/* Store the boundary of the read_chunk list to prevent buffer overrun.
+	 * The write_chunk pointer marks the end of the read_chunk list.
+	 */
+	void *read_chunk_end = cbc->write_chunk;
+	uint32_t read_chunk_count = 0;
+	const uint32_t MAX_READ_CHUNKS = 1024; /* Safety limit to prevent infinite loops */
+
 	while (rl(cbc->read_chunk)->present && status) {
+		/* Bounds check: ensure we haven't exceeded the read_chunk list boundary */
+		if ((char *)cbc->read_chunk >= (char *)read_chunk_end) {
+			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				"%s: read_chunk %p exceeded boundary %p (write_chunk), "
+				"possible buffer overrun or malformed read_chunk list",
+				__func__, cbc->read_chunk, read_chunk_end);
+			status = false;
+			break;
+		}
+
+		/* Safety limit to prevent infinite loops from corrupted data */
+		if (read_chunk_count >= MAX_READ_CHUNKS) {
+			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				"%s: exceeded maximum read_chunks limit %u, "
+				"possible infinite loop from malformed read_chunk list",
+				__func__, MAX_READ_CHUNKS);
+			status = false;
+			break;
+		}
+
+		read_chunk_count++;
 		l = ntohl(rl(cbc->read_chunk)->target.length);
 
 		__warnx(TIRPC_DEBUG_FLAG_XDR,
-			"%s() offset %u length %u",
-			__func__, offset, l);
+			"%s() offset %u length %u read_chunk_count %u",
+			__func__, offset, l, read_chunk_count);
 
 		if (!read_chunk_uv) {
 			read_chunk_uv = IOQ_(xdr_rdma_ioq_uv_fetch(&cbc->dataq,
@@ -1772,8 +1800,20 @@ xdr_rdma_svc_recv(struct rpc_rdma_cbc *cbc, u_int32_t xid)
 		pthread_mutex_unlock(&cbc->freeq.ioq_uv.uvqh.qmutex);
 		pthread_mutex_unlock(&cbc->recvq.ioq_uv.uvqh.qmutex);
 
-		cbc->read_chunk = (char *)cbc->read_chunk
-						+ sizeof(struct xdr_read_list);
+		/* Advance to next read_chunk entry, but validate bounds first */
+		void *next_read_chunk = (char *)cbc->read_chunk
+					+ sizeof(struct xdr_read_list);
+
+		if ((char *)next_read_chunk > (char *)read_chunk_end) {
+			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				"%s: next read_chunk %p would exceed boundary %p, "
+				"stopping read_chunk processing",
+				__func__, next_read_chunk, read_chunk_end);
+			status = false;
+			break;
+		}
+
+		cbc->read_chunk = next_read_chunk;
 
 		/* Move offset by length */
 		offset = offset + l;

--- a/tests/rpcping.c
+++ b/tests/rpcping.c
@@ -160,7 +160,7 @@ worker(void *arg)
 {
 	struct state *s = arg;
 	struct clnt_req *cc;
-	int i;
+	int i, rc = 0;
 
 	pthread_cond_init(&s->s_cond, NULL);
 	pthread_mutex_init(&s->s_mutex, NULL);
@@ -176,6 +176,7 @@ worker(void *arg)
 			rpc_perror(&cc->cc_error, "clnt_req_setup failed");
 			s->count = i;
 			clnt_req_release(cc);
+			rc = -1;
 			break;
 		}
 		cc->cc_refreshes = 1;
@@ -186,15 +187,17 @@ worker(void *arg)
 			rpc_perror(&cc->cc_error, "CLNT_CALL_BACK failed");
 			s->count = i;
 			clnt_req_release(cc);
+			rc = -1;
 			break;
 		}
 	}
 
-	if (s->proto != RDMA) {
+	if (!rc) {
 		pthread_mutex_lock(&s->s_mutex);
 		pthread_cond_wait(&s->s_cond, &s->s_mutex);
 		pthread_mutex_unlock(&s->s_mutex);
 	}
+
 	clock_gettime(CLOCK_MONOTONIC, &s->stopping);
 
 	if (atomic_dec_uint32_t(&rpcping_threads) > 0) {

--- a/tests/rpcping.c
+++ b/tests/rpcping.c
@@ -266,7 +266,9 @@ int main(int argc, char *argv[])
 	int proc = 0;
 	int send_sz = 8192;
 	int recv_sz = 8192;
+#ifdef USE_RPC_RDMA
 	int page_sz = sysconf(_SC_PAGESIZE);
+#endif
 	unsigned int failures = 0;
 	unsigned int timeouts = 0;
 	bool rpcbind = false;


### PR DESCRIPTION
Only add RDMA stats on successful connection (not on error), properly reject and cleanup failed rendezvous attempts, add thread exit logging for debugging

Add bounds checking to prevent buffer overruns when processing read_chunk lists, add MAX_READ_CHUNKS=1024 safety limit to prevent infinite loops from malformed or corrupted data

Introduce MAX_RDMA_CALLBACKS=64 limit per connection, track active client callbacks with counter, return EAGAIN if limit reached before allocating resources

Extract work completion processing into modular functions for better maintainability, add retry logic when expected poll count not met, improve error logging

Move active_client_callbacks decrement from release time to response receipt time in svc_rdma_decode(), fix rpcping to wait for RDMA responses properly