### PR TITLE
Fix race condition in svc_xprt_foreach causing invalid node traversal

### DIFF
--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -1403,13 +1403,22 @@ svc_rqst_clean_func(SVCXPRT *xprt, void *arg)
 	if (xprt->xp_ops == NULL)
 		return (false);
 
-	if (xprt->xp_flags & (SVC_XPRT_FLAG_DESTROYED | SVC_XPRT_FLAG_UREG))
+	if (xprt->xp_flags & SVC_XPRT_FLAG_UREG)
 		return (false);
 
 	/* Make sure recv.ts is initialized */
 	if (REC_XPRT(xprt)->recv.ts.tv_sec &&
 	    ((acc->ts.tv_sec - REC_XPRT(xprt)->recv.ts.tv_sec) < acc->timeout))
 		return (false);
+
+	/* If another thread is destroying the xprt,
+	 * return true to indicate the caller that the xprt is being disposed,
+	 * but don't count it as cleaned since we didn't initate this destruction.
+	 * Note: there is still a small window between this check and
+	 * SVC_DESTROY() where another thread could start destroying this xprt.
+	 */
+	if (xprt->xp_flags & SVC_XPRT_FLAG_DESTROYING)
+		return (true);
 
 	SVC_DESTROY(xprt);
 	acc->cleaned++;


### PR DESCRIPTION
Updated svc_rqst_clean_func() to not return false when another thread is destroying the xprt, indicating svc_xprt_foreach() to restart the iteration.

Added a check for SVC_XPRT_FLAG_DESTROYING instead of SVC_XPRT_FLAG_DESTROYED, since svc_xprt_foreach holds a reference on the transport.