### PR TITLE
Fix crash for HAPROXY_RET_CODE__IGNORE_LOCAL

### DIFF
--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -1243,6 +1243,16 @@ again:
 			"sx_fbtbc = %08x", (int)xd->sx_fbtbc);
 
 		if (xd->sx_fbtbc == PP2_SIG_UINT32) {
+			/* Since this is haproxy header clear off sx_fbtbc
+			 * In case of HAPROXY_RET_CODE__IGNORE_LOCAL,
+			 * handle_haproxy_header() do rearm the xprt recv fd.
+			 * causing a race if the thread gets scheduled
+			 * out after rearm and epoll_wait gets data available
+			 * event, then new recv endup in elsecase
+			 * "if (!xd->sx_fbtbc)"
+			 * and will cause uv to NULL */
+			xd->sx_fbtbc = 0;
+
 			/* HA Proxy V2? */
 			enum haproxy_ret_code ret = handle_haproxy_header(xprt);
 			switch (ret) {
@@ -1252,17 +1262,15 @@ again:
 					return SVC_STAT(xprt);
 				}
 				/* Now look to see if there's more... */
-	                        xd->sx_fbtbc = 0;
 				hap_again = true;
 				goto again;
 			case HAPROXY_RET_CODE__FAILURE:
 				SVC_DESTROY(xprt);
 				return SVC_STAT(xprt);
 			case HAPROXY_RET_CODE__IGNORE_LOCAL:
-				/* clear off sx_fbtbc */
-	                        xd->sx_fbtbc = 0;
 				return SVC_STAT(xprt);
 			case HAPROXY_RET_CODE__NOT_HAPROXY:
+				xd->sx_fbtbc = PP2_SIG_UINT32;
 				break;
 			}
 		}


### PR DESCRIPTION
Ganesha is crashing with backtrace
(gdb) bt
(gdb) f 0
1071  flags = uv->u.uio_flags;

In case of HAPROXY_RET_CODE__IGNORE_LOCAL, which do rearm the xprt fd for recv. There is a small race if the current thread gets scheduled out after rearm and epoll_wait gets data available event, then new recv endup in elsecase. "if (!xd->sx_fbtbc)"
and will cause uv to NULL