### PR TITLE
RDMA: Add RDMA-specific debug flags in libntirpc

### DIFF
--- a/src/clnt_rdma.c
+++ b/src/clnt_rdma.c
@@ -103,7 +103,7 @@ clnt_rdma_ncreatef(const SVCXPRT *xprt,		/* init but NOT connect()ed */
 	if (create) {
 		rdma_xprt = rpc_rdma_allocate(((RDMAXPRT *)xprt)->xa);
 		if (!rdma_xprt) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s: rdma allocate failed", __func__);
 			cl->cl_error.re_status = RPC_SYSTEMERROR;
 			return cl;
@@ -143,7 +143,7 @@ clnt_rdma_ncreatef(const SVCXPRT *xprt,		/* init but NOT connect()ed */
 		rdma_xprt->server = RDMAX_CLIENT;
 
 		if (!rdma_xprt || rdma_xprt->state != RDMAXS_INITIAL) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s: %p@%p called with invalid transport address",
 				__func__, cl, rdma_xprt);
 			cl->cl_error.re_status = RPC_UNKNOWNADDR;
@@ -151,19 +151,19 @@ clnt_rdma_ncreatef(const SVCXPRT *xprt,		/* init but NOT connect()ed */
 		}
 
 		if (rpc_rdma_connect_prepare(rdma_xprt)) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: failed", __func__);
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR, "%s: failed", __func__);
 			cl->cl_error.re_status = RPC_UNKNOWNADDR;
 			return (cl);
 		}
 
 		if (rpc_rdma_connect(rdma_xprt)) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s: rdma connect failed", __func__);
 			cl->cl_error.re_status = RPC_UNKNOWNADDR;
 			return (cl);
 		}
 		if (rpc_rdma_connect_finalize(rdma_xprt)) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s: rdma connect finalize failed", __func__);
 			cl->cl_error.re_status = RPC_UNKNOWNADDR;
 			return (cl);
@@ -178,7 +178,7 @@ clnt_rdma_ncreatef(const SVCXPRT *xprt,		/* init but NOT connect()ed */
 		rdma_xprt->sm_dr.send_hdr_sz = rec->send_hdr_sz;
 
 		if (xdr_rdma_create(rdma_xprt)) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s: buffer allocation failed", __func__);
 			cl->cl_error.re_status = RPC_SYSTEMERROR;
 			return (cl);
@@ -200,7 +200,7 @@ clnt_rdma_ncreatef(const SVCXPRT *xprt,		/* init but NOT connect()ed */
 	xdrmem_create(xdrs, cm->cm_cx.cx_mcallc, MCALL_MSG_SIZE,
 		      XDR_ENCODE);
 	if (!xdr_callhdr(xdrs, &call_msg)) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s: %p@%p xdr_callhdr failed",
 			__func__, cl, rdma_xprt);
 		cl->cl_error.re_status = RPC_CANTENCODEARGS;

--- a/src/rpc_rdma.c
+++ b/src/rpc_rdma.c
@@ -165,13 +165,13 @@ rpc_rdma_pd_by_verbs(RDMAXPRT *rdma_xprt)
 	int rc;
 
 	if (!rdma_xprt->cm_id) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() transport missing cm_id",
 			__func__);
 		return EINVAL;
 	}
 	if (!rdma_xprt->cm_id->verbs) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() cm_id missing verbs",
 			__func__);
 		/* return EINVAL; legal value for dispatcher??? */
@@ -221,7 +221,7 @@ rpc_rdma_pd_get(RDMAXPRT *rdma_xprt)
 	int rc = rpc_rdma_pd_by_verbs(rdma_xprt);
 
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s:%u ERROR (return)",
 			__func__, __LINE__);
 		return rc;
@@ -230,7 +230,7 @@ rpc_rdma_pd_get(RDMAXPRT *rdma_xprt)
 		rdma_xprt->pd->pd = ibv_alloc_pd(rdma_xprt->cm_id->verbs);
 		if (!rdma_xprt->pd->pd) {
 			rc = errno;
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() %p[%u] ibv_alloc_pd failed: %s (%d)",
 				__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 			return rc;
@@ -248,7 +248,7 @@ static inline void
 rpc_rdma_pd_put(RDMAXPRT *rdma_xprt)
 {
 	if (!rdma_xprt->pd) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() missing protection domain?",
 			__func__);
 		return;
@@ -284,7 +284,7 @@ rpc_rdma_print_devinfo(RDMAXPRT *rdma_xprt)
 	struct ibv_device_attr device_attr;
 	ibv_query_device(rdma_xprt->cm_id->verbs, &device_attr);
 	uint64_t node_guid = be64toh(device_attr.node_guid);
-	__warnx(TIRPC_DEBUG_FLAG_EVENT, "Device Info:\n"
+	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA, "Device Info:\n"
 		"\tNode Guid:\t\t\t%04x:%04x:%04x:%04x\n"
 		"\tvendor_id:\t\t\t0x%04x\n"
 		"\tvendor_part_id:\t\t\t%d\n"
@@ -440,7 +440,7 @@ rpc_rdma_thread_create(pthread_t *thrid, size_t stacksize,
 	/* Init for thread parameter (mostly for scheduling) */
 	rc = pthread_attr_init(&attr);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() can't init pthread's attributes: %s (%d)",
 			__func__, strerror(rc), rc);
 		return rc;
@@ -448,7 +448,7 @@ rpc_rdma_thread_create(pthread_t *thrid, size_t stacksize,
 
 	rc = pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() can't set pthread's scope: %s (%d)",
 			__func__, strerror(rc), rc);
 		return rc;
@@ -456,7 +456,7 @@ rpc_rdma_thread_create(pthread_t *thrid, size_t stacksize,
 
 	rc = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() can't set pthread's join state: %s (%d)",
 			__func__, strerror(rc), rc);
 		return rc;
@@ -464,7 +464,7 @@ rpc_rdma_thread_create(pthread_t *thrid, size_t stacksize,
 
 	rc = pthread_attr_setstacksize(&attr, stacksize);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() can't set pthread's stack size: %s (%d)",
 			__func__, strerror(rc), rc);
 		return rc;
@@ -496,7 +496,7 @@ rpc_rdma_thread_create_epoll_cq(void *(*routine)(void *))
 		epollfd = epoll_create(EPOLL_SIZE);
 		if (epollfd == -1) {
 			rc = errno;
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() epoll_create failed: %s (%d)",
 				__func__, strerror(rc), rc);
 			break;
@@ -508,7 +508,7 @@ rpc_rdma_thread_create_epoll_cq(void *(*routine)(void *))
 			routine,
 			(void*) (&rpc_rdma_state.cq_epollfd[rpc_rdma_state.cq_thread_count]));
 		if (rc) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() could not create thread: %s (%d)",
 				__func__, strerror(rc), rc);
 			break;
@@ -542,7 +542,7 @@ rpc_rdma_thread_create_epoll(pthread_t *thrid, void *(*routine)(void *),
 		*epollfd = epoll_create(EPOLL_SIZE);
 		if (*epollfd == -1) {
 			rc = errno;
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() epoll_create failed: %s (%d)",
 				__func__, strerror(rc), rc);
 			break;
@@ -551,7 +551,7 @@ rpc_rdma_thread_create_epoll(pthread_t *thrid, void *(*routine)(void *),
 		rc = rpc_rdma_thread_create(thrid, WORKER_STACK_SIZE,
 					routine, arg);
 		if (rc) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() could not create thread: %s (%d)",
 				__func__, strerror(rc), rc);
 			*thrid = 0;
@@ -619,7 +619,7 @@ rpc_rdma_worker_callback(struct work_pool_entry *wpe)
 		break;
 
 	default:
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] cbc %p opcode: %d unknown",
 			__func__, rdma_xprt, rdma_xprt->state, cbc, cbc->opcode);
 		break;
@@ -644,7 +644,7 @@ rpc_rdma_fd_add(RDMAXPRT *rdma_xprt, int fd, int epollfd)
 
 	if (rc < 0) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p Failed to make the channel nonblock: %s (%d)",
 			__func__, rdma_xprt, strerror(rc), rc);
 		return rc;
@@ -656,7 +656,7 @@ rpc_rdma_fd_add(RDMAXPRT *rdma_xprt, int fd, int epollfd)
 	rc = epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev);
 	if (rc == -1) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p Failed to add fd to epoll: %s (%d)",
 			__func__, rdma_xprt, strerror(rc), rc);
 		return rc;
@@ -681,7 +681,7 @@ rpc_rdma_fd_del(int fd, int epollfd)
 	/* Let epoll deal with multiple deletes of the same fd */
 	if (rc == -1 && errno != ENOENT) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() Failed to del fd to epoll: %s (%d)",
 			__func__, strerror(rc), rc);
 		return rc;
@@ -704,7 +704,7 @@ rpc_rdma_stats_add(RDMAXPRT *rdma_xprt)
 	rdma_xprt->stats_sock = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (rdma_xprt->stats_sock == -1) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() socket on stats socket failed, quitting thread: %s (%d)",
 			__func__, strerror(rc), rc);
 		return rc;
@@ -721,7 +721,7 @@ rpc_rdma_stats_add(RDMAXPRT *rdma_xprt)
 						sizeof(sockaddr));
 	if (rc == -1) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() bind on stats socket failed, quitting thread: %s (%d)",
 			__func__, strerror(rc), rc);
 		return rc;
@@ -730,7 +730,7 @@ rpc_rdma_stats_add(RDMAXPRT *rdma_xprt)
 	rc = listen(rdma_xprt->stats_sock, 5);
 	if (rc == -1) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() listen on stats socket failed, quitting thread: %s (%d)",
 			__func__, strerror(rc), rc);
 		return rc;
@@ -781,7 +781,7 @@ rpc_rdma_stats_thread(void *arg)
 				continue;
 
 			rc = errno;
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() epoll_wait failed: %s (%d)",
 				__func__, strerror(rc), rc);
 			break;
@@ -790,7 +790,7 @@ rpc_rdma_stats_thread(void *arg)
 		for (i = 0; i < n; ++i) {
 			rdma_xprt = (RDMAXPRT*)epoll_events[i].data.ptr;
 			if (!rdma_xprt) {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 					"%s() no rdma_xprt: got an event on a fd that should have been removed!",
 					__func__);
 				continue;
@@ -808,7 +808,7 @@ rpc_rdma_stats_thread(void *arg)
 				if (errno == EINTR) {
 					continue;
 				} else {
-					__warnx(TIRPC_DEBUG_FLAG_ERROR,
+					__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 						"%s() accept on stats socket failed: %s (%d)",
 						__func__, strerror(errno), errno);
 					continue;
@@ -866,14 +866,14 @@ rpc_rdma_cq_event_handler(RDMAXPRT *rdma_xprt, int expected_poll_count)
 	if (rc) {
 		rc = errno;
 		if (rc != EAGAIN) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() ibv_get_cq_event failed: %d.",
 				__func__, rc);
 		}
 		return rc;
 	}
 	if (ev_cq != rdma_xprt->cq) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() Unknown cq %p",
 			__func__, ev_cq);
 		ibv_ack_cq_events(ev_cq, 1);
@@ -882,7 +882,7 @@ rpc_rdma_cq_event_handler(RDMAXPRT *rdma_xprt, int expected_poll_count)
 
 	rc = ibv_req_notify_cq(rdma_xprt->cq, 0);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() ibv_req_notify_cq failed: %d.",
 			__func__, rc);
 		return rc;
@@ -904,7 +904,7 @@ rpc_rdma_cq_event_handler(RDMAXPRT *rdma_xprt, int expected_poll_count)
 			}
 
 			if (rdma_xprt->bad_send_wr) {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 					"%s() Something was bad on that send",
 					__func__);
 				rc = -1;
@@ -933,7 +933,7 @@ rpc_rdma_cq_event_handler(RDMAXPRT *rdma_xprt, int expected_poll_count)
 						break;
 				}
 
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 					"%s() cq completion status: %s (%d) rdma_xprt state %x opcode %d cbc %p "
 					"inline %d",
 					__func__, ibv_wc_status_str(wc[i].status), wc[i].status,
@@ -1015,7 +1015,7 @@ rpc_rdma_cq_event_handler(RDMAXPRT *rdma_xprt, int expected_poll_count)
 					data->v.vio_tail = data->v.vio_head + len;
 					VALGRIND_MAKE_MEM_DEFINED(data->v.vio_head, ioquv_length(data));
 				} else if (len) {
-					__warnx(TIRPC_DEBUG_FLAG_ERROR,
+					__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 						"%s() ERROR %d leftover bytes?",
 						__func__, len);
 				}
@@ -1030,7 +1030,7 @@ rpc_rdma_cq_event_handler(RDMAXPRT *rdma_xprt, int expected_poll_count)
 				break;
 
 			default:
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 					"%s() unknown opcode: %d",
 					__func__, wc[i].opcode);
 				rc = EINVAL;
@@ -1039,7 +1039,7 @@ rpc_rdma_cq_event_handler(RDMAXPRT *rdma_xprt, int expected_poll_count)
 	}
 
 	if (npoll < 0) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] ibv_poll_cq failed: %s (%d)",
 			__func__, rdma_xprt, rdma_xprt->state, strerror(-npoll), -npoll);
 		rc = -npoll;
@@ -1142,7 +1142,7 @@ rpc_rdma_cq_thread(void *arg)
 				continue;
 
 			rc = errno;
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() epoll_wait failed: %s (%d)",
 				__func__, strerror(rc), rc);
 			break;
@@ -1151,7 +1151,7 @@ rpc_rdma_cq_thread(void *arg)
 		for (i = 0; i < n; ++i) {
 			rdma_xprt = (RDMAXPRT*)epoll_events[i].data.ptr;
 			if (!rdma_xprt) {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 					"%s() got an event on a fd that should have "
 					"been removed! (no rdma_xprt)",
 					__func__);
@@ -1163,7 +1163,7 @@ rpc_rdma_cq_thread(void *arg)
 
 			if (epoll_events[i].events == EPOLLERR
 			 || epoll_events[i].events == EPOLLHUP) {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 					"%s() epoll error or hup (%d) rdma_xprt %p",
 					__func__, epoll_events[i].events, rdma_xprt);
 
@@ -1212,12 +1212,12 @@ rpc_rdma_cm_event_handler(RDMAXPRT *ep_rdma_xprt, struct rdma_cm_event *event)
 		__func__, ep_rdma_xprt, rdma_event_str(event->event));
 
 	if (rdma_xprt->bad_recv_wr) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() Something was bad on that recv",
 			__func__);
 	}
 	if (rdma_xprt->bad_send_wr) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() Something was bad on that send",
 			__func__);
 	}
@@ -1256,7 +1256,7 @@ rpc_rdma_cm_event_handler(RDMAXPRT *ep_rdma_xprt, struct rdma_cm_event *event)
 			rc = rpc_rdma_fd_add(rdma_xprt, cq_fd,
 				     rpc_rdma_state.cq_epollfd[cq_thread_index]);
 			if (rc) {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 					"%s:%u ERROR (return)",
 					__func__, __LINE__);
 			}
@@ -1278,7 +1278,7 @@ rpc_rdma_cm_event_handler(RDMAXPRT *ep_rdma_xprt, struct rdma_cm_event *event)
 	case RDMA_CM_EVENT_CONNECT_ERROR:
 	case RDMA_CM_EVENT_UNREACHABLE:
 	case RDMA_CM_EVENT_REJECTED:
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] cma event %s, error %d",
 			__func__, rdma_xprt, rdma_xprt->state,
 			rdma_event_str(event->event), event->status);
@@ -1315,7 +1315,7 @@ rpc_rdma_cm_event_handler(RDMAXPRT *ep_rdma_xprt, struct rdma_cm_event *event)
 		break;
 
 	default:
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] unhandled event: %s, ignoring %d\n",
 			__func__, rdma_xprt, rdma_xprt->state,
 			rdma_event_str(event->event), event->event);
@@ -1352,7 +1352,7 @@ rpc_rdma_cm_thread(void *nullarg)
 				continue;
 
 			rc = errno;
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() %p[%u] epoll_wait failed: %s (%d)",
 				__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 			break;
@@ -1362,7 +1362,7 @@ rpc_rdma_cm_thread(void *nullarg)
 			/* data.ptr is in rpc_rdma_fd_add */
 			rdma_xprt = (RDMAXPRT*)epoll_events[i].data.ptr;
 			if (!rdma_xprt) {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 					"%s() got an event on a fd that should have been removed! (no rdma_xprt)",
 					__func__);
 				continue;
@@ -1370,7 +1370,7 @@ rpc_rdma_cm_thread(void *nullarg)
 
 			if (epoll_events[i].events == EPOLLERR
 			 || epoll_events[i].events == EPOLLHUP) {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 					"%s() epoll error or hup (%d) rdma_xprt %p",
 					__func__, epoll_events[i].events, rdma_xprt);
 				SVC_DESTROY(&rdma_xprt->sm_dr.xprt);
@@ -1378,7 +1378,7 @@ rpc_rdma_cm_thread(void *nullarg)
 			}
 
 			if (rdma_xprt->sm_dr.xprt.xp_flags & SVC_XPRT_FLAG_DESTROYED) {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 					"%s() got a cm event on a closed rdma_xprt %p",
 					__func__, rdma_xprt);
 			}
@@ -1388,7 +1388,7 @@ rpc_rdma_cm_thread(void *nullarg)
 			rc = rdma_get_cm_event(rdma_xprt->event_channel, &event);
 			if (rc) {
 				rc = errno;
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 					"%s() rdma_get_cm_event failed: %d rdma_xprt %p",
 					__func__, rc, rdma_xprt);
 				SVC_DESTROY(&rdma_xprt->sm_dr.xprt);
@@ -1427,13 +1427,13 @@ rpc_rdma_cm_event_handler_inline(RDMAXPRT *rdma_xprt, int expected_event)
 	rc = rdma_get_cm_event(rdma_xprt->event_channel, &event);
 	if (rc) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: rdma get event failed xprt %p "
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR, "%s: rdma get event failed xprt %p "
 			"err %d", __func__, rdma_xprt, rc);
 		goto out;
 	}
 
 	if (event->event != expected_event) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: unexpected event %d, expected %d "
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR, "%s: unexpected event %d, expected %d "
 			"xprt %s", __func__, event->event, expected_event);
 	}
 
@@ -1698,7 +1698,7 @@ rpc_rdma_allocate(const struct rpc_rdma_attr *xa)
 	int rc;
 
 	if (!xa) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() Invalid argument",
 			__func__);
 		return NULL;
@@ -1726,7 +1726,7 @@ rpc_rdma_allocate(const struct rpc_rdma_attr *xa)
 
 	rc = mutex_init(&rdma_xprt->cm_lock, NULL);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() mutex_init failed: %s (%d)",
 			__func__, strerror(rc), rc);
 		goto cm_lock;
@@ -1734,7 +1734,7 @@ rpc_rdma_allocate(const struct rpc_rdma_attr *xa)
 
 	rc = cond_init(&rdma_xprt->cm_cond, NULL, NULL);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() cond_init failed: %s (%d)",
 			__func__, strerror(rc), rc);
 		goto cm_cond;
@@ -1770,7 +1770,7 @@ rpc_rdma_ncreatef(const struct rpc_rdma_attr *xa,
 	int rc;
 
 	if (xa->backlog > 4096) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() backlog (%u) much too large",
 			__func__, xa->backlog);
 		return NULL;
@@ -1778,7 +1778,7 @@ rpc_rdma_ncreatef(const struct rpc_rdma_attr *xa,
 
 	rdma_xprt = rpc_rdma_allocate(xa);
 	if (!rdma_xprt) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s:%u ERROR (return)",
 			__func__, __LINE__);
 		return NULL;
@@ -1791,7 +1791,7 @@ rpc_rdma_ncreatef(const struct rpc_rdma_attr *xa,
 	rdma_xprt->event_channel = rdma_create_event_channel();
 	if (!rdma_xprt->event_channel) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() create_event_channel failed: %s (%d)",
 			__func__, strerror(rc), rc);
 		goto failure;
@@ -1801,7 +1801,7 @@ rpc_rdma_ncreatef(const struct rpc_rdma_attr *xa,
 			    rdma_xprt->conn_type);
 	if (rc) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() create_id failed: %s (%d)",
 			__func__, strerror(rc), rc);
 		goto failure;
@@ -1811,7 +1811,7 @@ rpc_rdma_ncreatef(const struct rpc_rdma_attr *xa,
 	if (!svc_work_pool.params.thrd_max) {
 		pthread_mutex_unlock(&svc_work_pool.pqh.qmutex);
 
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() svc_work_pool already shutdown",
 			__func__);
 		goto failure;
@@ -1835,7 +1835,7 @@ rpc_rdma_ncreatef(const struct rpc_rdma_attr *xa,
 
 	rc = rpc_rdma_bind_server(rdma_xprt);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() NFS/RDMA dispatcher could not bind engine",
 			__func__);
 		goto failure;
@@ -1883,7 +1883,7 @@ rpc_rdma_create_qp(RDMAXPRT *rdma_xprt, struct rdma_cm_id *cm_id)
 	rc = rdma_create_qp(cm_id, rdma_xprt->pd->pd, &qp_attr);
 	if (rc) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] rdma_create_qp failed: %s (%d)",
 			__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 		return rc;
@@ -1913,7 +1913,7 @@ rpc_rdma_setup_stuff_client(RDMAXPRT *rdma_xprt)
 	rdma_xprt->comp_channel = ibv_create_comp_channel(rdma_xprt->cm_id->verbs);
 	if (!rdma_xprt->comp_channel) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: create comp channel failed xprt %p "
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR, "%s: create comp channel failed xprt %p "
 			"err %d", __func__, rdma_xprt, rc);
 		goto out;
 	}
@@ -1922,7 +1922,7 @@ rpc_rdma_setup_stuff_client(RDMAXPRT *rdma_xprt)
 	    rdma_xprt, rdma_xprt->comp_channel, 0);
 	if (!rdma_xprt->cq) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: create cq failed xprt %p err %d",
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR, "%s: create cq failed xprt %p err %d",
 			__func__, rdma_xprt, rc);
 		goto out;
 	}
@@ -1930,7 +1930,7 @@ rpc_rdma_setup_stuff_client(RDMAXPRT *rdma_xprt)
 	rc = ibv_req_notify_cq(rdma_xprt->cq, 0);
 	if (rc) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: notify cq failed xprt %p err %d",
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR, "%s: notify cq failed xprt %p err %d",
 			__func__, rdma_xprt, rc);
 		goto out;
 	}
@@ -1938,7 +1938,7 @@ rpc_rdma_setup_stuff_client(RDMAXPRT *rdma_xprt)
 	rc = rpc_rdma_create_qp(rdma_xprt, rdma_xprt->cm_id);
 	if (rc) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: create qp failed xprt %p err %d",
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR, "%s: create qp failed xprt %p err %d",
 			__func__, rdma_xprt, rc);
 	}
 
@@ -1967,7 +1967,7 @@ rpc_rdma_setup_stuff(RDMAXPRT *rdma_xprt)
 	 */
 	rc = rpc_rdma_thread_create_epoll_cq(rpc_rdma_cq_thread);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s:%u ERROR (return)",
 			__func__, __LINE__);
 		return rc;
@@ -1976,7 +1976,7 @@ rpc_rdma_setup_stuff(RDMAXPRT *rdma_xprt)
 	if (rdma_xprt->xa->statistics_prefix != NULL
 	 && (rc = rpc_rdma_thread_create_epoll(&rpc_rdma_state.stats_thread_id,
 		rpc_rdma_stats_thread, rdma_xprt, &rpc_rdma_state.stats_epollfd))) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s:%u ERROR (return)",
 			__func__, __LINE__);
 		return rc;
@@ -1985,7 +1985,7 @@ rpc_rdma_setup_stuff(RDMAXPRT *rdma_xprt)
 	rdma_xprt->comp_channel = ibv_create_comp_channel(rdma_xprt->cm_id->verbs);
 	if (!rdma_xprt->comp_channel) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] ibv_create_comp_channel failed: %s (%d)",
 			__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 		return rc;
@@ -1996,7 +1996,7 @@ rpc_rdma_setup_stuff(RDMAXPRT *rdma_xprt)
 				rdma_xprt, rdma_xprt->comp_channel, 0);
 	if (!rdma_xprt->cq) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] ibv_create_cq failed: %s (%d)",
 			__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 		return rc;
@@ -2004,7 +2004,7 @@ rpc_rdma_setup_stuff(RDMAXPRT *rdma_xprt)
 
 	rc = ibv_req_notify_cq(rdma_xprt->cq, 0);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] ibv_req_notify_cq failed: %s (%d)",
 			__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 		return rc;
@@ -2012,7 +2012,7 @@ rpc_rdma_setup_stuff(RDMAXPRT *rdma_xprt)
 
 	rc = rpc_rdma_create_qp(rdma_xprt, rdma_xprt->cm_id);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s:%u ERROR (return)",
 			__func__, __LINE__);
 		return rc;
@@ -2077,7 +2077,7 @@ rpc_rdma_setup_cbq(RDMAXPRT *rdma_xprt,
 		__func__, rdma_xprt, depth, sge);
 
 	if (ioqh->qsize) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() contexts already allocated",
 			__func__);
 		return EINVAL;
@@ -2124,21 +2124,21 @@ rpc_rdma_bind_server(RDMAXPRT *rdma_xprt)
 	int rc;
 
 	if (!rdma_xprt) {
-                __warnx(TIRPC_DEBUG_FLAG_ERROR,
+                __warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
                         "%s() rdma_xprt is NULL",
                         __func__);
                 return EINVAL;
         }
 
 	if (rdma_xprt->state != RDMAXS_INITIAL) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] must be initialized first!",
 			__func__, rdma_xprt, rdma_xprt->state);
 		return EINVAL;
 	}
 
 	if (rdma_xprt->server <= 0) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() Must be on server side to call this function",
 			__func__);
 		return EINVAL;
@@ -2151,7 +2151,7 @@ rpc_rdma_bind_server(RDMAXPRT *rdma_xprt)
 	rc = rdma_getaddrinfo(rdma_xprt->xa->node, rdma_xprt->xa->port, &hints, &res);
 	if (rc) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] rdma_getaddrinfo: %s (%d)",
 			__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 		return rc;
@@ -2160,7 +2160,7 @@ rpc_rdma_bind_server(RDMAXPRT *rdma_xprt)
 	rc = rdma_bind_addr(rdma_xprt->cm_id, res->ai_src_addr);
 	if (rc) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] rdma_bind_addr: %s (%d)",
 			__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 		return rc;
@@ -2170,7 +2170,7 @@ rpc_rdma_bind_server(RDMAXPRT *rdma_xprt)
 	/* at this point, the cm_id->verbs aren't filled */
 	rc = rpc_rdma_pd_by_verbs(rdma_xprt);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] register pd failed: %s (%d)",
 			__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 		return rc;
@@ -2179,7 +2179,7 @@ rpc_rdma_bind_server(RDMAXPRT *rdma_xprt)
 	rc = rdma_listen(rdma_xprt->cm_id, rdma_xprt->xa->backlog);
 	if (rc) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] rdma_listen failed: %s (%d)",
 			__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 		return rc;
@@ -2188,7 +2188,7 @@ rpc_rdma_bind_server(RDMAXPRT *rdma_xprt)
 	rdma_xprt->state = RDMAXS_LISTENING;
 
 	/* Log at EVENT level that RDMA listener is up */
-	__warnx(TIRPC_DEBUG_FLAG_EVENT,
+	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
 		"%s() RDMA: NFS/RDMA server is now listening on node %s port %s (backlog=%d sq_depth=%d rq_depth=%d)",
 		__func__,
 		rdma_xprt->xa->node ? rdma_xprt->xa->node : "*",
@@ -2202,7 +2202,7 @@ rpc_rdma_bind_server(RDMAXPRT *rdma_xprt)
 	rc = rpc_rdma_thread_create_epoll(&rpc_rdma_state.cm_thread_id,
 		rpc_rdma_cm_thread, rdma_xprt, &rpc_rdma_state.cm_epollfd);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] rpc_rdma_thread_create_epoll failed: %s (%d)",
 			__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 		(void) atomic_dec_int32_t(&rpc_rdma_state.run_count);
@@ -2228,7 +2228,7 @@ rpc_rdma_clone(RDMAXPRT *l_rdma_xprt, struct rdma_cm_id *cm_id)
 	int rc;
 
 	if (!rdma_xprt) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s:%u ERROR (return)",
 			__func__, __LINE__);
 		return NULL;
@@ -2243,7 +2243,7 @@ rpc_rdma_clone(RDMAXPRT *l_rdma_xprt, struct rdma_cm_id *cm_id)
 
 	rc = rpc_rdma_pd_get(rdma_xprt);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s:%u ERROR (return)",
 			__func__, __LINE__);
 		goto failure;
@@ -2259,7 +2259,7 @@ rpc_rdma_clone(RDMAXPRT *l_rdma_xprt, struct rdma_cm_id *cm_id)
 				ibv_create_srq(rdma_xprt->pd->pd, &srq_attr);
 			if (!rdma_xprt->pd->srq) {
 				rc = errno;
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 					"%s() ibv_create_srq failed: %s (%d)",
 					__func__, strerror(rc), rc);
 				goto failure;
@@ -2271,7 +2271,7 @@ rpc_rdma_clone(RDMAXPRT *l_rdma_xprt, struct rdma_cm_id *cm_id)
 						rdma_xprt->xa->rq_depth,
 						rdma_xprt->xa->max_recv_sge);
 			if (rc) {
-				__warnx(TIRPC_DEBUG_FLAG_ERROR,
+				__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 					"%s:%u ERROR (return)",
 					__func__, __LINE__);
 				goto failure;
@@ -2283,7 +2283,7 @@ rpc_rdma_clone(RDMAXPRT *l_rdma_xprt, struct rdma_cm_id *cm_id)
 					rdma_xprt->xa->sq_depth,
 					rdma_xprt->xa->credits);
 		if (rc) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s:%u ERROR (return)",
 				__func__, __LINE__);
 			goto failure;
@@ -2293,7 +2293,7 @@ rpc_rdma_clone(RDMAXPRT *l_rdma_xprt, struct rdma_cm_id *cm_id)
 					MAX_CBC_ALLOCATION(rdma_xprt->xa),
 					rdma_xprt->xa->credits);
 		if (rc) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s:%u ERROR (return)",
 				__func__, __LINE__);
 			goto failure;
@@ -2305,7 +2305,7 @@ rpc_rdma_clone(RDMAXPRT *l_rdma_xprt, struct rdma_cm_id *cm_id)
 
 	rc = rpc_rdma_setup_stuff(rdma_xprt);
 	if (rc) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s:%u ERROR (return)",
 			__func__, __LINE__);
 		goto failure;
@@ -2334,14 +2334,14 @@ rpc_rdma_accept_finalize(RDMAXPRT *rdma_xprt)
 	int rc;
 
 	if (!rdma_xprt) {
-                __warnx(TIRPC_DEBUG_FLAG_ERROR,
+                __warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
                         "%s() rdma_xprt is NULL",
                         __func__);
                 return EINVAL;
         }
 
 	if (rdma_xprt->state != RDMAXS_CONNECT_REQUEST) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] isn't from a connection request?",
 			__func__, rdma_xprt, rdma_xprt->state);
 		return EINVAL;
@@ -2357,7 +2357,7 @@ rpc_rdma_accept_finalize(RDMAXPRT *rdma_xprt)
 	rc = rdma_accept(rdma_xprt->cm_id, &conn_param);
 	if (rc) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] rdma_accept failed: %s (%d)",
 			__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 	}
@@ -2386,11 +2386,11 @@ rpc_rdma_accept_timedwait(RDMAXPRT *l_rdma_xprt, struct timespec *abstime)
 
 	if (!l_rdma_xprt || l_rdma_xprt->state != RDMAXS_LISTENING) {
 		if (!l_rdma_xprt) {
-                        __warnx(TIRPC_DEBUG_FLAG_ERROR,
+                        __warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
                                 "%s() listening (parent) transport is NULL",
                                 __func__);
                 } else {
-                        __warnx(TIRPC_DEBUG_FLAG_ERROR,
+                        __warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
                                 "%s() %p[%u] isn't listening (after bind_server)?",
                                 __func__, l_rdma_xprt, l_rdma_xprt->state);
                 }
@@ -2400,7 +2400,7 @@ rpc_rdma_accept_timedwait(RDMAXPRT *l_rdma_xprt, struct timespec *abstime)
 	cm_id = rpc_rdma_state.c_r.id_queue[0];
 
 	if (!cm_id) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() missing cm_id",
 			__func__);
 		return (NULL);
@@ -2414,7 +2414,7 @@ rpc_rdma_accept_wait(RDMAXPRT *l_rdma_xprt, int msleep)
 {
 	struct timespec ts;
 
-	__warnx(TIRPC_DEBUG_FLAG_ERROR,
+	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 		"%s() accept wait msleep %d",
 		__func__, msleep);
 	if (msleep == 0)
@@ -2456,7 +2456,7 @@ rpc_rdma_bind_client(RDMAXPRT *rdma_xprt)
 					&hints, &res);
 		if (rc) {
 			rc = errno;
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() %p[%u] rdma_getaddrinfo: %s (%d) ip %s port %d",
 				__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc,
 				rdma_xprt->sm_dr.xprt.xp_ip, rdma_xprt->sm_dr.xprt.xp_port);
@@ -2468,7 +2468,7 @@ rpc_rdma_bind_client(RDMAXPRT *rdma_xprt)
 					5000);
 		if (rc) {
 			rc = errno;
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() %p[%u] rdma_resolve_addr failed: %s (%d)",
 				__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 			break;
@@ -2477,7 +2477,7 @@ rpc_rdma_bind_client(RDMAXPRT *rdma_xprt)
 
 		rc = rpc_rdma_cm_event_handler_inline(rdma_xprt, RDMA_CM_EVENT_ADDR_RESOLVED);
 		if (rc) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() Could not resolve addr",
 				__func__);
 			rc = EINVAL;
@@ -2488,7 +2488,7 @@ rpc_rdma_bind_client(RDMAXPRT *rdma_xprt)
 					5000);
 		if (rc) {
 			rdma_xprt->state = RDMAXS_ERROR;
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() %p[%u] rdma_resolve_route failed: %s (%d)",
 				__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 			break;
@@ -2496,7 +2496,7 @@ rpc_rdma_bind_client(RDMAXPRT *rdma_xprt)
 
 		rc = rpc_rdma_cm_event_handler_inline(rdma_xprt, RDMA_CM_EVENT_ROUTE_RESOLVED);
 		if (rc) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 				"%s() Could not resolve route",
 				__func__);
 			rc = EINVAL;
@@ -2523,14 +2523,14 @@ rpc_rdma_connect_finalize(RDMAXPRT *rdma_xprt)
 	int rc;
 
 	if (!rdma_xprt) {
-                __warnx(TIRPC_DEBUG_FLAG_ERROR,
+                __warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
                         "%s() rdma_xprt is NULL",
                         __func__);
                 return EINVAL;
         }
 
 	if (rdma_xprt->state != RDMAXS_ROUTE_RESOLVED) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] isn't half-connected?",
 			__func__, rdma_xprt, rdma_xprt->state);
 		return EINVAL;
@@ -2545,7 +2545,7 @@ rpc_rdma_connect_finalize(RDMAXPRT *rdma_xprt)
 	rc = rdma_connect(rdma_xprt->cm_id, &conn_param);
 	if (rc) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] rdma_connect failed: %s (%d)",
 			__func__, rdma_xprt, rdma_xprt->state, strerror(rc), rc);
 	}
@@ -2553,7 +2553,7 @@ rpc_rdma_connect_finalize(RDMAXPRT *rdma_xprt)
 	rc = rpc_rdma_cm_event_handler_inline(rdma_xprt, RDMA_CM_EVENT_ESTABLISHED);
 	if (rc) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: conect failed xprt %p err %d",
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR, "%s: conect failed xprt %p err %d",
 			__func__, rdma_xprt, rc);
 	}
 
@@ -2569,7 +2569,7 @@ rpc_rdma_connect_prepare(RDMAXPRT *rdma_xprt)
 	rdma_xprt->event_channel = rdma_create_event_channel();
 	if (!rdma_xprt->event_channel) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: create event channel failed "
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR, "%s: create event channel failed "
 			"ip %s err %d", __func__, rdma_xprt->sm_dr.xprt.xp_ip, rc);
 		goto out;
 	}
@@ -2578,7 +2578,7 @@ rpc_rdma_connect_prepare(RDMAXPRT *rdma_xprt)
 	    rdma_xprt->conn_type);
 	if (rc) {
 		rc = errno;
-		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s: create id failed ip %s err %d",
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR, "%s: create id failed ip %s err %d",
 			__func__, rdma_xprt->sm_dr.xprt.xp_ip, rc);
 		goto out;
 	}
@@ -2599,21 +2599,21 @@ rpc_rdma_connect(RDMAXPRT *rdma_xprt)
 	int rc;
 
 	if (!rdma_xprt) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
                         "%s() rdma_xprt is NULL",
                         __func__);
                 return EINVAL;
 	}
 
 	if (rdma_xprt->state != RDMAXS_INITIAL) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() %p[%u] must be initialized first!",
 			__func__, rdma_xprt, rdma_xprt->state);
 		return EINVAL;
 	}
 
 	if (rdma_xprt->server != RDMAX_CLIENT) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s() only called from client side!",
 			__func__);
 		return EINVAL;

--- a/src/svc_rdma.c
+++ b/src/svc_rdma.c
@@ -74,7 +74,7 @@ svc_rdma_rendezvous(SVCXPRT *xprt)
 					           __svc_params->idle_timeout);
 
 	if (!rdma_xprt) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s:%u ERROR (return)",
 			__func__, __LINE__);
 		return (XPRT_DIED);
@@ -135,7 +135,7 @@ svc_rdma_rendezvous(SVCXPRT *xprt)
 
 	int retval = xprt->xp_dispatch.rendezvous_cb(&rdma_xprt->sm_dr.xprt);
 	if (retval) {
-		__warnx(TIRPC_DEBUG_FLAG_WARN,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_WARN,
 			"%s:%u ERROR (return %d)",
 			__func__, __LINE__, retval);
 		SVC_DESTROY(&rdma_xprt->sm_dr.xprt);
@@ -148,7 +148,7 @@ svc_rdma_rendezvous(SVCXPRT *xprt)
 	rdma_xprt->sm_dr.xprt.xp_fd = rdma_xprt->event_channel->fd;
 
 	if (svc_rdma_add_xprt_fd(&rdma_xprt->sm_dr.xprt)) {
-		__warnx(TIRPC_DEBUG_FLAG_WARN,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_WARN,
 			"%s:%u svc_rdma_add_xprt failed (xprt %p)",
 			__func__, __LINE__, &rdma_xprt->sm_dr.xprt);
 		SVC_DESTROY(&rdma_xprt->sm_dr.xprt);
@@ -158,7 +158,7 @@ svc_rdma_rendezvous(SVCXPRT *xprt)
 	atomic_set_uint16_t_bits(&rdma_xprt->sm_dr.xprt.xp_flags,
 	    SVC_XPRT_FLAG_READY);
 
-	__warnx(TIRPC_DEBUG_FLAG_EVENT,
+	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
 		"%s:%u New RDMA client connected xprt %p, xp_fd %d, "
 		"qp_num %d, xp_fd %d is_rdma_enabled %d to local port %d "
 		"from remote port %d ref %d epoll %#04x remote ip %s",
@@ -206,7 +206,7 @@ svc_rdma_decode(struct svc_req *req)
 		__func__, req->rq_xprt, req, cbc, xdrs);
 
 	if (!xdr_rdma_svc_recv(cbc, 0)){
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s: xdr_rdma_svc_recv failed",
 			__func__);
 		return (XPRT_DIED);
@@ -222,7 +222,7 @@ svc_rdma_decode(struct svc_req *req)
 	rpc_msg_init(&req->rq_msg);
 
 	if (!xdr_dplx_decode(xdrs, &req->rq_msg)) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s: xdr_dplx_decode failed",
 			__func__);
 		return (XPRT_DIED);
@@ -240,7 +240,7 @@ svc_rdma_decode(struct svc_req *req)
 		return XPRT_IDLE;
 	}
 
-	__warnx(TIRPC_DEBUG_FLAG_WARN,
+	__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_WARN,
 		"%s: %p fd %d failed direction %" PRIu32
 		" (will set dead)",
 		__func__, req->rq_xprt, req->rq_xprt->xp_fd,
@@ -273,7 +273,7 @@ svc_rdma_reply(struct svc_req *req)
 	xdrs = cbc->sendq.xdrs;
 
 	if (!xdr_rdma_svc_reply(cbc, 0, req->data_chunk_length ? 1 : 0)){
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s: xdr_rdma_svc_reply failed (will set dead)",
 			__func__);
 		return (XPRT_DIED);
@@ -282,7 +282,7 @@ svc_rdma_reply(struct svc_req *req)
 	xdrs->x_op = XDR_ENCODE;
 
 	if (!xdr_reply_encode(xdrs, &req->rq_msg)) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s: xdr_reply_encode failed (will set dead)",
 			__func__);
 		return (XPRT_DIED);
@@ -293,7 +293,7 @@ svc_rdma_reply(struct svc_req *req)
 	 && req->rq_msg.rm_reply.rp_acpt.ar_stat == SUCCESS
 	 && req->rq_auth
 	 && !SVCAUTH_WRAP(req, xdrs)) {
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s: SVCAUTH_WRAP failed (will set dead)",
 			__func__);
 		return (XPRT_DIED);
@@ -301,7 +301,7 @@ svc_rdma_reply(struct svc_req *req)
 	xdr_tail_update(xdrs);
 
 	if (!xdr_rdma_svc_flushout(cbc, req->data_chunk_length ? 1 : 0)){
-		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			"%s: flushout failed (will set dead)",
 			__func__);
 		return (XPRT_DIED);
@@ -329,7 +329,7 @@ svc_rdma_unlink(SVCXPRT *xprt, u_int flags, const char *tag, const int line)
 		attr.qp_state = IBV_QPS_RESET;
 
 		if (ibv_modify_qp(rdma_xprt->qp, &attr, IBV_QP_STATE)) {
-			__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_ERROR,
 			    "%s() modify_qp failed rdma_xprt %p",
 			    __func__, rdma_xprt);
 		}


### PR DESCRIPTION
Use RDMA-specific debug flags (TIRPC_DEBUG_FLAG_RPC_RDMA, etc.) in RDMA code paths to improve log filtering and debugging.

For error paths, combine TIRPC_DEBUG_FLAG_ERROR with RDMA flags instead of replacing them, so that messages retain their severity while also being categorized under RDMA for easier isolation of RDMA-related issues.