### PR TITLE
[TLS] : TLS support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,38 @@ if (USE_GSS)
 endif (USE_GSS)
 
 option(USE_MONITORING "Enable monitoring stack" ON)
+option(USE_TLS "Enable TLS support" OFF)
+option(USE_OPENSSL "Use OpenSSL as TLS backend" OFF)
+option(USE_GNUTLS "Use GNUTLS as TLS backend" OFF)
+# Find TLS libraries based on configuration
+if(USE_TLS)
+  set(TLS_COMPONENTS "")
+
+  if(USE_OPENSSL)
+    list(APPEND TLS_COMPONENTS "openssl")
+    set(USE_GNUTLS OFF)
+  endif(USE_OPENSSL)
+
+  if(USE_GNUTLS)
+    list(APPEND TLS_COMPONENTS "gnutls")
+    set(USE_OPENSSL OFF)
+  endif(USE_GNUTLS)
+
+  if( NOT USE_OPENSSL AND NOT USE_GNUTLS)
+    list(APPEND TLS_COMPONENTS "openssl")
+    list(APPEND TLS_COMPONENTS "gnutls")
+  endif()
+
+  find_package(TLS REQUIRED ${TLS_COMPONENTS})
+
+  # Add TLS libraries to system libraries
+  if (TLS_FOUND)
+    set(SYSTEM_LIBRARIES ${TLS_LIBRARIES} ${SYSTEM_LIBRARIES})
+    include_directories(${TLS_INCLUDE_DIRS})
+  else (TLS_FOUND)
+    set(USE_TLS OFF)
+  endif(TLS_FOUND)
+endif(USE_TLS)
 
 option(PROXY_PROTOCOL_PARSE_COMMON_NETWORK_ID "Enable parsing of common network id from haproxy TLV" OFF)
 
@@ -248,6 +280,9 @@ message(STATUS "USE_PROFILE = ${USE_PROFILE}")
 message(STATUS "USE_LTTNG_NTIRPC = ${USE_LTTNG_NTIRPC}")
 message(STATUS "USE_MONITORING = ${USE_MONITORING}")
 message(STATUS "PROXY_PROTOCOL_PARSE_COMMON_NETWORK_ID = ${PROXY_PROTOCOL_PARSE_COMMON_NETWORK_ID}")
+message(STATUS "NTIRPC USE_TLS = ${USE_TLS}")
+message(STATUS "NTIRPC USE_OPENSSL = ${USE_OPENSSL}")
+message(STATUS "NTIRPC USE_GNUTLS = ${USE_GNUTLS}")
 
 #force command line options to be stored in cache
 set(_MSPAC_SUPPORT ${_MSPAC_SUPPORT}

--- a/cmake/modules/FindTLS.cmake
+++ b/cmake/modules/FindTLS.cmake
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+# vim:noexpandtab:shiftwidth=8:tabstop=8:
+#
+# Copyright (C) 2025, IBM . All rights reserved.
+# Author: Deeraj Patil <deeraj.patil@ibm.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA.  see <http://www.gnu.org/licenses/
+#
+#-------------------------------------------------------------------------------
+# - Find TLS libraries
+# Find the TLS libraries (OpenSSL, GNU-TLS) and headers
+#  TLS_INCLUDE_DIRS      - where to find tls headers
+#  TLS_LIBRARIES         - List of libraries when using TLS
+#  TLS_FOUND             - True if TLS found
+#  TLS_BACKEND           - Which TLS backend is being used (OPENSSL, GNUTLS)
+# TLS modules may be specified as components for this find module.
+# Components include:
+#  openssl           - OpenSSL library
+#  gnutls            - GNU-TLS library
+# Typical usage:
+#  FIND_PACKAGE(TLS REQUIRED openssl)
+
+# First check for TLS_PREFIX to find custom installations
+IF(TLS_PREFIX)
+  FIND_PROGRAM(OPENSSL_CONFIG NAMES openssl
+    PATHS ${TLS_PREFIX}/bin
+    NO_SYSTEM_ENVIRONMENT_PATH
+    NO_DEFAULT_PATH
+  )
+
+  FIND_PROGRAM(GNUTLS_CONFIG NAMES gnutls
+    PATHS ${TLS_PREFIX}/bin
+    NO_SYSTEM_ENVIRONMENT_PATH
+    NO_DEFAULT_PATH
+  )
+ENDIF(TLS_PREFIX)
+
+# Find OpenSSL
+FIND_PROGRAM(OPENSSL_CONFIG NAMES openssl)
+IF(OPENSSL_CONFIG)
+  MESSAGE(STATUS "Found OpenSSL: ${OPENSSL_CONFIG}")
+ENDIF(OPENSSL_CONFIG)
+
+# Find GNUTLS
+FIND_PROGRAM(GNUTLS_CONFIG NAMES gnutls)
+IF(GNUTLS_CONFIG)
+  MESSAGE(STATUS "Found GNUTLS: ${GNUTLS_CONFIG}")
+ENDIF(GNUTLS_CONFIG)
+
+# Check if we found anything
+SET(TLS_FOUND 0)
+
+# Process the requested components
+SET(TLS_BACKEND "NONE")
+
+# Check for OpenSSL - compatible with older CMake versions
+LIST(FIND TLS_FIND_COMPONENTS "openssl" _openssl_idx)
+IF(NOT _openssl_idx EQUAL -1)
+  FIND_PACKAGE(OpenSSL)
+  IF(OPENSSL_FOUND)
+    SET(TLS_FOUND 1)
+    SET(TLS_BACKEND "OPENSSL")
+    SET(TLS_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
+    SET(TLS_LIBRARIES ${OPENSSL_LIBRARIES})
+    MESSAGE(STATUS "Using OpenSSL as TLS backend")
+    SET(USE_OPENSSL ON)
+    add_definitions(-DUSE_TLS -DUSE_OPENSSL)
+  ELSE(OPENSSL_FOUND)
+    IF(TLS_FIND_REQUIRED_openssl)
+      MESSAGE(FATAL_ERROR "OpenSSL requested but not found")
+    ELSE(TLS_FIND_REQUIRED_openssl)
+      MESSAGE(WARNING "OpenSSL requested but not found")
+    ENDIF(TLS_FIND_REQUIRED_openssl)
+  ENDIF(OPENSSL_FOUND)
+ENDIF(NOT _openssl_idx EQUAL -1)
+
+LIST(FIND TLS_FIND_COMPONENTS "gnutls" _gnutls_idx)
+IF(NOT _gnutls_idx EQUAL -1)
+  IF(TLS_FOUND)
+    MESSAGE(STATUS "TLS_LIB already found ${TLS_BACKEND}")
+  ELSE(TLS_FOUND)
+    FIND_PACKAGE(GnuTLS)
+    IF(GNUTLS_FOUND)
+      SET(TLS_FOUND 1)
+      SET(TLS_BACKEND "GNUTLS")
+      SET(TLS_INCLUDE_DIRS ${GNUTLS_INCLUDE_DIRS})
+      SET(TLS_LIBRARIES ${GNUTLS_LIBRARIES})
+      MESSAGE(STATUS "Using GnuTLS as TLS backend")
+      SET(USE_GNUTLS ON)
+      add_definitions(-DUSE_TLS -DUSE_GNUTLS)
+    ELSE(GNUTLS_FOUND)
+      IF(TLS_FIND_REQUIRED_gnutls)
+        MESSAGE(FATAL_ERROR "GnuTLS requested but not found")
+      ELSE(TLS_FIND_REQUIRED_gnutls)
+        MESSAGE(WARNING "GnuTLS requested but not found")
+      ENDIF(TLS_FIND_REQUIRED_gnutls)
+    ENDIF(GNUTLS_FOUND)
+  ENDIF(TLS_FOUND)
+ENDIF(NOT _gnutls_idx EQUAL -1)
+
+# Report the results
+IF(NOT TLS_FOUND)
+  SET(TLS_DIR_MESSAGE
+    "TLS was not found. Make sure the entries TLS_* are set.")
+  IF(NOT TLS_FIND_QUIETLY)
+    MESSAGE(STATUS "${TLS_DIR_MESSAGE}")
+  ELSE(NOT TLS_FIND_QUIETLY)
+    IF(TLS_FIND_REQUIRED)
+      MESSAGE(FATAL_ERROR "${TLS_DIR_MESSAGE}")
+    ENDIF(TLS_FIND_REQUIRED)
+  ENDIF(NOT TLS_FIND_QUIETLY)
+ELSE(NOT TLS_FOUND)
+  MESSAGE(STATUS "Found TLS backend: ${TLS_BACKEND}")
+  MESSAGE(STATUS "Found TLS headers: ${TLS_INCLUDE_DIRS}")
+  MESSAGE(STATUS "Found TLS libs: ${TLS_LIBRARIES}")
+ENDIF(NOT TLS_FOUND)
+

--- a/config-h.in.cmake
+++ b/config-h.in.cmake
@@ -21,6 +21,9 @@
 #cmakedefine USE_RPC_RDMA 1
 #cmakedefine USE_LTTNG_NTIRPC 1
 #cmakedefine USE_MONITORING 1
+#cmakedefine USE_TLS 1
+#cmakedefine USE_OPENSSL 1
+#cmakedefine USE_GNUTLS 1
 
 /* Package stuff */
 #define PACKAGE "libntirpc"

--- a/ntirpc/rpc/auth.h
+++ b/ntirpc/rpc/auth.h
@@ -289,6 +289,7 @@ enum auth_stat _svcauth_none(struct svc_req *);
 enum auth_stat _svcauth_short(struct svc_req *);
 enum auth_stat _svcauth_unix(struct svc_req *);
 enum auth_stat _svcauth_gss(struct svc_req *, bool *);
+enum auth_stat _svcauth_tls(struct svc_req *req);
 __END_DECLS
 
 #define AUTH_NONE 0		/* no authentication */
@@ -300,5 +301,8 @@ __END_DECLS
 #define AUTH_DES AUTH_DH	/* for backward compatibility */
 #define AUTH_KERB 4		/* kerberos style */
 #define RPCSEC_GSS 6		/* RPCSEC_GSS */
+
+/* AUTH_TLS authentication flavor - value from RFC */
+#define AUTH_TLS    7  /* As defined in Section 7.1 of the RFC */
 
 #endif				/* !_TIRPC_AUTH_H */

--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -181,6 +181,7 @@ typedef struct svc_init_params {
 #define SVC_XPRT_FLAG_READY		0x0400	/* ready to use */
 #define SVC_XPRT_FLAG_IOQ_WRITING	0x0800	/* xprt is used by svc_ioq_write */
 #define SVC_XPRT_FLAG_NO_SET		0x1000  /* do not register with rpcbind */
+#define SVC_XPRT_FLAG_TLS_MORE_DATA_AVAILABLE 0x2000 /* TLS specific more data available on xprt to read */
 
 #define SVC_XPRT_FLAG_DESTROYED (SVC_XPRT_FLAG_DESTROYING \
 				| SVC_XPRT_FLAG_RELEASING)
@@ -230,6 +231,22 @@ struct svc_req;			/* forward decl. */
 
 typedef enum xprt_stat (*svc_req_fun_t) (struct svc_req *);
 
+#ifdef USE_TLS
+struct xp_tls {
+	void *tls_ctx;        /* TLS context */
+	pthread_mutex_t tls_lock;
+	/* If keyupdate needs to be supported based on connection time
+	 * i.e expire connection after 1hour */
+	time_t last_key_update_time;
+	volatile bool tls_enabled; /* Is TLS enabled for this transport */
+	bool tls_established; /* Is TLS handshake complete */
+	bool tls_pending; /* Used in AUTH_TLS handling */
+	bool mtls; /* type of TLS handshake, is mtls is true */
+	bool not_first_packet; /* Used for identifying TLS connection request
+				 which doesnt use AUTH_TLS */
+};
+#endif
+
 /**
  * Server side transport handle
  */
@@ -267,6 +284,10 @@ struct svc_xprt {
 		/** free client user data */
 		svc_xprt_fun_t xp_free_user_data;
 	} *xp_ops;
+
+#ifdef USE_TLS
+	struct xp_tls xp_tls;  /* TLS state */
+#endif
 
 	/* handle incoming connections (per xp_fd) */
 	union {
@@ -459,6 +480,67 @@ __END_DECLS
 #define SVC_RECV(xprt) \
 	(*(xprt)->xp_ops->xp_recv)(xprt)
 
+#ifdef USE_TLS
+
+ssize_t xp_tls_send_impl(SVCXPRT *xprt, const struct msghdr *msg, int flags);
+ssize_t xp_tls_recv_impl(SVCXPRT *xprt, void *buf, size_t len, int flags);
+ssize_t xp_tls_datapending_check(SVCXPRT *xprt);
+void xp_tls_recv_wait(SVCXPRT *xprt);
+void xp_tls_close_impl(SVCXPRT *xprt);
+bool is_handshake_msg(SVCXPRT *xprt);
+
+/*
+ * For stunnel:
+ * In svc_recv, code flow checks whether it is a client handshake message.
+ * If it is, the flow does not transfer to epoll_wait.
+ *
+ * For upperlayer protocol specific TLS handshake (eg :AUTH_TLS in NFS-Ganesha)
+ * The request is scheduled to process by the upper layer, and the flow moves on
+ * to wait for new events.
+ * The data available on socket event will be generated because handshake is in
+ * progress and data is handshake data. Therefore, we wait for the handshake to
+ * complete (either successfully or with failure) for the xprt before performing
+ * any actual read/write operations.
+ * Below locking is applicable only for such handshake (eg :AUTH_TLS in
+ * NFS-Ganesha) and not stunnel type connection.
+ *
+ * It can also be possible that handshake failed,
+ * till that time dont process the data.
+ */
+static inline ssize_t svc_tls_recv(SVCXPRT *xprt, void *address, size_t bytes,
+				   int flags)
+{
+	if (xprt->xp_tls.tls_enabled && !xprt->xp_tls.tls_established)
+		xp_tls_recv_wait(xprt);
+	if (xprt->xp_tls.tls_established)
+		return xp_tls_recv_impl(xprt, address, bytes, flags);
+	return recv(xprt->xp_fd, address, bytes, flags);
+}
+
+static inline ssize_t svc_tls_send(SVCXPRT *xprt, const struct msghdr *msg,
+				   int flags)
+{
+	if (xprt->xp_tls.tls_established)
+		return xp_tls_send_impl(xprt, msg, flags);
+	return sendmsg(xprt->xp_fd, msg, flags);
+}
+
+static inline void svc_tls_close(SVCXPRT *xprt)
+{
+	if (xprt->xp_tls.tls_established)
+		xp_tls_close_impl(xprt);
+}
+
+static inline ssize_t svc_tls_datapending(SVCXPRT *xprt)
+{
+	if (!xprt->xp_tls.tls_established)
+		return 0;
+	return xp_tls_datapending_check(xprt);
+}
+
+#endif /* USE_TLS */
+
+
 #define SVC_STAT(xprt) \
 	(*(xprt)->xp_ops->xp_stat)(xprt)
 
@@ -592,6 +674,10 @@ static inline void svc_destroy_it(SVCXPRT *xprt,
 	 * Also for UDP xprt, this is never set, needn't enter here */
 	if ((atomic_fetch_uint16_t(&xprt->xp_flags) & SVC_XPRT_FLAG_CLOSE)
 	    && xprt->xp_fd != RPC_ANYFD) {
+		/*  need to tell the client about TLS Connection closure */
+#ifdef USE_TLS
+		svc_tls_close(xprt);
+#endif
 		(void)shutdown(xprt->xp_fd, SHUT_RDWR);
 		if (xprt->xp_fd_send != RPC_ANYFD)
 			(void)shutdown(xprt->xp_fd_send, SHUT_RDWR);

--- a/ntirpc/rpc/svc_rqst.h
+++ b/ntirpc/rpc/svc_rqst.h
@@ -59,6 +59,7 @@
 #define SVC_RQST_FLAG_LOCKED		SVC_XPRT_FLAG_LOCKED
 #define SVC_RQST_FLAG_UNLOCK		SVC_XPRT_FLAG_UNLOCK
 #define SVC_RQST_FLAG_EPOLL		0x00080000
+#define SVC_RQST_FLAG_TLS_MORE_DATA_AVAILABLE	SVC_XPRT_FLAG_TLS_MORE_DATA_AVAILABLE
 
 void svc_rqst_init(uint32_t);
 int svc_rqst_new_evchan(uint32_t *chan_id /* OUT */ , void *u_data,

--- a/ntirpc/rpc/tls.h
+++ b/ntirpc/rpc/tls.h
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/*
+ * vim:noexpandtab:shiftwidth=8:tabstop=8:
+ *
+ * Copyright (C) 2025, IBM . All rights reserved.
+ * Author: Deeraj Patil <deeraj.patil@ibm.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.  see <http://www.gnu.org/licenses/
+ *
+ * ---------------------------------------
+ */
+
+/**
+ * @file rpc/tls.h
+ * @brief Public TLS configuration structure and API for ntirpc.
+ */
+
+#ifndef TIRPC_TLS_H
+#define TIRPC_TLS_H
+
+#include <stdbool.h>
+#include <time.h>
+
+#ifdef USE_TLS
+
+/* TLS configuration structure */
+typedef struct tls_config {
+	bool enabled;
+	char *cert_file;
+	char *key_file;
+	char *ca_file;
+	char *ciphers;
+	char *min_version;
+	time_t session_timeout; /* for future use for session key updates */
+	bool ktls; /* Enable kernel TLS if available */
+	bool debug;
+} tls_config_t;
+
+extern tls_config_t tls_config;
+extern bool tls_init(tls_config_t *from_config);
+extern void tls_cleanup(void);
+
+#endif /* USE_TLS */
+
+#endif /* TIRPC_TLS_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,28 @@ if(USE_RPC_RDMA)
   )
 endif(USE_RPC_RDMA)
 
+if(USE_GNUTLS)
+  SET(ntirpc_tls_SRCS
+    tls_gnutls.c
+    )
+endif(USE_GNUTLS)
+
+if(USE_OPENSSL)
+  SET(ntirpc_tls_SRCS
+    ${ntirpc_tls_SRC}
+    tls_openssl.c)
+endif(USE_OPENSSL)
+
+if(USE_TLS)
+  SET(ntirpc_tls_SRCS
+    ${ntirpc_tls_SRCS}
+    tls_transport.c
+    tls_init.c
+    svc_auth_tls.c
+    )
+endif(USE_TLS)
+
+
 if(USE_LTTNG_NTIRPC)
   include("${CMAKE_CURRENT_BINARY_DIR}/../ntirpc_lttng_generation_file_properties.cmake")
   add_subdirectory(lttng)
@@ -107,6 +129,7 @@ add_library(ntirpc SHARED
   ${ntirpc_common_SRCS}
   ${ntirpc_gss_SRCS}
   ${ntirpc_rdma_SRCS}
+  ${ntirpc_tls_SRCS}
   ${ntirpc_monitoring_SRCS}
 )
 

--- a/src/libntirpc.map.in.cmake
+++ b/src/libntirpc.map.in.cmake
@@ -36,6 +36,7 @@ NTIRPC_${NTIRPC_VERSION_BASE} {
     _svcauth_none;
     _svcauth_short;
     _svcauth_unix;
+    _svcauth_tls;
 
     # a*
     authgss_ncreate;
@@ -176,6 +177,8 @@ NTIRPC_${NTIRPC_VERSION_BASE} {
     # t*
     taddr2uaddr;
     tirpc_control;
+    tls_cleanup;
+    tls_init;
 
     # u*
     uaddr2taddr;
@@ -230,6 +233,10 @@ NTIRPC_${NTIRPC_VERSION_BASE} {
     xdr_wrapstring;
     xdrmem_ncreate;
     xdrstdio_create;
+    xprt_tls_init;
+    xp_tls_recv_impl;
+    xp_tls_send_impl;
+    xp_tls_close_impl;
 
   local:
     *;

--- a/src/metrics_libntirpc.c
+++ b/src/metrics_libntirpc.c
@@ -71,8 +71,8 @@ static bool initialized = false;
  * will have the default `0` value in the array. Such entries will not be
  * represented in the metrics array.
  */
-static const uint8_t
-	sec_flavors_idx[] = { [AUTH_NONE] = 1, [AUTH_SYS] = 2, [RPCSEC_GSS] = 3 };
+static const uint8_t sec_flavors_idx[] = { [AUTH_NONE] = 1, [AUTH_SYS] = 2,
+					[RPCSEC_GSS] = 3 , [AUTH_TLS] = 4};
 
 /* For each auth-stat as an array index, assign a serial number to be
  * represented as the index in the metrics array.
@@ -149,6 +149,8 @@ static const char *get_sec_flavor_string(int sec_flavor)
 		return "SYS";
 	case RPCSEC_GSS:
 		return "RPCSEC_GSS";
+	case AUTH_TLS:
+		return "AUTH_TLS";
 	default:
 		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 			"%s: Unsupported security flavor value: %d", __func__,

--- a/src/svc_auth.c
+++ b/src/svc_auth.c
@@ -102,6 +102,12 @@ svc_auth_authenticate(struct svc_req *req, bool *no_dispatch)
 	cred_flavor = req->rq_msg.cb_cred.oa_flavor;
 	req->rq_msg.RPCM_ack.ar_verf.oa_flavor = cred_flavor;
 	switch (cred_flavor) {
+#ifdef USE_TLS
+	case AUTH_TLS:
+		/* Validate AUTH_TLS probe */
+		rslt = _svcauth_tls(req);
+		goto out;
+#endif /* USE_TLS */
 #ifdef _HAVE_GSSAPI
 	case RPCSEC_GSS:
 		rslt = _svcauth_gss(req, no_dispatch);
@@ -173,6 +179,9 @@ int svc_auth_reg(int cred_flavor,
 	switch (cred_flavor) {
 	case AUTH_NULL:
 	case AUTH_SYS:
+#ifdef USE_TLS
+	case AUTH_TLS:
+#endif
 	case AUTH_SHORT:
 	case RPCSEC_GSS:
 #ifdef DES_BUILTIN

--- a/src/svc_auth_tls.c
+++ b/src/svc_auth_tls.c
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+/*
+ * vim:noexpandtab:shiftwidth=8:tabstop=8:
+ *
+ * Copyright (C) 2025, IBM . All rights reserved.
+ * Author: Deeraj Patil <deeraj.patil@ibm.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.  see <http://www.gnu.org/licenses/
+ *
+ * ---------------------------------------
+ */
+
+/**
+ * @file svc_auth_tls.c
+ * @brief Routines used handling the AUTH_TLS request and internally calls the
+ * TLS functions for handshake.
+ * Reference : https://datatracker.ietf.org/doc/rfc9289/
+ *
+ */
+
+#include <rpc/svc_auth.h>
+#include <rpc/gss_internal.h>
+#include "tls.h"
+#include "tls_transport.h"
+
+#define STARTTLS_TOKEN "STARTTLS"
+#define STARTTLS_TOKEN_LEN 8
+
+extern SVCAUTH svc_auth_none;
+/**
+ * Send AUTH_TLS response with STARTTLS token using existing RPC infrastructure
+ */
+bool svcauth_tls_send_response(struct svc_req *req)
+{
+	SVCXPRT *xprt = req->rq_xprt;
+	char starttls_token[STARTTLS_TOKEN_LEN];
+	bool res = true;
+	int rc = 0;
+
+	/* Prepare STARTTLS token */
+	memcpy(starttls_token, STARTTLS_TOKEN, STARTTLS_TOKEN_LEN);
+
+	/* Set up the reply verifier with STARTTLS token */
+	req->rq_msg.RPCM_ack.ar_verf.oa_flavor = AUTH_NONE;
+	req->rq_msg.RPCM_ack.ar_verf.oa_length = STARTTLS_TOKEN_LEN;
+	memcpy(req->rq_msg.RPCM_ack.ar_verf.oa_body, starttls_token,
+	       STARTTLS_TOKEN_LEN);
+
+	/* Set up successful reply */
+	req->rq_msg.RPCM_ack.ar_stat = SUCCESS;
+	req->rq_msg.RPCM_ack.ar_results.where = NULL;
+	req->rq_msg.RPCM_ack.ar_results.proc = (xdrproc_t)xdr_void;
+	req->rq_msg.rm_direction = REPLY;
+	req->rq_msg.rm_reply.rp_stat = MSG_ACCEPTED;
+	/* Send the reply using existing RPC infrastructure */
+	rc = svc_sendreply(req);
+	if (rc >= XPRT_DIED) {
+		LogDebugTLS(TLS_HANDSHAKE,
+			    "svc_sendreply failed for AUTH_TLS response on fd %"
+			    PRId32, xprt->xp_fd);
+		res = false;
+	} else {
+		LogDebugTLS(TLS_HANDSHAKE,
+			    "AUTH_TLS STARTTLS response sent on fd %" PRId32,
+			    xprt->xp_fd);
+	}
+	res = svc_tls_init_xprt(xprt);
+	return res;
+}
+
+/**
+ * AUTH_TLS authentication handler
+ */
+enum auth_stat svcauth_tls_checks(struct svc_req *req)
+{
+	enum auth_stat rc = AUTH_OK;
+
+	/* Unserialize client credentials. */
+	if (req->rq_msg.cb_cred.oa_length != 0) {
+		/* AUTH_TLS credentials MUST be zero length */
+		LogDebugTLS(TLS_HANDSHAKE,
+			"AUTH_TLS credential length must be zero, got %" PRIu32,
+			req->rq_msg.cb_cred.oa_length);
+		return AUTH_BADCRED;
+	}
+
+	/* Validate AUTH_TLS probe format */
+	if (req->rq_msg.cb_cred.oa_flavor != AUTH_TLS) {
+		LogDebugTLS(TLS_HANDSHAKE,
+			    "Expected AUTH_TLS flavor, got %" PRId32,
+			    req->rq_msg.cb_cred.oa_flavor);
+		rc = AUTH_BADCRED;
+	}
+
+	/* Check verifier - MUST be AUTH_NONE with zero length */
+	if (req->rq_msg.cb_verf.oa_flavor != AUTH_NONE ||
+	    req->rq_msg.cb_verf.oa_length != 0) {
+		LogDebugTLS(TLS_HANDSHAKE,
+			"AUTH_TLS verifier must be AUTH_NONE with zero length");
+		rc = AUTH_BADCRED;
+	}
+
+	/* Check if this is within an existing TLS session */
+	if (req->rq_xprt->xp_tls.tls_enabled ||
+	    req->rq_xprt->xp_tls.tls_established) {
+		LogDebugTLS(TLS_HANDSHAKE,
+			"AUTH_TLS probe within existing TLS session on fd %"
+			PRId32,	req->rq_xprt->xp_fd);
+		rc = AUTH_BADCRED;
+		return rc;
+	}
+
+	/* Check if this is NULL procedure - AUTH_TLS only allowed on NULL */
+	if (req->rq_msg.cb_proc != NULLPROC) {
+		LogDebugTLS(TLS_HANDSHAKE,
+			"AUTH_TLS only allowed on NULL procedure, proc %"
+			PRIu32,	req->rq_msg.cb_proc);
+		rc = AUTH_BADCRED;
+	}
+
+	/* Mark this connection as TLS-pending */
+	req->rq_xprt->xp_tls.tls_pending = true;
+
+	return rc;
+}
+
+enum auth_stat _svcauth_tls(struct svc_req *req)
+{
+	enum auth_stat rslt;
+
+	rslt = svcauth_tls_checks(req);
+	if (rslt == AUTH_OK) {
+		/* Set rq_auth to avoid NULL pointer dereference in SVCAUTH_CHECKSUM */
+		req->rq_auth = &svc_auth_none;
+		LogDebugTLS(TLS_HANDSHAKE,
+			    "TLS Valid AUTH_TLS probe detected on fd %" PRId32,
+			    req->rq_xprt->xp_fd);
+		if (svcauth_tls_send_response(req) == false)
+			rslt = AUTH_TOOWEAK;
+	}
+	return rslt;
+}

--- a/src/svc_internal.h
+++ b/src/svc_internal.h
@@ -202,6 +202,10 @@ void svc_rqst_unhook(SVCXPRT *);
  */
 #define SOCK_NAME_MAX 128
 
+#if USE_TLS
+void svc_tls_send_event(SVCXPRT *xprt);
+#endif
+
 typedef struct sockaddr_storage sockaddr_t;
 int svc_get_port(sockaddr_t *);
 

--- a/src/svc_ioq.c
+++ b/src/svc_ioq.c
@@ -64,6 +64,9 @@
 #include <getpeereid.h>
 #include <misc/opr.h>
 #include "svc_ioq.h"
+#ifdef USE_TLS
+#include "tls.h"
+#endif
 
 #define LAST_FRAG ((u_int32_t)(1 << 31))
 #define LAST_FRAG_XDR_UNITS ((LAST_FRAG - 1) & ~(BYTES_PER_XDR_UNIT - 1))
@@ -223,7 +226,13 @@ again:
 
 		/* non-blocking write */
 		errno = 0;
+
+#ifdef USE_TLS
+		result = svc_tls_send(xprt, &msg, MSG_DONTWAIT);
+#else
 		result = sendmsg(xprt->xp_fd, &msg, MSG_DONTWAIT);
+#endif
+
 		error = errno;
 
 		__warnx((error == EWOULDBLOCK || error == EAGAIN || error == 0)

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -56,6 +56,9 @@
 #include "rpc_rdma.h"
 #endif // USE_RPC_RDMA
 
+#ifdef USE_TLS
+#include "tls.h"
+#endif /* USE_TLS */
 /**
  * @file svc_rqst.c
  * @contributeur William Allen Simpson <bill@cohortfs.com>
@@ -1473,11 +1476,29 @@ svc_rqst_epoll_event(struct svc_rqst_rec *sr_rec, struct epoll_event *ev)
 			"%s: fd %d wakeup (sr_rec %p)",
 			__func__, sr_rec->sv[1],
 			sr_rec);
+#if USE_TLS
+		if (consume_ev_sig_nb(sr_rec->sv[1]) ==
+				SVC_RQST_FLAG_TLS_MORE_DATA_AVAILABLE) {
+			int tls_dpr_fd = 0;
+
+			LogDebugTLS(TLS_DISPATCH,
+				    "recv sig DPR fd %d events =:%d",
+				     ev_data.data.fd, ev->events);
+			/* next 4 bytes indicates DPR fd */
+			read(sr_rec->sv[1], &tls_dpr_fd, sizeof(uint32_t));
+			xprt = svc_xprt_lookup(tls_dpr_fd, NULL);
+			if (xprt && svc_tls_datapending(xprt)) {
+				rec = REC_XPRT(xprt);
+				goto tls_dpr;
+			}
+		}
+#else
 		(void)consume_ev_sig_nb(sr_rec->sv[1]);
-		__warnx(TIRPC_DEBUG_FLAG_SVC_RQST,
-			"%s: fd %d after consume sig (sr_rec %p)",
-			__func__, sr_rec->sv[1],
-			sr_rec);
+#endif
+               __warnx(TIRPC_DEBUG_FLAG_SVC_RQST,
+                       "%s: fd %d after consume sig (sr_rec %p)",
+                       __func__, sr_rec->sv[1],
+                       sr_rec);
 		return (NULL);
 	}
 
@@ -1515,6 +1536,9 @@ svc_rqst_epoll_event(struct svc_rqst_rec *sr_rec, struct epoll_event *ev)
 		ev->events & EPOLLOUT ? " SEND" : "",
 		rec, sr_rec);
 
+#if USE_TLS
+tls_dpr:
+#endif
 	if (ev->events & EPOLLIN) {
 		/* This is a RECV event */
 		ev_flag = SVC_XPRT_FLAG_ADDED_RECV;
@@ -1567,14 +1591,29 @@ svc_rqst_epoll_event(struct svc_rqst_rec *sr_rec, struct epoll_event *ev)
 	}
 	XPRT_UNIQUE_AUTO_TRACEPOINT(&rec->xprt, epoll_event, TRACE_INFO,
 		"irrelevant epoll event. ev_flag: {}", ev_flag);
-	/* Do not return destroyed transports.
-	 * Probably log non-fatal "WARNING! already destroying!"
-	 */
-	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+
+#if USE_TLS
+	/*  In case of TLS, there is possiblity of data EPOLLIN event just got
+	 *  processed and xp_flag has been cleared.
+	 *  Because of current DPR event processing will cause:
+	 *  (xp_flags & ev_flag) != TRUE
+	 *  In that case DPR event should be dropped. i.e already recv IO in
+	 *  progress and it will be the reposibillity of this recv IO to raise
+	 *  another DPR after proper check.
+	 *  so added check for proper case of destroy
+	 *  */
+	if (xp_flags & SVC_XPRT_FLAG_DESTROYED)
+#endif
+	{
+		/* Do not return destroyed transports.
+		 * Probably log non-fatal "WARNING! already destroying!"
+		 */
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
 		"%s: %p fd %d already destroying. prev flags %x, curr flags %x, ev_flag %x,"
 		"ref_count = %" PRId32,
 		__func__, &rec->xprt, rec->xprt.xp_fd, xp_flags, xprt->xp_flags,
 		ev_flag, xprt->xp_refcnt);
+	}
 	SVC_RELEASE(&rec->xprt, SVC_RELEASE_FLAG_NONE);
 	return (NULL);
 }
@@ -1618,7 +1657,7 @@ svc_rqst_epoll_events(struct svc_rqst_rec *sr_rec, int n_events)
 
 static void svc_rqst_epoll_loop(struct work_pool_entry *wpe)
 {
-	struct svc_rqst_rec *sr_rec = 
+	struct svc_rqst_rec *sr_rec =
 		opr_containerof(wpe, struct svc_rqst_rec, ev_wpe);
 	struct clnt_req *cc;
 	struct opr_rbtree_node *n;
@@ -1845,3 +1884,34 @@ svc_get_port(sockaddr_t *addr)
 		return -1;
 	}
 }
+
+#if USE_TLS
+/* Signal to wake up recv fd from epoll_wait to recv data
+ * this is because TLS lib reads all available data from underlying sockets
+ * and caches it, so libntirpc doesn't receives any event for buffered
+ * data and this event helps in this situtation
+ * */
+void svc_tls_send_event(SVCXPRT *xprt)
+{
+        struct rpc_dplx_rec *rec = REC_XPRT(xprt);
+        struct svc_rqst_rec *sr_rec = rec->ev_p;
+        int tls_code;
+        struct tls_signal_dpr dpr;
+        dpr.signal = SVC_RQST_FLAG_TLS_MORE_DATA_AVAILABLE;
+        dpr.fd = rec->xprt.xp_fd;
+
+        LogDebugTLS(TLS_DISPATCH,
+                        "TLS sending DPR fd %d epoll_fd %" PRId32
+                        "control fd pair (%d:%d)",
+                        rec->xprt.xp_fd,
+                        sr_rec->ev_u.epoll.epoll_fd,
+                        sr_rec->sv[0], sr_rec->sv[1]);
+        /* we cannot do ev_sig, because of need fd info also to
+         * resume data, so directly write to control pipe */
+        tls_code = write(sr_rec->sv[0], &dpr, sizeof(dpr));
+        LogDebugTLS(TLS_DISPATCH,
+                        "fd %d sig %d :%d :%d",
+                        sr_rec->sv[0], dpr.signal, tls_code, errno);
+
+}
+#endif

--- a/src/svc_vc.c
+++ b/src/svc_vc.c
@@ -82,6 +82,7 @@
 #include "svc_xprt.h"
 #include "rpc_dplx_internal.h"
 #include "svc_ioq.h"
+#include "tls.h"
 
 static void svc_vc_rendezvous_ops(SVCXPRT *);
 static void svc_vc_override_ops(SVCXPRT *, SVCXPRT *);
@@ -634,6 +635,12 @@ svc_vc_destroy_task(struct work_pool_entry *wpe)
 	close_fd = ((xp_flags & SVC_XPRT_FLAG_CLOSE) &&
 		rec->xprt.xp_fd != RPC_ANYFD);
 	if (close_fd) {
+#ifdef USE_TLS
+		/*   need to tell the client about TLS Connection closure */
+		SVCXPRT *xprt = &rec->xprt;
+
+		svc_tls_close(xprt);
+#endif
 		/* Shutting down without releasing the fd, since
 		 * xp_free_user_data() might be using it */
 		(void)shutdown(rec->xprt.xp_fd, SHUT_RDWR);
@@ -1213,9 +1220,30 @@ svc_vc_recv(SVCXPRT *xprt)
 
 	if (!xd->sx_fbtbc) {
 again:
-
+#ifdef USE_TLS
+               /* This is stunnel like TLS handshake request handling
+                * this internally does handshake if this is handshake msg*/
+		if (!((xprt)->xp_tls.not_first_packet)) {
+			if (is_handshake_msg(xprt)) {
+				(xprt)->xp_tls.not_first_packet = true;
+				xd->sx_fbtbc = 0;
+				if (unlikely(svc_rqst_rearm_events(xprt,
+								SVC_XPRT_FLAG_ADDED_RECV))) {
+					__warnx(TIRPC_DEBUG_FLAG_ERROR,
+							"%s: %p fd %d svc_rqst_rearm_events failed (will set dead)",
+							__func__, xprt, xprt->xp_fd);
+					SVC_DESTROY(xprt);
+				}
+				return SVC_STAT(xprt);
+			}
+			(xprt)->xp_tls.not_first_packet = true;
+		}
+		rlen = svc_tls_recv(xprt, &xd->sx_fbtbc, BYTES_PER_XDR_UNIT,
+				    hap_again ? MSG_DONTWAIT : MSG_WAITALL);
+#else
 		rlen = recv(xprt->xp_fd, &xd->sx_fbtbc, BYTES_PER_XDR_UNIT,
-			    hap_again ? MSG_DONTWAIT : MSG_WAITALL);
+				    hap_again ? MSG_DONTWAIT : MSG_WAITALL);
+#endif
 
 		if (unlikely(rlen < 0)) {
 			code = errno;
@@ -1287,6 +1315,9 @@ again:
 				}
 				/* Now look to see if there's more... */
 				hap_again = true;
+#ifdef USE_TLS
+				xprt->xp_tls.not_first_packet = false;
+#endif
 				goto again;
 			case HAPROXY_RET_CODE__FAILURE:
 				SVC_DESTROY(xprt);
@@ -1327,8 +1358,11 @@ again:
 		uv = IOQ_(TAILQ_LAST(&xioq->ioq_uv.uvqh.qh, poolq_head_s));
 		flags = uv->u.uio_flags;
 	}
-
+#ifdef USE_TLS
+	rlen = svc_tls_recv(xprt, uv->v.vio_tail, xd->sx_fbtbc, MSG_DONTWAIT);
+#else
 	rlen = recv(xprt->xp_fd, uv->v.vio_tail, xd->sx_fbtbc, MSG_DONTWAIT);
+#endif
 
 	if (unlikely(rlen < 0)) {
 		code = errno;
@@ -1398,6 +1432,10 @@ again:
 		} else {
 			XPRT_UNIQUE_AUTO_TRACEPOINT(xprt, recv_exit,
 				TRACE_DEBUG, "recv exit");
+#if USE_TLS
+			if (svc_tls_datapending(xprt) == true)
+				svc_tls_send_event(xprt);
+#endif
 		}
 
 		return SVC_STAT(xprt);
@@ -1427,6 +1465,11 @@ again:
 
 		return SVC_STAT(xprt);
 	}
+
+#if USE_TLS
+	if (svc_tls_datapending(xprt) == true)
+		svc_tls_send_event(xprt);
+#endif
 
 	XPRT_UNIQUE_AUTO_TRACEPOINT(xprt, calling_svc_request,
 		TRACE_DEBUG, "Calling svc_request");

--- a/src/tls.h
+++ b/src/tls.h
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+/*
+ * vim:noexpandtab:shiftwidth=8:tabstop=8:
+ *
+ * Copyright (C) 2025, IBM . All rights reserved.
+ * Author: Deeraj Patil <deeraj.patil@ibm.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.  see <http://www.gnu.org/licenses/
+ *
+ * ---------------------------------------
+ */
+
+/**
+ * @file tls.h
+ */
+
+
+#ifndef TIRPC_SRC_TLS_H
+#define TIRPC_SRC_TLS_H
+
+#ifdef USE_TLS
+
+#include <fcntl.h>
+#include <errno.h>
+#include "strl.h"
+#include "rpc/svc.h"
+#include "rpc/types.h"
+#include "rpc/tls.h"
+#include "svc_internal.h"
+#ifdef USE_OPENSSL
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/types.h>
+#endif
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#endif
+
+#ifdef USE_GNUTLS
+#include <gnutls/gnutls.h>
+#include <gnutls/x509.h>
+#endif
+
+#define TLS_SESSION_UNKNOWN_ERROR -1
+#define TLS_SESSION_CLOSED_ADRUPTLY -2
+#define TLS_HANDSHAKE_FAILED -3
+
+#define TLS_INIT "[Init Path]:"
+#define TLS_DISPATCH "[Dispatch]:"
+#define TLS_HANDSHAKE "[Handshake Path]:"
+#define TLS_SHUTDOWN "[Shutdown Path]:"
+#define TLS_UNKNOWN " "
+
+#define LogCritTLS(component, format, ...)                                 \
+	__warnx(TIRPC_DEBUG_FLAG_ERROR, "[TLS]:%s:%s:%" PRId32 " " format, \
+		component, __func__, __LINE__, ##__VA_ARGS__)
+
+#define LogWarnTLS(component, format, ...)                                \
+	__warnx(TIRPC_DEBUG_FLAG_WARN, "[TLS]:%s:%s:%" PRId32 " " format, \
+		component, __func__, __LINE__, ##__VA_ARGS__)
+
+#define LogEventTLS(component, format, ...)                                \
+	__warnx(TIRPC_DEBUG_FLAG_EVENT, "[TLS]:%s:%s:%" PRId32 " " format, \
+		component, __func__, __LINE__, ##__VA_ARGS__)
+
+#define LogDebugTLS(component, format, ...)                                \
+	if (tls_config.debug)                                              \
+		__warnx(TIRPC_DEBUG_FLAG_EVENT, "[TLS]:%s:%s:%" PRId32 " " \
+			format, component, __func__, __LINE__, ##__VA_ARGS__)
+
+
+/* TLS context structure */
+typedef struct tls_ctx {
+#ifdef USE_OPENSSL
+	struct ssl_st *ssl; /* openSSL session */
+	struct ssl_ctx_st *ctx;
+#endif
+
+#ifdef USE_GNUTLS
+	/*
+	struct gnutls_session_int *session;
+	struct gnutls_certificate_credentials_st *cred;
+	*/
+	gnutls_session_t session; /* GnuTLS session */
+	gnutls_certificate_credentials_t creds; /* GnuTLS credentials */
+#endif
+
+	pthread_mutex_t ctx_lock;
+	bool handshake_complete;
+	int fd;
+} tls_ctx_t;
+
+/* libs cache the data in buffers, signal stucture used for DPR */
+struct tls_signal_dpr {
+	uint32_t signal;
+	int fd;
+};
+
+#ifdef USE_OPENSSL
+typedef SSL_CTX tls_cred_t;
+#endif
+
+#ifdef USE_GNUTLS
+typedef struct gnutls_certificate_credentials_st tls_cred_t;
+#endif
+
+#endif /*  USE_TLS */
+
+#endif /*  TIRPC_SRC_TLS_H */

--- a/src/tls_gnutls.c
+++ b/src/tls_gnutls.c
@@ -1,0 +1,1015 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+/*
+ * vim:noexpandtab:shiftwidth=8:tabstop=8:
+ *
+ * Copyright (C) 2025, IBM . All rights reserved.
+ * Author: Deeraj Patil <deeraj.patil@ibm.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.  see <http://www.gnu.org/licenses/
+ *
+ * ---------------------------------------
+ */
+
+/**
+ * @file tls_gnutls.c
+ * @brief Routines used for managing the TLS Session using GnuTLS lib.
+ * Implementation patterns have been derived from GNUTLS library
+ * especially from server.c patterns
+ *
+ * Routines used for support TLS in ntirpc.
+ *
+ */
+#include "tls.h"
+
+#ifdef USE_GNUTLS
+
+/* Global GnuTLS context */
+static gnutls_priority_t global_priority;
+static void tls_enhanced_debug_callback(int level, const char *str);
+static int tls_verify_certificate(gnutls_session_t session);
+
+/* Helper function to get GnuTLS error string */
+static char *get_gnutls_error(int error_code)
+{
+	return (char *)gnutls_strerror(error_code);
+}
+
+#define MAX_PRIORITY_STR 512
+
+/**
+ * Initialize the TLS subsystem
+ *
+ * @param cert_file    Path to the server certificate file (PEM format)
+ * @param key_file     Path to the server private key file (PEM format)
+ * @param ca_file      Path to the CA certificate file (PEM format) for
+ *			client verification
+ * @param ciphers      Cipher suite string (GnuTLS priority string)
+ * @param min_version  Minimum TLS version ("TLSv1.2" or "TLSv1.3")
+ * @param ktls         To enable or disable ktls
+ * @param debug        To enable or disable debugging including registering
+ *			lib callbacks
+ * @return             Creds which should be used for per session connection
+ *			creation, if fails returns NULL.
+ */
+tls_cred_t *tls_cred_init(const char *cert_file, const char *key_file,
+			     const char *ca_file, const char *ciphers,
+			     const char *min_version, bool ktls, bool debug)
+{
+	int ret;
+	char priority_str[MAX_PRIORITY_STR] = { 0 };
+	gnutls_certificate_credentials_t global_creds = NULL;
+
+	LogDebugTLS(TLS_DISPATCH, "%s:%" PRId32 , __func__, __LINE__);
+	/* Initialize GnuTLS */
+	ret = gnutls_global_init();
+	if (ret < 0) {
+		LogCritTLS(TLS_INIT, "Failed to initialize GnuTLS: %s",
+			   get_gnutls_error(ret));
+		return NULL;
+	}
+
+	/*  Register debug callback - THIS IS THE KEY PART for debugging */
+	/*  As per lib set to 9 for maximum verbosity, adjust as needed */
+	if (debug) {
+		gnutls_global_set_log_function(tls_enhanced_debug_callback);
+		gnutls_global_set_log_level(9);
+	}
+
+	/* Initialize certificate credentials */
+	ret = gnutls_certificate_allocate_credentials(&global_creds);
+	if (ret < 0) {
+		LogCritTLS(TLS_INIT, "Failed to allocate credentials: %s",
+			   get_gnutls_error(ret));
+		goto cleanup_global;
+	}
+
+	/* Load CA certificates for client verification */
+	if (ca_file) {
+		ret = gnutls_certificate_set_x509_trust_file(
+			global_creds, ca_file, GNUTLS_X509_FMT_PEM);
+		if (ret < 0) {
+			LogCritTLS(TLS_INIT, "Failed to load CA file %s: %s",
+				   ca_file, get_gnutls_error(ret));
+			goto cleanup_global;
+		}
+	} else {
+		/* Use default system CA certificates */
+		ret = gnutls_certificate_set_x509_system_trust(global_creds);
+		if (ret < 0) {
+			LogWarnTLS(TLS_INIT,
+				   "Failed to set default system trust: %s",
+				   get_gnutls_error(ret));
+			goto cleanup_global;
+		}
+	}
+
+	/* Load server certificate and key */
+	ret = gnutls_certificate_set_x509_key_file(global_creds, cert_file,
+						   key_file,
+						   GNUTLS_X509_FMT_PEM);
+	if (ret < 0) {
+		LogCritTLS(TLS_INIT, "Failed to load certificate/key files: %s",
+			   get_gnutls_error(ret));
+		goto cleanup_creds;
+	}
+
+	if (min_version && strcmp(min_version, "TLSv1.2") == 0)
+		snprintf(priority_str, MAX_PRIORITY_STR, "NORMAL:-VERS-ALL:+%s",
+			 "VERS-TLS1.2:+VERS-TLS1.3");
+	else
+		/* Default to TLSv1.3 only when min_version is NULL */
+		snprintf(priority_str, MAX_PRIORITY_STR, "NORMAL:-VERS-ALL:+%s",
+			 "VERS-TLS1.3");
+
+	/* If custom cipher list provided, append it, else do the default*/
+	if (ciphers && strlen(ciphers) > 0) {
+		strncat(priority_str, ciphers,
+			MAX_PRIORITY_STR - strlen(priority_str) - 1);
+	}
+
+	LogDebugTLS(TLS_INIT, "Setting priority: %s", priority_str);
+	ret = gnutls_priority_init(&global_priority, priority_str, NULL);
+	if (ret < 0) {
+		LogCritTLS(TLS_INIT, "Failed to set priority: %s",
+			   get_gnutls_error(ret));
+		goto cleanup_creds;
+	}
+
+	/* Set certificate verification function if CA is provided */
+	if (ca_file) {
+		gnutls_certificate_set_verify_function(
+			global_creds, tls_verify_certificate);
+	}
+
+	LogDebugTLS(TLS_INIT, "TLS initialized successfully with GnuTLS");
+	return global_creds;
+
+cleanup_creds:
+	gnutls_certificate_free_credentials(global_creds);
+cleanup_global:
+	gnutls_global_deinit();
+	return NULL;
+}
+
+/**
+ * Create a new TLS context for a socket
+ *
+ * @param fd           Socket file descriptor
+ * @param cred         creds which got returned from tls_cred_init()
+ * @param is_server    Connection type i.e fd is acting as server or a client.
+ * @return             Pointer to the new TLS context, or NULL on failure
+ */
+tls_ctx_t *tls_ctx_init(int fd, tls_cred_t *creds, bool is_server)
+{
+	tls_ctx_t *ctx;
+	int ret;
+
+	LogDebugTLS(TLS_HANDSHAKE, "%s:%" PRId32 , __func__, __LINE__);
+
+	if (!creds) {
+		LogCritTLS(TLS_HANDSHAKE, "TLS not initialized");
+		return NULL;
+	}
+
+	ctx = mem_calloc(1, sizeof(tls_ctx_t));
+	if (!ctx) {
+		LogCritTLS(TLS_HANDSHAKE, "Failed to allocate TLS context");
+		return NULL;
+	}
+
+	pthread_mutex_init(&(ctx->ctx_lock), NULL);
+	ctx->fd = fd;
+
+	/* Initialize session */
+	if (is_server) {
+		ret = gnutls_init(&ctx->session, GNUTLS_SERVER);
+	} else {
+		ret = gnutls_init(&ctx->session, GNUTLS_CLIENT);
+	}
+	if (ret < 0) {
+		LogCritTLS(TLS_HANDSHAKE,
+			   "Failed to initialize GnuTLS session: %s",
+			   get_gnutls_error(ret));
+		mem_free(ctx, sizeof(tls_ctx_t));
+		return NULL;
+	}
+
+	gnutls_transport_set_int(ctx->session, fd);
+
+	/* Set credentials */
+	ret = gnutls_credentials_set(ctx->session, GNUTLS_CRD_CERTIFICATE,
+				     creds);
+	if (ret < 0) {
+		LogCritTLS(TLS_HANDSHAKE, "Failed to set credentials: %s",
+			   get_gnutls_error(ret));
+		gnutls_deinit(ctx->session);
+		mem_free(ctx, sizeof(tls_ctx_t));
+		return NULL;
+	}
+
+	/* Set priority */
+	ret = gnutls_priority_set(ctx->session, global_priority);
+	if (ret < 0) {
+		LogCritTLS(TLS_HANDSHAKE, "Failed to set priority: %s",
+			   get_gnutls_error(ret));
+		gnutls_deinit(ctx->session);
+		mem_free(ctx, sizeof(tls_ctx_t));
+		return NULL;
+	}
+	if (is_server)
+		gnutls_certificate_server_set_request(ctx->session,
+						      GNUTLS_CERT_REQUEST);
+
+	return ctx;
+}
+
+/**
+ * Perform TLS handshake
+ *
+ * @param ctx          TLS context
+ * @return             true on success, false on failure
+ */
+bool tls_handshake(tls_ctx_t *ctx)
+{
+	int ret;
+
+	LogDebugTLS(TLS_HANDSHAKE, "%s:%" PRId32 , __func__, __LINE__);
+	gnutls_datum_t out;
+	int type;
+	unsigned int status;
+	int counter = 0;
+
+	if (!ctx || !ctx->session) {
+		LogCritTLS(TLS_HANDSHAKE, "Invalid TLS context");
+		return false;
+	}
+
+	pthread_mutex_lock(&(ctx->ctx_lock));
+
+	if (ctx->handshake_complete) {
+		pthread_mutex_unlock(&(ctx->ctx_lock));
+		return true;
+	}
+
+	/* Set timeout to 10 seconds, time in milliseconds */
+	gnutls_handshake_set_timeout(ctx->session, 100000);
+
+	/* Perform server handshake */
+retry:
+	do {
+		LogDebugTLS(TLS_HANDSHAKE, "trying Handhake ");
+		ret = gnutls_handshake(ctx->session);
+		++counter;
+	} while (ret < 0 && gnutls_error_is_fatal(ret) == 0);
+
+	if (ret < 0) {
+		LogEventTLS(TLS_HANDSHAKE, "*** Handshake failed: :%" PRId32
+			    " %s\n", ret, gnutls_strerror(ret));
+		switch (ret) {
+		case GNUTLS_E_AGAIN:
+		case GNUTLS_E_INTERRUPTED:
+			/* Handshake needs more data, not an error */
+			LogDebugTLS(TLS_HANDSHAKE, "Need more data: %s",
+				    get_gnutls_error(ret));
+			goto retry;
+
+		case GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR:
+			/* check certificate verification status */
+			type = gnutls_certificate_type_get(ctx->session);
+			status = gnutls_session_get_verify_cert_status(
+				ctx->session);
+			gnutls_certificate_verification_status_print(status,
+								     type, &out,
+								     0);
+			LogDebugTLS(TLS_HANDSHAKE, "cert verify output: %s\n",
+				    out.data);
+			gnutls_free(out.data);
+			break;
+
+		case GNUTLS_E_FATAL_ALERT_RECEIVED:
+			LogDebugTLS(TLS_HANDSHAKE,
+				    "TLS fatal alert received on fd ");
+			break;
+
+		default:
+			LogDebugTLS(TLS_HANDSHAKE,
+				    "TLS Error <NOT HANDLED> :%s",
+				    gnutls_strerror(ret));
+			break;
+		}
+		pthread_mutex_unlock(&(ctx->ctx_lock));
+		return false;
+	}
+
+	ctx->handshake_complete = true;
+	/* Check for SNI hostname */
+	char name[256];
+	size_t name_len = sizeof(name);
+
+	ret = gnutls_server_name_get(ctx->session, name, &name_len, &type, 0);
+	if (ret == 0 && type == GNUTLS_NAME_DNS) {
+		LogDebugTLS(TLS_HANDSHAKE, "SNI hostname: %s", name);
+	} else {
+		LogDebugTLS(TLS_HANDSHAKE, "No SNI hostname received");
+	}
+
+	ret = true;
+	pthread_mutex_unlock(&(ctx->ctx_lock));
+	LogDebugTLS(TLS_HANDSHAKE, "TLS handshake done");
+	return ret;
+}
+
+/**
+ * Check secure connection is TLS or MTLS
+ *
+ * @param ctx          TLS context
+ * @return             true on MTLS, false on TLS
+ */
+bool tls_get_type(tls_ctx_t *ctx)
+{
+	unsigned int cert_list_size = 0;
+	const gnutls_datum_t *cert_list;
+	bool ret = false;
+
+	if (!ctx->session)
+		return ret;
+
+	cert_list = gnutls_certificate_get_peers(ctx->session, &cert_list_size);
+
+	if (cert_list && cert_list_size > 0) {
+		unsigned int status = 0;
+
+		ret = gnutls_certificate_verify_peers3(ctx->session, NULL,
+						       &status);
+
+		if (ret == 0 && status == 0) {
+			ret = true;
+		} else {
+			ret = false;
+		}
+	}
+	LogDebugTLS(TLS_HANDSHAKE, "MTLS CERIFICATE %" PRId32 , ret);
+	return ret;
+}
+
+/**
+ * Verify peer certificate and extract identity
+ *
+ * @param ctx           TLS context
+ * @param peer_identity Buffer to store peer identity (CN from certificate)
+ * @param id_size       Size of the peer_identity buffer
+ * @return              true if verification succeeded, false otherwise
+ */
+static int tls_verify_certificate(gnutls_session_t session)
+{
+	unsigned int status;
+	const gnutls_datum_t *cert_list;
+	unsigned int cert_list_size;
+	gnutls_x509_crt_t cert;
+	int ret;
+
+	/* Get peer certificate list */
+	cert_list = gnutls_certificate_get_peers(session, &cert_list_size);
+	if (cert_list == NULL || cert_list_size == 0) {
+		LogDebugTLS(TLS_HANDSHAKE, "No client certificate provided");
+		 /*  Allow connections without client certs */
+		return GNUTLS_E_SUCCESS;
+	}
+
+	/* Verify certificate chain */
+	ret = gnutls_certificate_verify_peers3(session, NULL, &status);
+	if (ret < 0) {
+		LogWarnTLS(TLS_HANDSHAKE, "Certificate verification failed: %s",
+			   gnutls_strerror(ret));
+		return GNUTLS_E_CERTIFICATE_ERROR;
+	}
+
+	if (status != 0) {
+		gnutls_datum_t out;
+
+		gnutls_certificate_verification_status_print(status,
+							     GNUTLS_CRT_X509,
+							     &out, 0);
+		LogWarnTLS(TLS_HANDSHAKE, "Certificate verification failed: %s",
+			   out.data);
+		gnutls_free(out.data);
+		return GNUTLS_E_CERTIFICATE_ERROR;
+	}
+
+	/* Initialize certificate */
+	ret = gnutls_x509_crt_init(&cert);
+	if (ret < 0) {
+		LogWarnTLS(TLS_INIT, "Failed to initialize certificate: %s",
+			   gnutls_strerror(ret));
+		return GNUTLS_E_CERTIFICATE_ERROR;
+	}
+
+	/* Import certificate */
+	ret = gnutls_x509_crt_import(cert, &cert_list[0], GNUTLS_X509_FMT_DER);
+	if (ret < 0) {
+		LogWarnTLS(TLS_HANDSHAKE, "Failed to import certificate: %s",
+			   gnutls_strerror(ret));
+		gnutls_x509_crt_deinit(cert);
+		return GNUTLS_E_CERTIFICATE_ERROR;
+	}
+
+	/* Log certificate information */
+	char dn[256];
+	size_t dn_size = sizeof(dn);
+
+	ret = gnutls_x509_crt_get_dn(cert, dn, &dn_size);
+	if (ret >= 0) {
+		LogDebugTLS(TLS_HANDSHAKE, "Client certificate DN: %s", dn);
+	}
+
+	gnutls_x509_crt_deinit(cert);
+	LogDebugTLS(TLS_HANDSHAKE, "Client certificate verified successfully");
+
+	return GNUTLS_E_SUCCESS;
+}
+
+/**
+ * Receive data over TLS
+ *
+ * @param ctx          TLS context
+ * @param buf          Buffer to store received data
+ * @param len          Length of the buffer
+ * @return             Number of bytes received, or converted error
+ */
+ssize_t tls_recv(tls_ctx_t *ctx, void *buf, size_t len, int flags)
+{
+	ssize_t ret;
+	int error_code = 0;
+	int fd = ctx->fd;
+	int orig_flags = fcntl(fd, F_GETFL, 0);
+	//bool nonblock = flags & MSG_DONTWAIT;
+	bool nonblock = 0;
+	ssize_t offset = 0;
+
+
+	if (!ctx || !ctx->session)
+		return EINVAL;
+
+	if (nonblock)
+		fcntl(fd, F_SETFL, orig_flags | O_NONBLOCK);
+
+	LogDebugTLS(TLS_DISPATCH, "Recv requested len > %" PRId32 , len);
+
+	while (offset < len) {
+retry:
+		ret = gnutls_record_recv(ctx->session, buf + offset,
+					 len - offset);
+		if (ret <= 0) {
+			LogDebugTLS(TLS_DISPATCH, "Read ret:%" PRId32
+				   " error:%s %" PRId32 ,
+				    ret, get_gnutls_error(ret), errno);
+			switch (ret) {
+			case GNUTLS_E_AGAIN:
+			case GNUTLS_E_INTERRUPTED:
+				goto retry;
+			case GNUTLS_E_PREMATURE_TERMINATION:
+			case GNUTLS_E_INVALID_SESSION:
+				error_code = TLS_SESSION_CLOSED_ADRUPTLY;
+				break;
+			default:
+				error_code = TLS_SESSION_UNKNOWN_ERROR;
+				break;
+			}
+			return error_code;
+		}
+		offset += ret;
+	}
+	/* restore original flags */
+	if (nonblock)
+		fcntl(fd, F_SETFL, orig_flags);
+
+	LogDebugTLS(TLS_DISPATCH, "Recv Completed len: %" PRId64 , offset);
+	return offset;
+}
+
+/**
+ * Function provides details of the pending data in library internal bufferes
+ * only for recv
+ *
+ * @param ctx          TLS context
+ * @return             Number of bytes cached in internal buffers
+ */
+int tls_datapending(tls_ctx_t *ctx)
+{
+        return gnutls_record_check_pending(ctx->session);
+}
+
+/**
+ * Send data over TLS
+ *
+ * @param ctx          TLS context
+ * @param msg          Message to send
+ * @param flags        Send flags
+ * @return             Number of bytes sent, or converted error
+ */
+ssize_t tls_send(tls_ctx_t *ctx, const struct msghdr *msg, int flags)
+{
+	int fd = ctx->fd;
+	int orig_flags = fcntl(fd, F_GETFL, 0);
+	//bool nonblock = flags & MSG_DONTWAIT;
+	bool nonblock = 0;
+	ssize_t total_sent = 0;
+	int error_code = 0;
+	ssize_t ret;
+
+	if (!ctx || !ctx->session)
+		return EINVAL;
+
+	if (nonblock)
+		fcntl(fd, F_SETFL, orig_flags | O_NONBLOCK);
+
+	LogDebugTLS(TLS_DISPATCH, "Send requested len > %" PRId32 ,
+		    msg->msg_iovlen);
+	for (int i = 0; i < msg->msg_iovlen; ++i) {
+		const char *buf = msg->msg_iov[i].iov_base;
+		ssize_t len = msg->msg_iov[i].iov_len;
+		ssize_t offset = 0;
+
+retry:
+		while (offset < len) {
+			ret = gnutls_record_send(ctx->session, buf + offset,
+						     len - offset);
+			if (ret <= 0) {
+				LogDebugTLS(TLS_DISPATCH,
+					    "Write ret:%" PRId32 " error:%s %"
+					    PRId32 , ret,
+					    get_gnutls_error(ret), errno);
+				switch (ret) {
+				case GNUTLS_E_AGAIN:
+				case GNUTLS_E_INTERRUPTED:
+					goto retry;
+				case GNUTLS_E_PREMATURE_TERMINATION:
+					error_code =
+						TLS_SESSION_CLOSED_ADRUPTLY;
+					break;
+				default:
+					error_code = TLS_SESSION_UNKNOWN_ERROR;
+					break;
+				}
+				return error_code;
+			}
+			offset += ret;
+			total_sent += ret;
+		}
+	}
+
+	/* Restore original Flags */
+	if (nonblock)
+		fcntl(fd, F_SETFL, orig_flags);
+
+	LogDebugTLS(TLS_DISPATCH, "Send Completed len: %" PRId64 , total_sent);
+	return total_sent;
+}
+
+/**
+ * Close TLS connection and free resources
+ *
+ * @param ctx          TLS context
+ * @return             true on success, false on failure
+ */
+bool tls_close(tls_ctx_t *ctx)
+{
+	LogDebugTLS(TLS_SHUTDOWN, "ctx:%p", ctx);
+
+	if (!ctx) {
+		return true;
+	}
+
+	if (ctx->session) {
+		/* Properly close the TLS session */
+		gnutls_bye(ctx->session, GNUTLS_SHUT_RDWR);
+		gnutls_deinit(ctx->session);
+	}
+
+	LogDebugTLS(TLS_SHUTDOWN, "freeing ctx");
+	mem_free(ctx, sizeof(tls_ctx_t));
+	return true;
+}
+
+/**
+ * Verify peer certificate and extract identity
+ *
+ * @param ctx           TLS context
+ * @param peer_identity Buffer to store peer identity (CN from certificate)
+ * @param id_size       Size of the peer_identity buffer
+ * @return              true if verification succeeded, false otherwise
+ */
+bool tls_verify_peer(tls_ctx_t *ctx, char *peer_identity,
+			 size_t id_size)
+{
+	unsigned int status;
+	int ret;
+	const gnutls_datum_t *cert_list;
+	unsigned int cert_list_size;
+	/* To extract Common Name from certificate */
+	gnutls_x509_crt_t cert;
+
+	LogDebugTLS(TLS_HANDSHAKE, "%s:%" PRId32 , __func__, __LINE__);
+
+	if (!ctx || !ctx->session) {
+		LogCritTLS(TLS_HANDSHAKE, "Invalid TLS context");
+		return false;
+	}
+
+	/* Check if client provided a certificate */
+	cert_list = gnutls_certificate_get_peers(ctx->session, &cert_list_size);
+
+	if (cert_list == NULL || cert_list_size == 0) {
+		LogDebugTLS(TLS_HANDSHAKE,
+			    "Client did not provide a certificate");
+		if (peer_identity && id_size > 0)
+			strlcpy(peer_identity, "anonymous", id_size);
+		return true; /* Allow connections without client cert */
+	}
+
+	/* Verify certificate */
+	ret = gnutls_certificate_verify_peers2(ctx->session, &status);
+	if (ret < 0) {
+		LogWarnTLS(TLS_HANDSHAKE, "Certificate verification failed: %s",
+			   get_gnutls_error(ret));
+		return false;
+	}
+
+	if (status != 0) {
+		gnutls_datum_t out;
+
+		ret = gnutls_certificate_verification_status_print(
+			status, GNUTLS_CRT_X509, &out, 0);
+		if (ret == 0) {
+			LogWarnTLS(TLS_HANDSHAKE,
+				   "Client certificate verification failed: %s",
+				   out.data);
+			gnutls_free(out.data);
+		} else {
+			LogWarnTLS(TLS_HANDSHAKE,
+				"Client certificate verification failed with status: %" PRIu32 ,
+				status);
+		}
+		return false;
+	}
+
+	ret = gnutls_x509_crt_init(&cert);
+	if (ret < 0) {
+		LogWarnTLS(TLS_HANDSHAKE,
+			   "Failed to initialize certificate structure: %s",
+			   get_gnutls_error(ret));
+		return false;
+	}
+
+	ret = gnutls_x509_crt_import(cert, &cert_list[0], GNUTLS_X509_FMT_DER);
+	if (ret < 0) {
+		LogWarnTLS(TLS_HANDSHAKE, "Failed to import certificate: %s",
+			   get_gnutls_error(ret));
+		gnutls_x509_crt_deinit(cert);
+		return false;
+	}
+
+	/* Get the common name */
+	char buf[256];
+	size_t buf_size = sizeof(buf);
+
+	ret = gnutls_x509_crt_get_dn_by_oid(cert, GNUTLS_OID_X520_COMMON_NAME,
+					    0, 0, buf, &buf_size);
+	if (ret < 0) {
+		LogWarnTLS(TLS_HANDSHAKE,
+			   "Could not get CN from client certificate: %s",
+			   get_gnutls_error(ret));
+		gnutls_x509_crt_deinit(cert);
+		return false;
+	}
+
+	/* Copy the common name to the output buffer if provided */
+	if (peer_identity && id_size > 0) {
+		strlcpy(peer_identity, buf, id_size);
+	}
+
+	LogDebugTLS(TLS_HANDSHAKE,
+		    "Client authenticated with certificate CN: %s", buf);
+	gnutls_x509_crt_deinit(cert);
+	return true;
+}
+
+/**
+ * Request a TLS 1.3 key update from the client.
+ * call this periodically (e.g. every 3 minutes)
+ * But currently its not supported.
+ * In future based on requirement will extend this.
+ * Note : Shutdown the connection if keyupdate is not supported,
+ * which will cause new key exchange
+ *
+ * @param ssl The active SSL connection.
+ * @return 0 on success, -1 on failure.
+ */
+bool tls_key_update(tls_ctx_t *ctx)
+{
+	int ret;
+
+	if (!ctx || !ctx->session) {
+		LogWarnTLS(TLS_HANDSHAKE, "Invalid ctx\n");
+		return false;
+	}
+
+	/* Check if we're using TLS 1.3, which supports key updates */
+	gnutls_protocol_t version = gnutls_protocol_get_version(ctx->session);
+
+	if (version != GNUTLS_TLS1_3) {
+		LogWarnTLS(TLS_HANDSHAKE,
+			   "Key update is only supported in TLS 1.3\n");
+		return false;
+	}
+
+	/* Request key update */
+	ret = gnutls_session_key_update(ctx->session, GNUTLS_KU_PEER);
+	if (ret < 0) {
+		LogWarnTLS(TLS_INIT, "gnutls_session_key_update failed: %s\n",
+			   get_gnutls_error(ret));
+		return false;
+	}
+
+	LogWarnTLS(TLS_HANDSHAKE, "Key update requested and completed.\n");
+	return true;
+}
+
+/*Debug callback registered with lib to get detailed o/p of whats happening */
+static void tls_enhanced_debug_callback(int level, const char *str)
+{
+	const char *prefix = "";
+	static int handshake_in_progress;
+	static int session_resumed;
+
+	/* Remove trailing newlines and whitespace */
+	char *clean_str = mem_strdup(str);
+
+	if (clean_str) {
+		size_t len = strlen(clean_str);
+
+		while (len > 0 && (clean_str[len - 1] == '\n' ||
+				   clean_str[len - 1] == '\r' ||
+				   clean_str[len - 1] == ' ' ||
+				   clean_str[len - 1] == '\t')) {
+			clean_str[--len] = '\0';
+		}
+	} else {
+		return;
+	}
+
+	/* Skip empty messages */
+	if (strlen(clean_str) == 0) {
+		mem_free(clean_str, 0);
+		return;
+	}
+
+	/* Detailed message parsing for different TLS states and operations */
+
+	/* Handshake related messages */
+	if (strstr(clean_str, "handshake") || strstr(clean_str, "Handshake")) {
+		if (strstr(clean_str, "start") ||
+		    strstr(clean_str, "starting") ||
+		    strstr(clean_str, "begin") ||
+		    strstr(clean_str, "initiated")) {
+			prefix = "[HANDSHAKE START]";
+			handshake_in_progress = 1;
+			session_resumed = 0;
+		} else if (strstr(clean_str, "finished") ||
+			   strstr(clean_str, "completed") ||
+			   strstr(clean_str, "successful") ||
+			   strstr(clean_str, "done")) {
+			if (session_resumed) {
+				prefix = "[HANDSHAKE RESUMED DONE]";
+			} else {
+				prefix = "[HANDSHAKE DONE]";
+			}
+			handshake_in_progress = 0;
+		} else if (strstr(clean_str, "resumed") ||
+			   strstr(clean_str, "resuming")) {
+			prefix = "[HANDSHAKE RESUMED]";
+			session_resumed = 1;
+		} else if (handshake_in_progress) {
+			prefix = "[HANDSHAKE LOOP]";
+		} else {
+			prefix = "[HANDSHAKE]";
+		}
+	}
+	/* Alert messages */
+	else if (strstr(clean_str, "alert") || strstr(clean_str, "Alert")) {
+		const char *dir = "unknown";
+		const char *level_str = "unknown";
+		const char *desc = "unknown";
+
+		if (strstr(clean_str, "received") ||
+		    strstr(clean_str, "recv")) {
+			dir = "read";
+		} else if (strstr(clean_str, "sent") ||
+			   strstr(clean_str, "send")) {
+			dir = "write";
+		}
+
+		if (strstr(clean_str, "warning")) {
+			level_str = "warning";
+		} else if (strstr(clean_str, "fatal")) {
+			level_str = "fatal";
+		}
+
+		/* Extract alert description if possible */
+		if (strstr(clean_str, "close_notify"))
+			desc = "close_notify";
+		else if (strstr(clean_str, "unexpected_message"))
+			desc = "unexpected_message";
+		else if (strstr(clean_str, "bad_record_mac"))
+			desc = "bad_record_mac";
+		else if (strstr(clean_str, "decryption_failed"))
+			desc = "decryption_failed";
+		else if (strstr(clean_str, "record_overflow"))
+			desc = "record_overflow";
+		else if (strstr(clean_str, "decompression_failure"))
+			desc = "decompression_failure";
+		else if (strstr(clean_str, "handshake_failure"))
+			desc = "handshake_failure";
+		else if (strstr(clean_str, "no_certificate"))
+			desc = "no_certificate";
+		else if (strstr(clean_str, "bad_certificate"))
+			desc = "bad_certificate";
+		else if (strstr(clean_str, "unsupported_certificate"))
+			desc = "unsupported_certificate";
+		else if (strstr(clean_str, "certificate_revoked"))
+			desc = "certificate_revoked";
+		else if (strstr(clean_str, "certificate_expired"))
+			desc = "certificate_expired";
+		else if (strstr(clean_str, "certificate_unknown"))
+			desc = "certificate_unknown";
+		else if (strstr(clean_str, "illegal_parameter"))
+			desc = "illegal_parameter";
+		else if (strstr(clean_str, "unknown_ca"))
+			desc = "unknown_ca";
+		else if (strstr(clean_str, "access_denied"))
+			desc = "access_denied";
+		else if (strstr(clean_str, "decode_error"))
+			desc = "decode_error";
+		else if (strstr(clean_str, "decrypt_error"))
+			desc = "decrypt_error";
+		else if (strstr(clean_str, "protocol_version"))
+			desc = "protocol_version";
+		else if (strstr(clean_str, "insufficient_security"))
+			desc = "insufficient_security";
+		else if (strstr(clean_str, "internal_error"))
+			desc = "internal_error";
+		else if (strstr(clean_str, "user_canceled"))
+			desc = "user_canceled";
+		else if (strstr(clean_str, "no_renegotiation"))
+			desc = "no_renegotiation";
+
+		LogWarnTLS(TLS_INIT, "[ALERT] %s: level=%s, desc=%s (%s)", dir,
+			   level_str, desc, clean_str);
+		mem_free(clean_str, 0);
+		return;
+	}
+	/* Read operations */
+	else if (strstr(clean_str, "read") || strstr(clean_str, "recv") ||
+		 strstr(clean_str, "Read") || strstr(clean_str, "reading") ||
+		 strstr(clean_str, "REC[") || strstr(clean_str, "received")) {
+		prefix = "[READ]";
+	}
+	/* Write operations */
+	else if (strstr(clean_str, "write") || strstr(clean_str, "send") ||
+		 strstr(clean_str, "Write") || strstr(clean_str, "writing") ||
+		 strstr(clean_str, "sending")) {
+		prefix = "[WRITE]";
+	}
+	/* Certificate related */
+	else if (strstr(clean_str, "certificate") ||
+		 strstr(clean_str, "Certificate") ||
+		 strstr(clean_str, "cert") || strstr(clean_str, "X.509")) {
+		prefix = "[CERTIFICATE]";
+	}
+	/* Key exchange */
+	else if (strstr(clean_str, "key") || strstr(clean_str, "Key") ||
+		 strstr(clean_str, "ECDHE") || strstr(clean_str, "RSA") ||
+		 strstr(clean_str, "DH") || strstr(clean_str, "exchange")) {
+		prefix = "[KEY EXCHANGE]";
+	}
+	/* Cipher related */
+	else if (strstr(clean_str, "cipher") || strstr(clean_str, "Cipher") ||
+		 strstr(clean_str, "AES") || strstr(clean_str, "GCM") ||
+		 strstr(clean_str, "encryption") ||
+		 strstr(clean_str, "decrypt")) {
+		prefix = "[CIPHER]";
+	}
+	/* Session related */
+	else if (strstr(clean_str, "session") || strstr(clean_str, "Session") ||
+		 strstr(clean_str, "ticket") || strstr(clean_str, "cache")) {
+		prefix = "[SESSION]";
+	}
+	/* Version negotiation */
+	else if (strstr(clean_str, "version") || strstr(clean_str, "Version") ||
+		 strstr(clean_str, "TLS") || strstr(clean_str, "protocol")) {
+		prefix = "[VERSION]";
+	}
+	/* Extensions */
+	else if (strstr(clean_str, "extension") ||
+		 strstr(clean_str, "Extension") || strstr(clean_str, "SNI") ||
+		 strstr(clean_str, "ALPN") ||
+		 strstr(clean_str, "server_name")) {
+		prefix = "[EXTENSION]";
+	}
+	/* KTLS related */
+	else if (strstr(clean_str, "ktls") || strstr(clean_str, "KTLS") ||
+		 strstr(clean_str, "kernel") || strstr(clean_str, "offload")) {
+		prefix = "[KTLS]";
+	}
+	/* Error conditions */
+	else if (strstr(clean_str, "error") || strstr(clean_str, "Error") ||
+		 strstr(clean_str, "fail") || strstr(clean_str, "Fail") ||
+		 strstr(clean_str, "invalid") || strstr(clean_str, "Invalid")) {
+		if (strstr(clean_str, "fatal") || strstr(clean_str, "Fatal")) {
+			prefix = "[EXIT] failed";
+		} else {
+			prefix = "[EXIT] error";
+		}
+	}
+	/* Success conditions */
+	else if (strstr(clean_str, "success") || strstr(clean_str, "Success") ||
+		 strstr(clean_str, "ok") || strstr(clean_str, "OK") ||
+		 strstr(clean_str, "complete") ||
+		 strstr(clean_str, "established")) {
+		prefix = "[EXIT] ok";
+	}
+	/* Loop/state machine */
+	else if (strstr(clean_str, "loop") || strstr(clean_str, "Loop") ||
+		 strstr(clean_str, "state") || strstr(clean_str, "State") ||
+		 strstr(clean_str, "step") || strstr(clean_str, "phase")) {
+		prefix = "[LOOP]";
+	}
+	/* Record layer */
+	else if (strstr(clean_str, "record") || strstr(clean_str, "Record") ||
+		 strstr(clean_str, "packet") || strstr(clean_str, "frame")) {
+		prefix = "[RECORD]";
+	}
+	/* Buffer operations */
+	else if (strstr(clean_str, "buffer") || strstr(clean_str, "Buffer") ||
+		 strstr(clean_str, "data") || strstr(clean_str, "bytes")) {
+		prefix = "[BUFFER]";
+	}
+	/* Default based on log level */
+	else {
+		switch (level) {
+		case 0:
+			prefix = "[FATAL]";
+			break;
+		case 1:
+			prefix = "[ERROR]";
+			break;
+		case 2:
+			prefix = "[WARNING]";
+			break;
+		case 3:
+			prefix = "[INFO]";
+			break;
+		case 4:
+			prefix = "[DEBUG]";
+			break;
+		case 5:
+			prefix = "[TRACE]";
+			break;
+		case 6:
+			prefix = "[DETAILED]";
+			break;
+		case 7:
+			prefix = "[VERBOSE]";
+			break;
+		case 8:
+			prefix = "[CRYPTO]";
+			break;
+		case 9:
+			prefix = "[ULTRA]";
+			break;
+		default:
+			prefix = "[UNKNOWN]";
+			break;
+		}
+	}
+
+	/* Log the message with appropriate prefix */
+	LogWarnTLS(TLS_UNKNOWN, "%s : %s", prefix, clean_str);
+
+	mem_free(clean_str, 0);
+}
+
+#endif /*  USE_GNUTLS */

--- a/src/tls_init.c
+++ b/src/tls_init.c
@@ -1,0 +1,45 @@
+#include "tls.h"
+#include "tls_transport.h"
+
+
+#ifdef USE_TLS
+tls_config_t tls_config;
+
+/* Initialize ntirpc TLS from configuration by keeping the local copy*/
+bool tls_init(tls_config_t *from_config)
+{
+	memcpy(&tls_config, from_config, sizeof(tls_config_t));
+	if (!tls_config.enabled) {
+		LogDebugTLS(TLS_INIT, "TLS is disabled in configuration");
+		return true;
+	}
+
+	LogDebugTLS(TLS_INIT, "Initializing TLS with cert=%s, key=%s, ca=%s",
+		    tls_config.cert_file, tls_config.key_file,
+		    tls_config.ca_file ? tls_config.ca_file : "none");
+
+	/* Initialize TLS library */
+	if (!xprt_tls_init(tls_config.cert_file, tls_config.key_file,
+			   tls_config.ca_file, tls_config.ciphers,
+			   tls_config.min_version, tls_config.ktls,
+			   tls_config.debug)) {
+		LogCritTLS(TLS_INIT, "Failed to initialize TLS");
+		return false;
+	}
+
+	LogDebugTLS(TLS_INIT, "TLS initialized successfully");
+	return true;
+}
+
+/* Cleanup ntiprc TLS config*/
+void tls_cleanup(void)
+{
+	tls_config.cert_file = NULL;
+	tls_config.key_file = NULL;
+	tls_config.ca_file = NULL;
+	tls_config.ciphers = NULL;
+	tls_config.min_version = NULL;
+	LogDebugTLS(TLS_INIT, "TLS resources cleaned up");
+}
+
+#endif /*  USE_TLS */

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -1,0 +1,1070 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+/*
+ * vim:noexpandtab:shiftwidth=8:tabstop=8:
+ *
+ * Copyright (C) 2025, IBM . All rights reserved.
+ * Author: Deeraj Patil <deeraj.patil@ibm.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.  see <http://www.gnu.org/licenses/
+ *
+ * ---------------------------------------
+ */
+
+/**
+ * @file tls_openssl.c
+ * @brief Routines used for managing the TLS Session using openSSL lib.
+ * Implementation patterns have been derived from openSSL library
+ * especially from server.c patterns
+ *
+ * Routines used for supporting TLS in ntirpc.
+ *
+ */
+
+#include "tls.h"
+
+#ifdef USE_OPENSSL
+
+/* Global SSL context */
+static int ssl_ctx_index = -1;
+static void tls_info_callback(const SSL *ssl, int where, int ret);
+
+/* Helper function to get OpenSSL error string */
+static char *get_ssl_error(void)
+{
+	static char ssl_error[256];
+	unsigned long e = ERR_get_error();
+
+	if (e == 0)
+		return "No SSL error";
+
+	ERR_error_string_n(e, ssl_error, sizeof(ssl_error));
+	return ssl_error;
+}
+unsigned char sid_ctx[] = "ntirpc-tls-session";
+
+/**
+ * Initialize the TLS subsystem
+ *
+ * @param cert_file    Path to the server certificate file (PEM format)
+ * @param key_file     Path to the server private key file (PEM format)
+ * @param ca_file      Path to the CA certificate file (PEM format) for
+ *			client verification
+ * @param ciphers      Cipher suite string (GnuTLS priority string)
+ * @param min_version  Minimum TLS version ("TLSv1.2" or "TLSv1.3")
+ * @param ktls         To enable or disable ktls
+ * @param debug        To enable or disable debugging including registering
+ *			lib callbacks
+ * @return             Creds which should be used for per session connection
+ *			creation, if fails returns NULL.
+ */
+tls_cred_t *tls_cred_init(const char *cert_file, const char *key_file,
+			     const char *ca_file, const char *ciphers,
+			     const char *min_version, bool ktls, bool debug)
+{
+	SSL_CTX *global_ctx = NULL;
+
+	LogDebugTLS(TLS_INIT, "%s:%" PRId32 , __func__, __LINE__);
+	/* Initialize OpenSSL */
+	SSL_library_init();
+	SSL_load_error_strings();
+	OpenSSL_add_all_algorithms();
+	/* Supports both client/server */
+	const SSL_METHOD *method = TLS_method();
+
+	/* Create SSL context */
+	global_ctx = SSL_CTX_new(method);
+	if (!global_ctx) {
+		LogCritTLS(TLS_INIT, "Failed to create SSL context: %s",
+			   get_ssl_error());
+		return NULL;
+	}
+
+	if (debug)
+		SSL_CTX_set_info_callback(global_ctx, tls_info_callback);
+
+	/* Enable KTLS enable */
+	/* KTLS is only supported by OpenSSL 3.0+ */
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	if (ktls)
+		SSL_CTX_set_options(global_ctx, SSL_OP_ENABLE_KTLS);
+#else
+	if (ktls)
+		LogWarnTLS(TLS_INIT,
+			   "KTLS not supported by OpenSSL version (< 3.0)");
+#endif
+
+	SSL_CTX_set_session_id_context(global_ctx, sid_ctx, sizeof(sid_ctx));
+
+	/* Set minimum TLS version */
+	if (min_version) {
+		int version = 0;
+
+		if (strcmp(min_version, "TLSv1.2") == 0)
+			version = TLS1_2_VERSION;
+		else if (strcmp(min_version, "TLSv1.3") == 0)
+			version = TLS1_3_VERSION;
+
+		if (version > 0) {
+			SSL_CTX_set_min_proto_version(global_ctx, version);
+		}
+	}
+	SSL_CTX_set_max_early_data(global_ctx, 0);
+
+	/* Set cipher list if provided */
+	if (ciphers && SSL_CTX_set_cipher_list(global_ctx, ciphers) != 1) {
+		LogCritTLS(TLS_INIT, "Failed to set cipher list: %s",
+			   get_ssl_error());
+		goto cleanup_global;
+	}
+
+	/* Load server certificate */
+	if (SSL_CTX_use_certificate_file(global_ctx, cert_file,
+				SSL_FILETYPE_PEM) != 1) {
+		LogCritTLS(TLS_INIT, "Failed to load certificate file %s: %s",
+				cert_file, get_ssl_error());
+		goto cleanup_global;
+	}
+
+	/*
+	 * Load certificate chain from cert_file.
+	 * SSL_CTX_use_certificate_chain_file() handles both cases:
+	 *   - Single certificate PEM: loads just the leaf cert.
+	 *   - Certificate chain PEM:  loads the leaf cert and all
+	 *     intermediate CA certificates in the file, so the full
+	 *     chain is sent to the peer during the TLS handshake.
+	 */
+	if (SSL_CTX_use_certificate_chain_file(global_ctx, cert_file) != 1) {
+		LogCritTLS(TLS_INIT,
+			   "Failed to load certificate/chain file '%s': %s",
+			   cert_file, get_ssl_error());
+		goto cleanup_global;
+	}
+
+	/* Load private key */
+	if (SSL_CTX_use_PrivateKey_file(global_ctx, key_file,
+					SSL_FILETYPE_PEM) != 1) {
+		LogCritTLS(TLS_INIT, "Failed to load private key file %s: %s",
+			   key_file, get_ssl_error());
+		goto cleanup_global;
+	}
+
+	/* Check key and certificate */
+	if (SSL_CTX_check_private_key(global_ctx) != 1) {
+		LogCritTLS(TLS_INIT,
+			   "Private key does not match certificate: %s",
+			   get_ssl_error());
+		goto cleanup_global;
+	}
+
+	/*  Load CA certificates for client verification */
+	if (ca_file) {
+		if (SSL_CTX_load_verify_locations(global_ctx, ca_file,
+						  NULL) != 1) {
+			LogCritTLS(TLS_INIT, "Failed to load CA file %s: %s",
+				   ca_file, get_ssl_error());
+			goto cleanup_global;
+		}
+
+		/*
+		 * Request client cert; accept connection regardless of
+		 * whether the client provides one.  tls_get_type() decides
+		 * post-handshake.
+		 */
+		SSL_CTX_set_verify(global_ctx, SSL_VERIFY_PEER, NULL);
+	} else {
+		/* try to use default system CA certificates */
+		if (SSL_CTX_set_default_verify_paths(global_ctx) != 1) {
+			LogWarnTLS(TLS_INIT,
+				   "Failed to set default verify paths: %s",
+				   get_ssl_error());
+			goto cleanup_global;
+		}
+	}
+
+	/* Set up an ex_data index for associating
+	 * tls_ctx_t with SSL objects */
+	ssl_ctx_index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+	if (ssl_ctx_index == -1) {
+		LogCritTLS(TLS_INIT, "Failed to get SSL ex_data index");
+		goto cleanup_global;
+	}
+	if (!SSL_CTX_set_num_tickets(global_ctx, 0)) {
+		LogCritTLS(TLS_INIT, "Failed to set num tickets on SSL");
+		goto cleanup_global;
+	}
+
+	LogDebugTLS(TLS_INIT, "TLS initialized successfully with OpenSSL");
+	return global_ctx;
+
+cleanup_global:
+	SSL_CTX_free(global_ctx);
+	global_ctx = NULL;
+	return NULL;
+
+}
+
+/**
+ * Create a new TLS context for a socket
+ *
+ * @param fd           Socket file descriptor
+ * @param cred         creds which got returned from tls_cred_init()
+ * @param is_server    Connection type i.e fd is acting as server or a client.
+ * @return             Pointer to the new TLS context, or NULL on failure
+ */
+tls_ctx_t *tls_ctx_init(int fd, tls_cred_t *cred, bool is_server)
+{
+	tls_ctx_t *ctx = mem_calloc(1, sizeof(tls_ctx_t));
+
+	if (!ctx)
+		return NULL;
+
+	pthread_mutex_init(&(ctx->ctx_lock), NULL);
+	ctx->fd = fd;
+	ctx->ctx = cred;
+
+	ctx->ssl = SSL_new(ctx->ctx);
+	if (!ctx->ssl) {
+		LogCritTLS(TLS_INIT, "Failed to create SSL: %s",
+			   get_ssl_error());
+		mem_free(ctx, sizeof(tls_ctx_t));
+		return NULL;
+	}
+
+	if (!SSL_set_fd(ctx->ssl, fd)) {
+		LogCritTLS(TLS_INIT, "Failed to set SSL fd: %s",
+			   get_ssl_error());
+		SSL_free(ctx->ssl);
+		mem_free(ctx, sizeof(tls_ctx_t));
+		return NULL;
+	}
+	if (!SSL_set_ex_data(ctx->ssl, ssl_ctx_index, ctx)) {
+		LogCritTLS(TLS_INIT, "Failed to set ex_data on SSL");
+		SSL_free(ctx->ssl);
+		mem_free(ctx, sizeof(tls_ctx_t));
+		return NULL;
+	}
+
+	/* Optionally set server/client specific behavior before handshake */
+	if (is_server) {
+		LogDebugTLS(TLS_INIT, "FD:%" PRId32 " SERVER_METHOD", fd);
+		SSL_set_accept_state(ctx->ssl);
+	} else {
+		LogDebugTLS(TLS_INIT, "FD:%" PRId32 " CLIENT_METHOD", fd);
+		SSL_set_connect_state(ctx->ssl);
+	}
+	LogDebugTLS(TLS_SHUTDOWN, "ctx_init:%x", ctx);
+
+	return ctx;
+}
+
+/**
+ * Perform TLS handshake
+ *
+ * @param ctx          TLS context
+ * @return             true on success, false on failure
+ */
+bool tls_handshake(tls_ctx_t *ctx)
+{
+	int ret;
+	int ssl_err;
+	int counter = 0;
+
+	LogDebugTLS(TLS_HANDSHAKE, "%s:%" PRId32 , __func__, __LINE__);
+	if (!ctx || !ctx->ssl) {
+		LogCritTLS(TLS_INIT, "Invalid TLS context");
+		return false;
+	}
+	pthread_mutex_lock(&(ctx->ctx_lock));
+
+	if (ctx->handshake_complete) {
+		pthread_mutex_unlock(&(ctx->ctx_lock));
+		return true;
+	}
+	/* Clear any previous errors */
+	ERR_clear_error();
+
+retry:
+	ret = SSL_accept(ctx->ssl);
+	if (ret == 1) {
+		ctx->handshake_complete = true;
+		LogDebugTLS(TLS_HANDSHAKE,
+			    "TLS handshake completed successfully");
+		const char *servername =
+			SSL_get_servername(ctx->ssl, TLSEXT_NAMETYPE_host_name);
+		if (servername) {
+			LogDebugTLS(TLS_HANDSHAKE, "SNI hostname: %s",
+					servername);
+		} else {
+			LogDebugTLS(TLS_HANDSHAKE, "No SNI hostname received");
+		}
+		pthread_mutex_unlock(&(ctx->ctx_lock));
+		return true;
+	}
+	++counter;
+	ssl_err = SSL_get_error(ctx->ssl, ret);
+	if (ssl_err == SSL_ERROR_WANT_READ || ssl_err == SSL_ERROR_WANT_WRITE) {
+		/* Handshake needs more data, not an error */
+		LogDebugTLS(TLS_HANDSHAKE, "Need more data:%s : %" PRId32 ,
+			    get_ssl_error(), ssl_err);
+	}
+	if (counter < 1) {
+		LogDebugTLS(TLS_HANDSHAKE, "retry %s : %" PRId32 ,
+			    get_ssl_error(), ssl_err);
+		goto retry;
+	}
+
+	LogCritTLS(TLS_HANDSHAKE, "TLS handshake failed: %s", get_ssl_error());
+	pthread_mutex_unlock(&(ctx->ctx_lock));
+	return false;
+}
+
+/**
+ * Check secure connection is TLS or MTLS
+ *
+ * @param ctx          TLS context
+ * @return             true on MTLS, false on TLS
+ */
+bool tls_get_type(tls_ctx_t *ctx)
+{
+	bool ret = false;
+
+	if (!ctx->ssl)
+		return ret;
+	X509 *cert = SSL_get_peer_certificate(ctx->ssl);
+
+	if (cert) {
+		long verify_result = SSL_get_verify_result(ctx->ssl);
+
+		X509_free(cert);
+		if (verify_result == X509_V_OK) {
+			ret = true;
+		} else {
+			ret = false;
+		}
+	}
+	LogDebugTLS(TLS_HANDSHAKE, "MTLS CERIFICATE %" PRId32 , ret);
+	return ret;
+}
+
+/**
+ * Verify peer certificate and extract identity
+ *
+ * @param ctx           TLS context
+ * @param peer_identity Buffer to store peer identity (CN from certificate)
+ * @param id_size       Size of the peer_identity buffer
+ * @return              true if verification succeeded, false otherwise
+ */
+bool tls_verify_peer(tls_ctx_t *ctx, char *peer_identity,
+			 size_t id_size)
+{
+	X509 *cert;
+	X509_NAME *subject;
+	char buf[256];
+
+	LogDebugTLS(TLS_HANDSHAKE, "%s:%" PRId32 , __func__, __LINE__);
+
+	if (!ctx || !ctx->ssl) {
+		LogCritTLS(TLS_HANDSHAKE, "Invalid TLS context");
+		return false;
+	}
+
+	/* Get client certificate */
+	cert = SSL_get_peer_certificate(ctx->ssl);
+	if (!cert) {
+		LogDebugTLS(TLS_HANDSHAKE,
+			    "Client did not provide a certificate");
+		if (peer_identity && id_size > 0)
+			strlcpy(peer_identity, "anonymous", id_size);
+		return true; /* Allow connections without client cert */
+	}
+
+	/* Verify certificate */
+	long verify_result = SSL_get_verify_result(ctx->ssl);
+
+	if (verify_result != X509_V_OK) {
+		LogWarnTLS(TLS_HANDSHAKE,
+			   "Client certificate verification failed: %s",
+			   X509_verify_cert_error_string(verify_result));
+		X509_free(cert);
+		return false;
+	}
+
+	/* Extract Common Name from certificate */
+	subject = X509_get_subject_name(cert);
+	if (!subject) {
+		LogWarnTLS(TLS_HANDSHAKE,
+			   "Could not get subject from client certificate");
+		X509_free(cert);
+		return false;
+	}
+
+	/* Get the common name */
+	int cn_len = X509_NAME_get_text_by_NID(subject, NID_commonName, buf,
+					       sizeof(buf));
+	if (cn_len < 0) {
+		LogWarnTLS(TLS_HANDSHAKE,
+			   "Could not get CN from client certificate");
+		X509_free(cert);
+		return false;
+	}
+
+	/* Copy the common name to the output buffer if provided */
+	if (peer_identity && id_size > 0) {
+		strlcpy(peer_identity, buf, id_size);
+	}
+
+	LogDebugTLS(TLS_HANDSHAKE,
+		    "Client authenticated with certificate CN: %s", buf);
+	X509_free(cert);
+	return true;
+}
+
+/**
+ * Receive data over TLS
+ *
+ * @param ctx          TLS context
+ * @param buf          Buffer to store received data
+ * @param len          Length of the buffer
+ * @return             Number of bytes received, or converted error
+ */
+ssize_t tls_recv(tls_ctx_t *ctx, void *buf, size_t len, int flags)
+{
+	int ret=0;
+	int error_code = 0;
+	int orig_flags = 0;
+	int fd = 0;
+	//bool nonblock = flags & MSG_DONTWAIT;
+	bool nonblock = 0;
+	ssize_t offset = 0;
+
+	if (!ctx || !ctx->ssl)
+		return EINVAL;
+	fd = ctx->fd;
+	orig_flags = fcntl(fd, F_GETFL, 0);
+
+	if (nonblock)
+		fcntl(fd, F_SETFL, orig_flags | O_NONBLOCK);
+
+	LogDebugTLS(TLS_DISPATCH, "Recv requested len > %" PRId32 , len);
+
+	while (offset < len) {
+retry:
+		ret = SSL_read(ctx->ssl, buf + offset, len - offset);
+		if (ret <= 0) {
+			int ssl_err = SSL_get_error(ctx->ssl, ret);
+
+			LogDebugTLS(TLS_DISPATCH, "Read ret:%" PRId32
+				   " error:%" PRId32 " %" PRId32 ,
+				    ret, ssl_err, errno);
+			switch (ssl_err) {
+			case SSL_ERROR_WANT_READ:
+			case SSL_ERROR_WANT_WRITE:
+				goto retry;
+			case SSL_ERROR_NONE:
+			case SSL_ERROR_SYSCALL:
+				error_code = TLS_SESSION_CLOSED_ADRUPTLY;
+				break;
+			default:
+				error_code = TLS_SESSION_UNKNOWN_ERROR;
+				break;
+			}
+			return error_code;
+		}
+		offset += ret;
+	}
+	/* Restore original flags */
+	if (nonblock)
+		fcntl(fd, F_SETFL, orig_flags);
+
+	LogDebugTLS(TLS_DISPATCH, "Recv Completed len: %" PRId64 , offset);
+	return offset;
+}
+
+/**
+ * Function provides details of the pending data in library internal bufferes
+ * only for recv
+ *
+ * @param ctx          TLS context
+ * @return             Number of bytes cached in internal buffers
+ */
+int tls_datapending(tls_ctx_t *ctx)
+{
+	return SSL_pending(ctx->ssl);
+}
+
+/**
+ * Send data over TLS
+ *
+ * @param ctx          TLS context
+ * @param msg          Message to send
+ * @param flags        Send flags
+ * @return             Number of bytes sent, or converted error
+ */
+ssize_t tls_send(tls_ctx_t *ctx, const struct msghdr *msg, int flags)
+{
+	int fd ;
+	int orig_flags;
+	//bool nonblock = flags & MSG_DONTWAIT;
+	bool nonblock = 0;
+	ssize_t total_sent = 0;
+	int error_code = 0;
+
+	if (!ctx || !ctx->ssl)
+		return EINVAL;
+
+	fd = ctx->fd;
+	orig_flags = fcntl(fd, F_GETFL, 0);
+
+	if (nonblock)
+		fcntl(fd, F_SETFL, orig_flags | O_NONBLOCK);
+
+	LogDebugTLS(TLS_DISPATCH, "Send requested len > %" PRId32 ,
+		    msg->msg_iovlen);
+	for (int i = 0; i < msg->msg_iovlen; ++i) {
+		const char *buf = msg->msg_iov[i].iov_base;
+		ssize_t len = msg->msg_iov[i].iov_len;
+		ssize_t offset = 0;
+retry:
+		while (offset < len) {
+			int ret =
+				SSL_write(ctx->ssl, buf + offset, len - offset);
+			if (ret <= 0) {
+				int ssl_err = SSL_get_error(ctx->ssl, ret);
+
+				LogDebugTLS(TLS_DISPATCH,
+					    "Write ret:%" PRId32 " error:%"
+					    PRId32 " %" PRId32 , ret,
+					    ssl_err, errno);
+				switch (ssl_err) {
+				case SSL_ERROR_WANT_READ:
+				case SSL_ERROR_WANT_WRITE:
+					goto retry;
+				case SSL_ERROR_NONE:
+				case SSL_ERROR_SYSCALL:
+					error_code =
+						TLS_SESSION_CLOSED_ADRUPTLY;
+					break;
+				default:
+					error_code = TLS_SESSION_UNKNOWN_ERROR;
+					break;
+				}
+				return error_code;
+			}
+			offset += ret;
+			total_sent += ret;
+		}
+	}
+
+	if (nonblock)
+		fcntl(fd, F_SETFL, orig_flags); // Restore original flags
+
+	LogDebugTLS(TLS_DISPATCH, "Send Completed len: %" PRId64 , total_sent);
+	return total_sent;
+}
+
+/**
+ * Close TLS connection and free resources
+ *
+ * @param ctx          TLS context
+ * @return             true on success, false on failure
+ */
+bool tls_close(tls_ctx_t *ctx)
+{
+	int ret = 0;
+	struct timeval tv;
+
+	LogDebugTLS(TLS_SHUTDOWN, "ctx:%x", ctx);
+	if (!ctx) {
+		return true;
+	}
+
+	/* Setting timeout so that SSL_shutdown() doesn't get stuck on
+	 * recv when close_notify is not receved from client */
+	tv.tv_sec = 5;
+	tv.tv_usec = 0;
+	setsockopt(ctx->fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+	if (ctx->ssl) {
+		/* write direction of the connection */
+		ret = SSL_shutdown(ctx->ssl);
+		LogDebugTLS(TLS_SHUTDOWN, "shutdown %" PRId32 , ret);
+		if (ret == 0) {
+			/* If return is 0, we need to call it again to complete
+			 * bidirectional shutdown
+			 * i.e read direction of the connection */
+			ret = SSL_shutdown(ctx->ssl);
+			LogDebugTLS(TLS_SHUTDOWN, "shutdown1 %" PRId32 , ret);
+		}
+
+		if (ret < 0) {
+			/* Optionally log SSL error */
+			int err = SSL_get_error(ctx->ssl, ret);
+
+			LogDebugTLS(TLS_SHUTDOWN, "shutdown failed %" PRId32
+				    " :%" PRId32 , ret, err);
+		}
+		SSL_free(ctx->ssl);
+	}
+
+	LogDebugTLS(TLS_SHUTDOWN, "freeing ctx ret:%" PRId32 , ret);
+	mem_free(ctx, sizeof(tls_ctx_t));
+	return true;
+}
+
+/**
+ * Request a TLS 1.3 key update from the client.
+ * call this periodically (e.g. every 3 minutes)
+ * But currently its not supported.
+ * In future based on requirement will extend this.
+ * Note : Shutdown the connection if keyupdate is not supported,
+ * which will cause new key exchange
+ *
+ * @param ssl The active SSL connection.
+ * @return 0 on success, -1 on failure.
+ */
+bool tls_key_update(tls_ctx_t *ctx)
+{
+	if (!ctx || !ctx->ssl) {
+		LogWarnTLS(TLS_HANDSHAKE, "Invalid ctx");
+		return false;
+	}
+
+	if (SSL_version(ctx->ssl) != TLS1_3_VERSION) {
+		LogWarnTLS(TLS_HANDSHAKE,
+			   "Key update is only supported in TLS 1.3");
+		return false;
+	}
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	int is_ktls_send = BIO_get_ktls_send(SSL_get_wbio(ctx->ssl));
+	int is_ktls_recv = BIO_get_ktls_recv(SSL_get_rbio(ctx->ssl));
+
+	LogWarnTLS(TLS_HANDSHAKE, "is_KTLS_rec:%" PRId32 " isKTLS_send:%"
+		   PRId32 , is_ktls_send, is_ktls_recv);
+
+	/* return false directly , which will shutdown the connection
+	 * or can try the openssl */
+	if (is_ktls_send || is_ktls_recv) {
+		return false;
+	}
+#else
+	/* KTLS status check not available on OpenSSL < 3.0 */
+	LogDebugTLS(TLS_HANDSHAKE,
+		   "KTLS not supported by this OpenSSL version (< 3.0)");
+#endif
+	/* Request peer to update keys for both directions */
+	if (!SSL_key_update(ctx->ssl, SSL_KEY_UPDATE_REQUESTED)) {
+		LogWarnTLS(TLS_HANDSHAKE, "SSL_key_update failed");
+		return false;
+	}
+
+	/* SSL_do_handshake must be called to complete the key update process */
+	if (SSL_do_handshake(ctx->ssl) <= 0) {
+		int err = SSL_get_error(ctx->ssl, -1);
+
+		LogWarnTLS(TLS_HANDSHAKE, "SSL_do_handshake failed: %" PRId32
+			  " (%s)\n",
+			  err, ERR_reason_error_string(ERR_get_error()));
+		return false;
+	}
+
+	LogWarnTLS(TLS_INIT,
+		   " Key update requested and handshake completed.");
+	return true;
+}
+
+/* Debug callback registered with lib to get detailed o/p of whats happening */
+static void tls_info_callback(const SSL *ssl, int where, int ret)
+{
+	const char *str = SSL_state_string_long(ssl);
+	const char *prefix = "";
+	const char *direction = "";
+	static int handshake_started;
+
+	/* Handshake state tracking */
+	if (where & SSL_CB_HANDSHAKE_START) {
+		prefix = "[HANDSHAKE START]";
+		handshake_started = 1;
+		LogWarnTLS(TLS_INIT, "%s : %s", prefix, str);
+
+		/* Log additional handshake details */
+		const char *version = SSL_get_version(ssl);
+
+		LogDebugTLS(TLS_UNKNOWN,
+			    "[HANDSHAKE START] Protocol version: %s",
+			    version ? version : "unknown");
+
+		/* Log cipher information if available */
+		const SSL_CIPHER *cipher = SSL_get_current_cipher(ssl);
+
+		if (cipher) {
+			LogDebugTLS(TLS_UNKNOWN, "[HANDSHAKE START] Cipher: %s",
+				    SSL_CIPHER_get_name(cipher));
+		}
+		return;
+	}
+
+	if (where & SSL_CB_HANDSHAKE_DONE) {
+		if (SSL_session_reused(ssl)) {
+			prefix = "[HANDSHAKE RESUMED DONE]";
+		} else {
+			prefix = "[HANDSHAKE DONE]";
+		}
+		handshake_started = 0;
+
+		LogWarnTLS(TLS_INIT, "%s : %s", prefix, str);
+
+		/* Log detailed handshake completion information */
+		const SSL_CIPHER *cipher = SSL_get_current_cipher(ssl);
+
+		if (cipher) {
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[HANDSHAKE DONE] Final cipher: %s",
+				    SSL_CIPHER_get_name(cipher));
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[HANDSHAKE DONE] Cipher bits: %" PRId32 ,
+				    SSL_CIPHER_get_bits(cipher, NULL));
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[HANDSHAKE DONE] Cipher version: %s",
+				    SSL_CIPHER_get_version(cipher));
+		}
+
+		/* Log protocol version */
+		LogDebugTLS(TLS_UNKNOWN, "[HANDSHAKE DONE] Protocol: %s",
+			    SSL_get_version(ssl));
+
+		/* Log session information */
+		SSL_SESSION *session = SSL_get_session(ssl);
+
+		if (session) {
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[HANDSHAKE DONE] Session timeout: %" PRId64
+				    , SSL_SESSION_get_timeout(session));
+			if (SSL_session_reused(ssl)) {
+				LogDebugTLS(TLS_UNKNOWN,
+					"[HANDSHAKE DONE] Session was reused");
+			} else {
+				LogDebugTLS(TLS_UNKNOWN,
+					"[HANDSHAKE DONE] New session created");
+			}
+		}
+
+		/* Check for SNI */
+		const char *servername =
+			SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
+		if (servername) {
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[HANDSHAKE DONE] SNI hostname: %s",
+				    servername);
+		}
+
+		/* Check for ALPN */
+		const unsigned char *alpn_selected;
+		unsigned int alpn_len;
+
+		SSL_get0_alpn_selected(ssl, &alpn_selected, &alpn_len);
+		if (alpn_selected && alpn_len > 0) {
+			char alpn_str[256];
+
+			snprintf(alpn_str, sizeof(alpn_str), "%.*s", alpn_len,
+				 alpn_selected);
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[HANDSHAKE DONE] ALPN protocol: %s",
+				    alpn_str);
+		}
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+		/* Check KTLS status */
+		BIO *wbio = SSL_get_wbio(ssl);
+		BIO *rbio = SSL_get_rbio(ssl);
+
+		if (wbio && rbio) {
+			int ktls_send = BIO_get_ktls_send(wbio);
+			int ktls_recv = BIO_get_ktls_recv(rbio);
+
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[HANDSHAKE DONE] KTLS send: %s, recv: %s",
+				    ktls_send ? "enabled" : "disabled",
+				    ktls_recv ? "enabled" : "disabled");
+		}
+#endif
+
+		return;
+	}
+
+	/* Alert handling with detailed information */
+	if (where & SSL_CB_ALERT) {
+		direction = (where & SSL_CB_READ) ? "read" : "write";
+		int level = ret >> 8;
+		int desc = ret & 0xff;
+		const char *level_str = (level == 1) ? "warning" : "fatal";
+		const char *alert_desc = SSL_alert_desc_string_long(desc);
+		const char *alert_type = SSL_alert_type_string_long(ret);
+
+		LogWarnTLS(TLS_UNKNOWN,
+			"[ALERT] %s: level=%s, desc=%" PRId32
+			" (%s) type=(%s) state=(%s)",
+			direction, level_str, desc,
+			alert_desc ? alert_desc : "unknown",
+			alert_type ? alert_type : "unknown", str);
+
+		/* Log additional context for specific alerts */
+		switch (desc) {
+		case SSL_AD_CLOSE_NOTIFY:
+			LogDebugTLS(TLS_UNKNOWN,
+				"[ALERT] Connection being closed gracefully");
+			break;
+		case SSL_AD_HANDSHAKE_FAILURE:
+			LogDebugTLS(TLS_UNKNOWN,
+				"[ALERT] Handshake failure - check cipher compatibility");
+			break;
+		case SSL_AD_BAD_CERTIFICATE:
+			LogDebugTLS(TLS_UNKNOWN,
+				"[ALERT] Bad certificate - certificate validation failed");
+			break;
+		case SSL_AD_CERTIFICATE_EXPIRED:
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[ALERT] Certificate has expired");
+			break;
+		case SSL_AD_CERTIFICATE_UNKNOWN:
+			LogDebugTLS(TLS_UNKNOWN,
+				"[ALERT] Certificate unknown or not trusted");
+			break;
+		case SSL_AD_ILLEGAL_PARAMETER:
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[ALERT] Illegal parameter in handshake");
+			break;
+		case SSL_AD_DECODE_ERROR:
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[ALERT] Message decode error");
+			break;
+		case SSL_AD_DECRYPT_ERROR:
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[ALERT] Message decryption error");
+			break;
+		case SSL_AD_PROTOCOL_VERSION:
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[ALERT] Protocol version not supported");
+			break;
+		case SSL_AD_INSUFFICIENT_SECURITY:
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[ALERT] Insufficient security level");
+			break;
+		case SSL_AD_INTERNAL_ERROR:
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[ALERT] Internal error occurred");
+			break;
+		case SSL_AD_USER_CANCELLED:
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[ALERT] User cancelled the operation");
+			break;
+		case SSL_AD_NO_RENEGOTIATION:
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[ALERT] Renegotiation not allowed");
+			break;
+		case SSL_AD_UNSUPPORTED_EXTENSION:
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[ALERT] Unsupported extension");
+			break;
+		case SSL_AD_CERTIFICATE_UNOBTAINABLE:
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[ALERT] Certificate unobtainable");
+			break;
+		case SSL_AD_UNRECOGNIZED_NAME:
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[ALERT] Unrecognized name (SNI mismatch)");
+			break;
+		case SSL_AD_BAD_CERTIFICATE_STATUS_RESPONSE:
+			LogDebugTLS(TLS_UNKNOWN,
+				"[ALERT] Bad certificate status response (OCSP)");
+			break;
+		case SSL_AD_BAD_CERTIFICATE_HASH_VALUE:
+			LogDebugTLS(TLS_UNKNOWN,
+				    "[ALERT] Bad certificate hash value");
+			break;
+		default:
+			LogDebugTLS(TLS_UNKNOWN, "[ALERT] Alert code %" PRId32
+				    , desc);
+			break;
+		}
+		return;
+	}
+
+	/* State-based categorization */
+	if (where & SSL_CB_LOOP) {
+		if (handshake_started) {
+			prefix = "[HANDSHAKE LOOP]";
+		} else {
+			prefix = "[LOOP]";
+		}
+
+		/* Detailed state analysis */
+		if (strstr(str, "read") || strstr(str, "Read")) {
+			LogDebugTLS(TLS_UNKNOWN,
+				    "%s : %s [Reading data/handshake messages]",
+				    prefix, str);
+		} else if (strstr(str, "write") || strstr(str, "Write")) {
+			LogDebugTLS(TLS_UNKNOWN,
+				    "%s : %s [Writing data/handshake messages]",
+				    prefix, str);
+		} else if (strstr(str, "certificate") ||
+			   strstr(str, "Certificate")) {
+			LogDebugTLS(TLS_UNKNOWN,
+				    "%s : %s [Certificate processing]", prefix,
+				    str);
+		} else if (strstr(str, "key") || strstr(str, "Key")) {
+			LogDebugTLS(TLS_UNKNOWN,
+				    "%s : %s [Key exchange/processing]", prefix,
+				    str);
+		} else if (strstr(str, "cipher") || strstr(str, "Cipher")) {
+			LogDebugTLS(TLS_UNKNOWN,
+				    "%s : %s [Cipher negotiation/setup]",
+				    prefix, str);
+		} else if (strstr(str, "finished") || strstr(str, "Finished")) {
+			LogDebugTLS(TLS_UNKNOWN,
+				    "%s : %s [Handshake finishing]", prefix,
+				    str);
+		} else {
+			LogWarnTLS(TLS_UNKNOWN, "%s : %s", prefix, str);
+		}
+		return;
+	}
+
+	if (where & SSL_CB_EXIT) {
+		if (ret == 0) {
+			prefix = "[EXIT] failed";
+			LogWarnTLS(TLS_UNKNOWN, "%s : %s [Operation failed]",
+				   prefix, str);
+
+			/* Log additional error information */
+			unsigned long err = ERR_peek_last_error();
+
+			if (err != 0) {
+				char err_buf[256];
+
+				ERR_error_string_n(err, err_buf,
+						   sizeof(err_buf));
+				LogDebugTLS(TLS_UNKNOWN,
+					    "[EXIT] Last error: %s", err_buf);
+			}
+		} else if (ret < 0) {
+			prefix = "[EXIT] error";
+			LogWarnTLS(TLS_UNKNOWN,
+				   "%s : %s [Error condition, ret=%"
+				   PRId32 "]", prefix, str, ret);
+
+			/* Log SSL error details */
+			int ssl_err = SSL_get_error(ssl, ret);
+			const char *ssl_err_str = "";
+
+			switch (ssl_err) {
+			case SSL_ERROR_NONE:
+				ssl_err_str = "SSL_ERROR_NONE";
+				break;
+			case SSL_ERROR_SSL:
+				ssl_err_str = "SSL_ERROR_SSL";
+				break;
+			case SSL_ERROR_WANT_READ:
+				ssl_err_str = "SSL_ERROR_WANT_READ";
+				break;
+			case SSL_ERROR_WANT_WRITE:
+				ssl_err_str = "SSL_ERROR_WANT_WRITE";
+				break;
+			case SSL_ERROR_WANT_X509_LOOKUP:
+				ssl_err_str = "SSL_ERROR_WANT_X509_LOOKUP";
+				break;
+			case SSL_ERROR_SYSCALL:
+				ssl_err_str = "SSL_ERROR_SYSCALL";
+				break;
+			case SSL_ERROR_ZERO_RETURN:
+				ssl_err_str = "SSL_ERROR_ZERO_RETURN";
+				break;
+			case SSL_ERROR_WANT_CONNECT:
+				ssl_err_str = "SSL_ERROR_WANT_CONNECT";
+				break;
+			case SSL_ERROR_WANT_ACCEPT:
+				ssl_err_str = "SSL_ERROR_WANT_ACCEPT";
+				break;
+			default:
+				ssl_err_str = "SSL_ERROR_UNKNOWN";
+				break;
+			}
+			LogDebugTLS(TLS_UNKNOWN, "[EXIT] SSL error: %s (%"
+				    PRId32 ")", ssl_err_str, ssl_err);
+		} else {
+			prefix = "[EXIT] ok";
+			LogDebugTLS(TLS_UNKNOWN,
+				    "%s : %s [Operation successful]", prefix,
+				    str);
+		}
+		return;
+	}
+
+	/* Read/Write operations */
+	if (where & SSL_CB_READ) {
+		prefix = "[READ]";
+		LogDebugTLS(TLS_UNKNOWN, "%s : %s [Reading TLS data]", prefix,
+			    str);
+		return;
+	}
+
+	if (where & SSL_CB_WRITE) {
+		prefix = "[WRITE]";
+		LogDebugTLS(TLS_UNKNOWN, "%s : %s [Writing TLS data]", prefix,
+			    str);
+		return;
+	}
+
+	/* Accept loop (server-specific) */
+	if (where & SSL_CB_ACCEPT_LOOP) {
+		prefix = "[ACCEPT LOOP]";
+		LogDebugTLS(TLS_UNKNOWN,
+			    "%s : %s [Server accepting connection]", prefix,
+			    str);
+		return;
+	}
+
+	/* Connect loop (client-specific) */
+	if (where & SSL_CB_CONNECT_LOOP) {
+		prefix = "[CONNECT LOOP]";
+		LogDebugTLS(TLS_UNKNOWN, "%s : %s [Client connecting]", prefix,
+			    str);
+		return;
+	}
+
+	/* Default case - analyze the state string for more context */
+	if (strstr(str, "error") || strstr(str, "Error") ||
+	    strstr(str, "failed")) {
+		prefix = "[ERROR]";
+	} else if (strstr(str, "certificate") || strstr(str, "Certificate")) {
+		prefix = "[CERTIFICATE]";
+	} else if (strstr(str, "key") || strstr(str, "Key")) {
+		prefix = "[KEY EXCHANGE]";
+	} else if (strstr(str, "cipher") || strstr(str, "Cipher")) {
+		prefix = "[CIPHER]";
+	} else if (strstr(str, "session") || strstr(str, "Session")) {
+		prefix = "[SESSION]";
+	} else if (strstr(str, "version") || strstr(str, "Version")) {
+		prefix = "[VERSION]";
+	} else if (strstr(str, "extension") || strstr(str, "Extension")) {
+		prefix = "[EXTENSION]";
+	} else {
+		prefix = "[INFO]";
+	}
+
+	LogWarnTLS(TLS_UNKNOWN, "%s : %s", prefix, str);
+}
+
+#endif /*  USE_OPENSSL */

--- a/src/tls_transport.c
+++ b/src/tls_transport.c
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+/*
+ * vim:noexpandtab:shiftwidth=8:tabstop=8:
+ *
+ * Copyright (C) 2025, IBM . All rights reserved.
+ * Author: Deeraj Patil <deeraj.patil@ibm.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.  see <http://www.gnu.org/licenses/
+ *
+ * ---------------------------------------
+ */
+
+/**
+ * @file tls_transport.c
+ * @brief Plugging module for entertaining different backend TLS libs.
+ * Implementation is done in such a way that, if any user wants to add support
+ * for more TLS libs, it should be seamless.
+ *
+ * Routines used for entertaining TLS in ntirpc.
+ *
+ */
+#ifdef USE_TLS
+
+#include "tls.h"
+#include "tls_transport.h"
+#include <arpa/inet.h>
+#include <stdatomic.h>
+
+tls_cred_t *g_xprt_cred;
+bool g_tls_enabled;
+
+bool xprt_tls_init(const char *cert_file, const char *key_file,
+		   const char *ca_file, const char *ciphers,
+		   const char *min_version, bool ktls, bool debug)
+{
+	g_xprt_cred = tls_cred_init(cert_file, key_file, ca_file, ciphers,
+				   min_version, ktls, debug);
+	if (g_xprt_cred != NULL) {
+		g_tls_enabled = true;
+		return true;
+	} else {
+		return false;
+	}
+}
+
+/* Initialize TLS for a transport */
+bool xp_tls_init_impl(SVCXPRT *xprt)
+{
+	int ret;
+	char ip[INET6_ADDRSTRLEN] = {0};
+
+	if (!xprt || !xprt->xp_tls.tls_enabled) {
+		LogEventTLS(TLS_HANDSHAKE,
+			    "TLS not enabled for this transport");
+		ret = false;
+		goto out;
+	}
+
+	/* Use xp_remote to get the real client IP, which is set by PROXY
+	 * protocol when HAProxy is used. If PROXY protocol is not used,
+	 * xp_remote contains the direct peer address from accept().
+	 */
+	struct sockaddr_storage *addr = &xprt->xp_remote.ss;
+	if (addr->ss_family == AF_INET) {
+		struct sockaddr_in *s = (struct sockaddr_in *)addr;
+		inet_ntop(AF_INET, &s->sin_addr, ip, sizeof(ip));
+	} else if (addr->ss_family == AF_INET6) {
+		struct sockaddr_in6 *s = (struct sockaddr_in6 *)addr;
+		inet_ntop(AF_INET6, &s->sin6_addr, ip, sizeof(ip));
+	}
+
+	LogEventTLS(TLS_HANDSHAKE, "trying TLS connection for fd %" PRId32
+		    " client: %s", xprt->xp_fd, ip);
+
+	pthread_mutex_lock(&(xprt->xp_tls.tls_lock));
+	/* Create TLS context if not already created */
+	if (!xprt->xp_tls.tls_ctx) {
+		xprt->xp_tls.tls_ctx =
+			tls_ctx_init(xprt->xp_fd, g_xprt_cred, true);
+		if (!xprt->xp_tls.tls_ctx) {
+			LogCritTLS(TLS_HANDSHAKE,
+				   "Failed to initialize TLS context for fd %"
+				   PRId32 , xprt->xp_fd);
+			ret = false;
+			goto out;
+		}
+	}
+
+	if (xprt->xp_tls.tls_established) {
+		LogDebugTLS(TLS_HANDSHAKE,
+			    "TLS already established for this transport");
+		ret = true;
+		goto out;
+	}
+
+	/* Perform TLS handshake */
+	if (!tls_handshake(xprt->xp_tls.tls_ctx)) {
+		LogWarnTLS(TLS_HANDSHAKE, "TLS handshake failed for fd %"
+			   PRId32 , xprt->xp_fd);
+		ret = false;
+		goto out;
+	}
+
+	/* Verify client certificate */
+	char peer_identity[512];
+	if (!tls_verify_peer(xprt->xp_tls.tls_ctx, peer_identity,
+				 sizeof(peer_identity))) {
+		LogWarnTLS(TLS_HANDSHAKE,
+			   "Client certificate verification failed for fd %"
+			   PRId32 , xprt->xp_fd);
+		ret = false;
+		goto out;
+	}
+
+
+	xprt->xp_tls.mtls = tls_get_type(xprt->xp_tls.tls_ctx);
+	xprt->xp_tls.tls_established = true;
+	LogEventTLS(TLS_HANDSHAKE, "TLS connection established for fd %" PRId32
+		    " client: %s mtls:%d", xprt->xp_fd, ip, xprt->xp_tls.mtls);
+
+	ret = true;
+out:
+	pthread_mutex_unlock(&(xprt->xp_tls.tls_lock));
+	return ret;
+}
+
+/* Receive TLS decoded data */
+ssize_t xp_tls_recv_impl(SVCXPRT *xprt, void *buf, size_t len, int flags)
+{
+	ssize_t ret;
+
+	LogDebugTLS(TLS_DISPATCH, "xprt:%p fd:%" PRId32 , xprt, xprt->xp_fd);
+	if (!xprt || !xprt->xp_tls.tls_ctx || !buf || len <= 0) {
+		LogDebugTLS(TLS_DISPATCH, "Invalid TLS context for recv");
+		return -1;
+	}
+
+	ret = tls_recv(xprt->xp_tls.tls_ctx, buf, len, flags);
+
+	if (ret == TLS_SESSION_CLOSED_ADRUPTLY) {
+		LogWarnTLS(TLS_DISPATCH, "Session Closed adruptly");
+		return -1;
+	}
+	return ret;
+}
+
+/* Send data over TLS */
+ssize_t xp_tls_send_impl(SVCXPRT *xprt, const struct msghdr *msg, int flags)
+{
+	ssize_t ret = 0;
+
+	LogDebugTLS(TLS_DISPATCH, "xprt:%p fd:%" PRId32 , xprt, xprt->xp_fd);
+	if (!xprt || !xprt->xp_tls.tls_ctx || !msg || !msg->msg_iov ||
+	    msg->msg_iovlen <= 0) {
+		LogDebugTLS(TLS_DISPATCH, "Invalid TLS context for send");
+		return -1;
+	}
+
+	ret = tls_send(xprt->xp_tls.tls_ctx, msg, flags);
+
+	if (ret == TLS_SESSION_CLOSED_ADRUPTLY) {
+		LogWarnTLS(TLS_DISPATCH, "Session Closed adruptly");
+		return -1;
+	}
+
+	return ret;
+}
+
+/* Query TLS library internal buffer for pending decoded bytes */
+ssize_t xp_tls_datapending_impl(SVCXPRT *xprt)
+{
+	LogDebugTLS(TLS_DISPATCH, "xprt:%p fd:%" PRId32 , xprt, xprt->xp_fd);
+	if (!xprt || !xprt->xp_tls.tls_ctx) {
+		LogDebugTLS(TLS_DISPATCH, "Invalid TLS context for dpr lib");
+		return -1;
+	}
+
+	return tls_datapending(xprt->xp_tls.tls_ctx);
+}
+
+/* Reset the TLS specific data in xprt */
+void xp_tls_reset_xprt(SVCXPRT *xprt)
+{
+	xprt->xp_tls.tls_enabled = false;
+	xprt->xp_tls.tls_ctx = NULL;
+	xprt->xp_tls.tls_established = false;
+	xprt->xp_tls.mtls = false;
+	xprt->xp_tls.not_first_packet = false;
+}
+
+/* Close TLS connection */
+void xp_tls_close_impl(SVCXPRT *xprt)
+{
+	if (!xprt || !xprt->xp_tls.tls_ctx) {
+		return; /* Nothing to close */
+	}
+	LogEventTLS(TLS_DISPATCH, "connection close xprt:%p fd:%" PRId32 ,
+		    xprt, xprt->xp_fd);
+	pthread_mutex_lock(&(xprt->xp_tls.tls_lock));
+	tls_close(xprt->xp_tls.tls_ctx);
+	xp_tls_reset_xprt(xprt);
+	pthread_mutex_unlock(&(xprt->xp_tls.tls_lock));
+}
+
+/* Initialize TLS operations for a transport */
+bool svc_tls_init_xprt(SVCXPRT *xprt)
+{
+	bool ret = false;
+
+	if (!xprt) {
+		return ret;
+	}
+
+	/*
+	 * Guard: if the TLS engine failed to initialize at startup, reject
+	 * immediately rather than attempting a handshake with NULL credentials.
+	 * Log only once regardless of how many clients attempt to connect,
+	 * to prevent log flooding.
+	 */
+	if (!g_tls_enabled) {
+		static atomic_flag logged = ATOMIC_FLAG_INIT;
+
+		if (!atomic_flag_test_and_set(&logged))
+			LogCritTLS(TLS_INIT,
+				   "TLS engine is disabled, rejecting "
+				   "connection on fd %" PRId32,
+				   xprt->xp_fd);
+		return false;
+	}
+
+	/* Initialize TLS structure */
+	pthread_mutex_init(&(xprt->xp_tls.tls_lock), NULL);
+	xprt->xp_tls.tls_enabled = true;
+	xprt->xp_tls.tls_ctx = NULL;
+	xprt->xp_tls.tls_established = false;
+
+	ret = xp_tls_init_impl(xprt);
+	if (ret == false) {
+		xp_tls_reset_xprt(xprt);
+		LogEventTLS(TLS_HANDSHAKE, "TLS disabled xprt:%p fd:%" PRId32 ,
+			    xprt, xprt->xp_fd);
+
+	} else {
+		LogDebugTLS(TLS_HANDSHAKE, "TLS enabled xprt:%p fd:%" PRId32 ,
+			    xprt, xprt->xp_fd);
+	}
+	return ret;
+}
+
+bool is_tls_clienthello(int fd)
+{
+	unsigned char peek_buf[5];
+	ssize_t n = recv(fd, peek_buf, sizeof(peek_buf), MSG_PEEK);
+
+	if (n < 5)
+		return false;
+
+	/* TLS record type = 0x16 (handshake), Version = 0x0303 or higher */
+	if (peek_buf[0] == 0x16 && peek_buf[1] == 0x03 &&
+	    (peek_buf[2] == 0x01 || peek_buf[2] == 0x03 ||
+	     peek_buf[2] == 0x04)) {
+		return true;
+	}
+	return false;
+}
+
+/*
+ * Used in case of Stunnel connection from client
+ */
+bool is_handshake_msg(SVCXPRT *xprt)
+{
+	if (is_tls_clienthello(xprt->xp_fd))
+		return svc_tls_init_xprt(xprt);
+	return false;
+}
+
+/*
+ * Slow-path handshake wait: called by svc_tls_recv (inline) only when
+ * tls_enabled is true but tls_established is not yet set, meaning the
+ * AUTH_TLS upper-layer handshake is still in flight.  Acquires tls_lock to
+ * block until the handshake thread completes, then logs the outcome.
+ */
+void xp_tls_recv_wait(SVCXPRT *xprt)
+{
+	pthread_mutex_lock(&(xprt->xp_tls.tls_lock));
+	if (!xprt->xp_tls.tls_established) {
+		LogDebugTLS(TLS_DISPATCH,
+			    "Waited for handshake, failed xprt:%p fd:%" PRId32,
+			    xprt, xprt->xp_fd);
+	} else {
+		LogDebugTLS(TLS_DISPATCH,
+			    "Waited for handshake, done xprt:%p fd:%" PRId32,
+			    xprt, xprt->xp_fd);
+	}
+	pthread_mutex_unlock(&(xprt->xp_tls.tls_lock));
+}
+
+/*
+ * Data-pending check: called by svc_tls_datapending (inline) after the fast
+ * tls_established guard.  Queries the TLS library buffer via
+ * xp_tls_datapending_impl, then peeks the raw socket to distinguish data that
+ * lives only in the TLS buffer (return 1) from data already on the socket
+ * (return 0, handled by the normal epoll path).
+ */
+ssize_t xp_tls_datapending_check(SVCXPRT *xprt)
+{
+	ssize_t ret = xp_tls_datapending_impl(xprt);
+
+	if (ret > 0) {
+		int any_data_on_socket;
+		int local_len = recv(xprt->xp_fd, &any_data_on_socket, 4,
+				     MSG_PEEK | MSG_DONTWAIT);
+
+		if (local_len == -1) {
+			LogDebugTLS(TLS_DISPATCH,
+				    "DPR xprt:%p fd:%" PRId32
+				    " lib:%" PRId32 " socket:-1",
+				    xprt, xprt->xp_fd, ret);
+			return 1;
+		}
+		return 0;
+	}
+	return 0;
+}
+
+#endif /*  USE_TLS */

--- a/src/tls_transport.h
+++ b/src/tls_transport.h
@@ -1,0 +1,22 @@
+#ifdef USE_TLS
+/* Backend TLS library operations (implemented in tls_openssl.c / tls_gnutls.c) */
+extern tls_ctx_t *tls_ctx_init(int fd, tls_cred_t *cred, bool is_server);
+extern tls_cred_t *tls_cred_init(const char *cert_file, const char *key_file,
+		const char *ca_file, const char *ciphers,
+		const char *min_version, bool ktls, bool debug);
+extern bool tls_handshake(tls_ctx_t *ctx);
+extern ssize_t tls_recv(tls_ctx_t *ctx, void *buf, size_t len, int flags);
+extern ssize_t tls_send(tls_ctx_t *ctx, const struct msghdr *msg, int flags);
+extern int tls_datapending(tls_ctx_t *ctx);
+extern bool tls_close(tls_ctx_t *ctx);
+extern bool tls_verify_peer(tls_ctx_t *ctx, char *peer_identity,
+		size_t id_size);
+extern bool tls_key_update(tls_ctx_t *ctx);
+extern bool tls_get_type(tls_ctx_t *ctx);
+
+/* Transport-layer TLS wiring (implemented in tls_transport.c) */
+extern bool xprt_tls_init(const char *cert_file, const char *key_file,
+		const char *ca_file, const char *ciphers,
+		const char *min_version, bool ktls, bool debug);
+extern bool svc_tls_init_xprt(SVCXPRT *xprt);
+#endif /*  USE_TLS */


### PR DESCRIPTION
  Backend TLS lib : Openssl, GnuTLS.
  Compile time option for enabling : USE_TLS, USE_OPENSSL, USE_GNUTLS.
  TLS entertained via AUTH_TLS and non-AUTH_TLS.
  KTLS and non KTLS based send and recv.

  Main data flow changes in exiting code :
  Added DPR (Data Pending Recovery/Resume)
  TLS libraries like openssl, GNUTLS  buffers the recv data.
  i.e  if 8 buffers of 1Kb are sent to server, libraries cache all the data
  in lib's buffer causing only 1 epoll_wait EPOLLIN event and not 8 events.
  Causing not to process/reply the pending 7 IO's, its all based on timing
  between read and avaibale data in the underlying socket stream. if there is a
  delay between the recv packets, we will not see this issue.

  Code flow change required for same:
  At the end of each RPC consumed, code rearms the fd.
  so before rearming check any data is in TLS lib's buffer.
  if yes, more data available event on control fd  then rearm the recv fd.
  dpr event will wake epoll_wait and special handling of this event
  (for more data available) will catch this and resume with the
  recv of the data which is buffered in TLS lib's and the loop
  continues to drain all the IO's till lib's buffer is empty and
  no data is available on underlying socket.

  TLS in case of HAPROXY (send-proxy-v2) also handled.

  Note: with OpenSSL, tested most of the things.
  	with GNUTLS, needs more testing.