### PR TITLE
RDMA: Fix rpcbind registration by initializing xp_local

### DIFF
--- a/src/rpc_generic.c
+++ b/src/rpc_generic.c
@@ -207,6 +207,10 @@ static const struct netid_af na_cvt[] = {
 #ifdef RPC_VSOCK
 	{"vsock", AF_VSOCK, PF_VSOCK},
 #endif /* VSOCK */
+#ifdef USE_RPC_RDMA
+	{"rdma", AF_INET, 0},	/* RDMA over IPv4 */
+	{"rdma6", AF_INET6, 0},	/* RDMA over IPv6 */
+#endif
 	{"local", AF_LOCAL, 0}
 };
 

--- a/src/rpc_rdma.c
+++ b/src/rpc_rdma.c
@@ -1841,6 +1841,34 @@ rpc_rdma_ncreatef(const struct rpc_rdma_attr *xa,
 		goto failure;
 	}
 
+	/* Initialize xp_local for rpcbind registration */
+	struct sockaddr_storage *ss =
+		(struct sockaddr_storage *)rdma_get_local_addr(rdma_xprt->cm_id);
+	if (ss) {
+		socklen_t len;
+
+		__rpc_address_setup(&rdma_xprt->sm_dr.xprt.xp_local);
+
+		/* Determine actual address length based on family */
+		if (ss->ss_family == AF_INET)
+			len = sizeof(struct sockaddr_in);
+		else if (ss->ss_family == AF_INET6)
+			len = sizeof(struct sockaddr_in6);
+		else
+			len = sizeof(struct sockaddr_storage);
+
+		memcpy(rdma_xprt->sm_dr.xprt.xp_local.nb.buf, ss, len);
+		rdma_xprt->sm_dr.xprt.xp_local.nb.len = len;
+
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA,
+			"%s() Initialized xp_local: family=%d len=%d",
+			__func__, ss->ss_family, len);
+	} else {
+		__warnx(TIRPC_DEBUG_FLAG_RPC_RDMA | TIRPC_DEBUG_FLAG_WARN,
+			"%s() Could not get local address for xp_local initialization",
+			__func__);
+	}
+
 	__warnx(TIRPC_DEBUG_FLAG_EVENT | TIRPC_DEBUG_FLAG_RPC_RDMA,
 		"%s() RDMA: NFS/RDMA transport ready on port %s recvsz=%llu sendsz=%llu xprt=%p",
 		__func__, xa->port,

--- a/src/rpcb_clnt.c
+++ b/src/rpcb_clnt.c
@@ -459,13 +459,18 @@ rpcb_set(rpcprog_t program, rpcvers_t version, const struct netconfig *nconf,
 	/* convert to universal */
 	/*LINTED const castaway */
 	parms.r_addr =
-	    taddr2uaddr((struct netconfig *)nconf, (struct netbuf *)address);
+		taddr2uaddr((struct netconfig *)nconf,
+			    (struct netbuf *)address);
 	if (!parms.r_addr) {
 		CLNT_DESTROY(client);
-		__warnx(TIRPC_DEBUG_FLAG_WARN, "%s: %s",
-			__func__, clnt_sperrno(RPC_N2AXLATEFAILURE));
+		__warnx(TIRPC_DEBUG_FLAG_WARN,
+			"%s: taddr2uaddr failed for netid=%s: %s",
+			__func__, nconf->nc_netid,
+			clnt_sperrno(RPC_N2AXLATEFAILURE));
 		return (false);	/* no universal address */
 	}
+	__warnx(TIRPC_DEBUG_FLAG_CLNT_RPCB,
+		"%s: Universal address: %s", __func__, parms.r_addr);
 	parms.r_prog = program;
 	parms.r_vers = version;
 	parms.r_netid = nconf->nc_netid;

--- a/src/svc.c
+++ b/src/svc.c
@@ -375,14 +375,28 @@ svc_reg(SVCXPRT *xprt, const rpcprog_t prog, const rpcvers_t vers,
 	if ((xprt->xp_netid == NULL) && (flag == 1) && netid)
 		((SVCXPRT *) xprt)->xp_netid = mem_strdup(netid);
 
- rpcb_it:
+rpcb_it:
 	rwlock_unlock(&svc_lock);
 	/* now register the information with the local binder service */
 	if (nconf && ((xprt->xp_flags & SVC_XPRT_FLAG_NO_SET) == 0)) {
+		__warnx(TIRPC_DEBUG_FLAG_SVC,
+			"%s: Registering prog=%u vers=%u netid=%s",
+			__func__, (unsigned)prog, (unsigned)vers,
+			nconf->nc_netid);
+
+		if (!xprt->xp_local.nb.buf || xprt->xp_local.nb.len == 0) {
+			__warnx(TIRPC_DEBUG_FLAG_SVC | TIRPC_DEBUG_FLAG_WARN,
+				"%s: xp_local.nb is empty or invalid",
+				__func__);
+		}
+
 		/*LINTED const castaway */
-		dummy =
-		    rpcb_set(prog, vers, (struct netconfig *)nconf,
-			     &((SVCXPRT *) xprt)->xp_local.nb);
+		dummy = rpcb_set(prog, vers, (struct netconfig *)nconf,
+				 &((SVCXPRT *)xprt)->xp_local.nb);
+
+		__warnx(TIRPC_DEBUG_FLAG_SVC,
+			"%s: rpcb_set returned %s",
+			__func__, dummy ? "TRUE" : "FALSE");
 		return (dummy);
 	}
 	return (true);


### PR DESCRIPTION
Initialize xp_local field for RDMA listening transports to enable proper rpcbind registration. Without this, RDMA services fail to register.