### PR TITLE
update cmake_minimum_required to please cmake 4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 # New TI-RPC  Cmake
 
-# Current version as of Fedora 16.  Not tested with earlier.
+# Current version as of Fedora 25.  Not tested with earlier.
+#  cmake 4.x wants 3.6 or better.
 
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.6.2)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 


### PR DESCRIPTION
cmake 4.x explicitly doesn't support all constructs for cmake < 3.6, which was nine years ago.  In fact, I'm testing with cmake 3.27.4, which is plenty old.