### PR TITLE
Enhance header files to support both C and C++ compilation

### DIFF
--- a/ntirpc/lttng/ntirpc_traces.h
+++ b/ntirpc/lttng/ntirpc_traces.h
@@ -32,6 +32,12 @@
 #define __S2(x) __S1(x)
 #define LINE_AS_STRING __S2(__LINE__)
 
+#ifndef UNUSED
+#define UNUSED_ATTR __attribute__((unused))
+#define UNUSED(...) UNUSED_(__VA_ARGS__)
+#define UNUSED_(arg) NOT_USED_##arg UNUSED_ATTR
+#endif
+
 #ifdef USE_LTTNG_NTIRPC
 
 #include "lttng_generator.h"
@@ -57,7 +63,7 @@
 
 /* We call the empty function with the variable args to avoid unused variables
  * warning when LTTNG traces are disabled */
-static void inline ntirpc_empty_function(const char* unused, ...) {}
+static void inline ntirpc_empty_function(const char* UNUSED(unused), ...) {}
 
 #define NTIRPC_AUTO_TRACEPOINT(prov_name, event_name, log_level, ...) \
 		ntirpc_empty_function("unused", ##__VA_ARGS__)

--- a/ntirpc/rpc/haproxy.h
+++ b/ntirpc/rpc/haproxy.h
@@ -30,6 +30,13 @@
 
 #include "config.h"
 
+/* Adding macro for compatibilty of c++ compilation */
+#ifdef __cplusplus
+#ifndef _Static_assert
+#define _Static_assert static_assert
+#endif
+#endif
+
 #ifndef _NTIRPC_RPC_HAPROXY_H
 #define _NTIRPC_RPC_HAPROXY_H
 
@@ -123,11 +130,7 @@ struct proxy_header_addr_ip4_part { /* for TCP/UDP over IPv4, len = 12 */
 	uint16_t dst_port;
 };
 
-#ifdef __cplusplus
-static_assert(
-#else
 _Static_assert(
-#endif
 	sizeof(struct proxy_header_addr_ip4_part) == PP2_ADDR_LEN_INET,
 	"proxy_header_addr_ip4_part size is not equal to PP2_ADDR_LEN_INET");
 
@@ -138,12 +141,7 @@ struct proxy_header_addr_ip6_part { /* for TCP/UDP over IPv6, len = 36 */
 	uint16_t dst_port;
 };
 
-
-#ifdef __cplusplus
-static_assert(
-#else
 _Static_assert(
-#endif
 	sizeof(struct proxy_header_addr_ip6_part) == PP2_ADDR_LEN_INET6,
 	"proxy_header_addr_ip6_part size is not equal to PP2_ADDR_LEN_INET6");
 

--- a/ntirpc/rpc/haproxy.h
+++ b/ntirpc/rpc/haproxy.h
@@ -122,7 +122,12 @@ struct proxy_header_addr_ip4_part { /* for TCP/UDP over IPv4, len = 12 */
 	uint16_t src_port;
 	uint16_t dst_port;
 };
+
+#ifdef __cplusplus
+static_assert(
+#else
 _Static_assert(
+#endif
 	sizeof(struct proxy_header_addr_ip4_part) == PP2_ADDR_LEN_INET,
 	"proxy_header_addr_ip4_part size is not equal to PP2_ADDR_LEN_INET");
 
@@ -132,7 +137,13 @@ struct proxy_header_addr_ip6_part { /* for TCP/UDP over IPv6, len = 36 */
 	uint16_t src_port;
 	uint16_t dst_port;
 };
+
+
+#ifdef __cplusplus
+static_assert(
+#else
 _Static_assert(
+#endif
 	sizeof(struct proxy_header_addr_ip6_part) == PP2_ADDR_LEN_INET6,
 	"proxy_header_addr_ip6_part size is not equal to PP2_ADDR_LEN_INET6");
 

--- a/ntirpc/rpc/svc.h
+++ b/ntirpc/rpc/svc.h
@@ -272,7 +272,11 @@ struct svc_xprt {
 		struct {
 			svc_req_fun_t process_cb;
 			svc_xprt_fun_t remote_addr_set_cb;
+#ifdef __cplusplus
+		}connection_dispatch_ops;
+#else
 		};
+#endif
 		svc_xprt_fun_t rendezvous_cb;
 	}  xp_dispatch;
 	SVCXPRT *xp_parent;

--- a/ntirpc/rpc/xdr.h
+++ b/ntirpc/rpc/xdr.h
@@ -123,7 +123,7 @@ typedef enum vio_type {
 	VIO_DATA,               /* data buffer */
 	VIO_TRAILER_LEN,	/* length field for following TRAILER buffer */
 	VIO_TRAILER,            /* trailer buffer after data */
-} vio_type;
+} vio_type_t;
 
 /* XDR buffer vector descriptors */
 typedef struct xdr_vio {
@@ -133,7 +133,7 @@ typedef struct xdr_vio {
 	uint8_t *vio_wrap;	/* maximum vio_tail */
 	uint32_t vio_length;	/* length of buffer, used for vector
 				   pre-allocation */
-	vio_type vio_type;	/* type of buffer */   
+	vio_type_t vio_type;	/* type of buffer */   
 } xdr_vio;
 
 /* vio_wrap >= vio_tail >= vio_head >= vio_base */
@@ -162,7 +162,11 @@ typedef struct xdr_uio {
 				 * 0: not allocated */
 	u_int	uio_flags;
 	int32_t uio_references;
+#ifdef __cplusplus
+	xdr_vio uio_vio[1];
+#else
 	xdr_vio	uio_vio[0];	/* appended vectors */
+#endif
 } xdr_uio;
 
 /* Op flags */

--- a/ntirpc/rpc/xdr_inline.h
+++ b/ntirpc/rpc/xdr_inline.h
@@ -52,6 +52,17 @@
 #include <rpc/types.h>
 #include <rpc/xdr.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef UNUSED
+#define UNUSED_ATTR __attribute__((unused))
+#define UNUSED(...) UNUSED_(__VA_ARGS__)
+#define UNUSED_(arg) NOT_USED_##arg UNUSED_ATTR
+#endif
+
+
 /*
  * XDR integers
  */
@@ -639,7 +650,7 @@ xdr_bytes_encode(XDR *xdrs, char **cpp, u_int *sizep, u_int maxsize)
 }
 
 static inline bool
-xdr_bytes_free(XDR *xdrs, char **cpp, size_t size)
+xdr_bytes_free(XDR *UNUSED(xdrs), char **cpp, size_t size)
 {
 	if (*cpp) {
 		mem_free(*cpp, size);
@@ -840,7 +851,7 @@ xdr_array_encode(XDR *xdrs, char **cpp, u_int *sizep, u_int maxsize,
 }
 
 static inline bool
-xdr_array_free(XDR *xdrs, char **cpp, u_int *sizep, u_int maxsize,
+xdr_array_free(XDR *xdrs, char **cpp, u_int *sizep, u_int UNUSED(maxsize),
 	       u_int selem, xdrproc_t xdr_elem)
 {
 	char *target = *cpp;
@@ -993,7 +1004,7 @@ xdr_string_encode(XDR *xdrs, char **cpp, u_int maxsize)
 }
 
 static inline bool
-xdr_string_free(XDR *xdrs, char **cpp)
+xdr_string_free(XDR *UNUSED(xdrs), char **cpp)
 {
 	if (*cpp) {
 		mem_free(*cpp, strlen(*cpp) + 1);
@@ -1063,5 +1074,9 @@ inline_xdr_u_longlong_t(XDR *xdrs, u_quad_t *ullp)
 	 */
 	return (inline_xdr_u_int64_t(xdrs, (u_int64_t *) ullp));
 }
+
+#ifdef __cplusplus
+}
+#endif /* extern "C" */
 
 #endif				/* _TIRPC_INLINE_XDR_H */

--- a/src/xdr_ioq.c
+++ b/src/xdr_ioq.c
@@ -1857,7 +1857,7 @@ xdr_ioq_allochdrs(XDR *xdrs, u_int start, xdr_vio *vector, int iov_count)
 
 	while (idx < iov_count) {
 		/* Another TRAILER buffer to manage */
-		vio_type vt = vector[idx].vio_type;
+		vio_type_t vt = vector[idx].vio_type;
 
 		__warnx(TIRPC_DEBUG_FLAG_XDR,
 			"Calling xdr_ioq_use_or_allocate for idx %d for %s",


### PR DESCRIPTION
This change standardizes the header interface, making it robust for use of both C and C++ source files, which is critical for monitoring .cc files usability.