### PR TITLE
Modernize cmake and build-fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,18 +36,7 @@ set( PACKNAME "${NTIRPC_VERSION}" )
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# Install destination, if built standalone
-get_property(USE_LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
-if (USE_LIB64)
-	set(LIB_INSTALL_DIR lib64 CACHE PATH
-		"Specify name of libdir inside install path")
-else (USE_LIB64)
-	set(LIB_INSTALL_DIR lib CACHE PATH
-		"Specify name of libdir inside install path")
-endif (USE_LIB64)
-
-set(SYSTEM_LIBRARIES ${SYSTEM_LIBRARIES})
-set(BINARY_LIBRARIES ${BINARY_LIBRARIES})
+include(GNUInstallDirs)
 
 include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC _GIT_HEAD_COMMIT)
@@ -337,6 +326,6 @@ add_custom_target( srpm
 endif (NOT TARGET rpm)
 ########### install files ###############
 
-install(FILES  ${PROJECT_BINARY_DIR}/libntirpc.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
-install(DIRECTORY  ${NTIRPC_BASE_DIR}/ntirpc DESTINATION include)
-install(FILES  ${PROJECT_BINARY_DIR}/ntirpc/version.h DESTINATION include/ntirpc)
+install(FILES  ${PROJECT_BINARY_DIR}/libntirpc.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install(DIRECTORY  ${NTIRPC_BASE_DIR}/ntirpc DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES  ${PROJECT_BINARY_DIR}/ntirpc/version.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ntirpc)

--- a/libntirpc.pc.in.cmake
+++ b/libntirpc.pc.in.cmake
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@LIB_INSTALL_DIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include/ntirpc
 
 Name: libntirpc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,9 +5,6 @@ add_definitions(
   -D_GNU_SOURCE
 )
 
-# ok on Linux and FreeBSD w/GCC and clang compilers
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-
 ########### next target ###############
 
 SET(ntirpc_common_SRCS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,7 +136,7 @@ set_target_properties(ntirpc PROPERTIES LINK_FLAGS
   SOVERSION "${NTIRPC_MAJOR_VERSION}${NTIRPC_MINOR_VERSION}"
   )
 
-install(TARGETS ntirpc DESTINATION ${LIB_INSTALL_DIR})
+install(TARGETS ntirpc DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 ########### install files ###############
 

--- a/src/lttng/CMakeLists.txt
+++ b/src/lttng/CMakeLists.txt
@@ -22,7 +22,7 @@ set_target_properties(ntirpc_tracepoints PROPERTIES
   SOVERSION "${NTIRPC_MAJOR_VERSION}${NTIRPC_MINOR_VERSION}"
 )
 
-install(TARGETS ntirpc_tracepoints COMPONENT tracing DESTINATION ${LIB_INSTALL_DIR} )
+install(TARGETS ntirpc_tracepoints COMPONENT tracing DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 
 add_library(ntirpc_lttng STATIC lttng_defines.c)
 #add_sanitizers(ntirpc_lttng)

--- a/src/monitoring/CMakeLists.txt
+++ b/src/monitoring/CMakeLists.txt
@@ -8,7 +8,7 @@ SET(ntirpcmonitoring_SRCS
 
 add_library(ntirpcmonitoring SHARED ${ntirpcmonitoring_SRCS})
 add_sanitizers(ntirpcmonitoring)
-set_target_properties(ntirpcmonitoring PROPERTIES COMPILE_FLAGS "-fPIC"
+set_target_properties(ntirpcmonitoring PROPERTIES
   VERSION ${NTIRPC_VERSION}
   SOVERSION "${NTIRPC_MAJOR_VERSION}${NTIRPC_MINOR_VERSION}"
   )

--- a/src/monitoring/CMakeLists.txt
+++ b/src/monitoring/CMakeLists.txt
@@ -14,7 +14,7 @@ set_target_properties(ntirpcmonitoring PROPERTIES COMPILE_FLAGS "-fPIC"
   )
 target_include_directories(ntirpcmonitoring     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/prometheus-cpp-lite/core/include)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors -Werror -Wall -Wextra")
-install(TARGETS ntirpcmonitoring DESTINATION ${LIB_INSTALL_DIR})
+install(TARGETS ntirpcmonitoring DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 ########### install files ###############
-install(FILES  include/monitoring.h DESTINATION include/ntirpc)
+install(FILES  include/monitoring.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ntirpc)

--- a/tests/rpcping.c
+++ b/tests/rpcping.c
@@ -263,7 +263,9 @@ int main(int argc, char *argv[])
 	int proc = 0;
 	int send_sz = 8192;
 	int recv_sz = 8192;
+#ifdef USE_RPC_RDMA
 	int page_sz = sysconf(_SC_PAGESIZE);
+#endif
 	unsigned int failures = 0;
 	unsigned int timeouts = 0;
 	bool rpcbind = false;


### PR DESCRIPTION
- Make the code more robust for different platform and also more maintainable by replacing hand written code by the official CMake module GnuInstallDirs.
- Fix build with USE_RPC_RDMA OFF (and -Werror)
- Let CMake handle the -fPIC for shared libraries