### PR TITLE
[RDMA]: All writes below the RDMA inline threshold (~8 KB, equal to RDMA_HDR_CHUNK_SZ = 8192) are affected.

### DIFF
--- a/src/xdr_ioq.c
+++ b/src/xdr_ioq.c
@@ -1000,12 +1000,12 @@ xdr_ioq_getstartdatapos_rdma(XDR *xdrs, u_int start, u_int datalen)
 	}
 
 	/*
-	 * Small RDMA Writes
-	 * If data is inline, it should be part of nfs_buffer itself.
-	 * So, to avoid the ILLEGAL_OP, start should advance by datalen
-	 * to pick the correct OP while decoding the COMPOUND ops.
+	 * Small RDMA Writes (Inline RDMA)
+	 * The write data fits entirely within the current (NFS header) UV
+	 * at the current XDR position.  Return 'start' unchanged so that
+	 * XDR_FILLBUFS reads the actual data bytes.
 	 */
-	return start + datalen;
+	return start;
 
 }
 
@@ -1029,9 +1029,15 @@ xdr_ioq_getenddatapos_rdma(XDR *xdrs, u_int start, u_int datalen)
 	 * next nfs header in compound op. */
 	if (datalen > ((uintptr_t)xdrs->x_v.vio_tail - (uintptr_t)xdrs->x_data)) {
 		offset = (uintptr_t)xdrs->x_v.vio_tail - (uintptr_t)xdrs->x_data;
+		return start - offset;
 	}
 
-	return start - offset;
+	/* Inline RDMA: 'start' is the position of the first data byte
+	 * (getstartdatapos returned it unchanged).  'datalen' here is
+	 * RNDUP(data_len), i.e. the data bytes plus any XDR alignment
+	 * padding.  Advance past both so the decoder is positioned at
+	 * the start of the next compound op. */
+	return start + datalen;
 }
 
 static bool


### PR DESCRIPTION
Inline RDMA (small writes):
The write data fits entirely within the NFS header receive buffer at the current XDR position. xdr_ioq_getstartdatapos_rdma() incorrectly returned the start position.

With start = P (first byte of 'abcdef') and datalen = 6:

    XDR_IOQ_GETSTARTDATAPOS_RDMA() returns P + 6

    XDR_FILLBUFS(P + 6, vio, 6) reads 6 bytes starting from after the data:
	00 00 (XDR pad) + 00 00 00 09 (OP_GETATTR) → 00 00 00 00 00 09 written
	to disk

    XDR_IOQ_GETENDDATAPOS_RDMA(P + 6, RNDUP(6)=8) returned P + 6 - 0 = P + 6
	(inline branch: offset = 0) — positions the XDR decoder 2 bytes before
	OP_GETATTR (misaligned), also corrupting subsequent compound op
	decoding for this request

Any write where datalen ≤ (vio_tail - x_data) at the time of decoding takes the inline branch and is affected. With RDMA_HDR_CHUNK_SZ = 8192, this applies to all writes up to approximately 8 KB minus the preceding NFS/RPC header overhead. Writes that exceed this threshold use RDMA_READ into a separate UV (non-inline path) and are not affected.