### PR TITLE
libntirpc: add free_sperror() helper for rpc_sperror() results

### DIFF
--- a/ntirpc/rpc/rpc_err.h
+++ b/ntirpc/rpc/rpc_err.h
@@ -74,6 +74,7 @@ struct rpc_err {
 
 extern void rpc_perror(const struct rpc_err *, const char *); /* stderr */
 extern char *rpc_sperror(const struct rpc_err *, const char *); /* string */
+extern void free_sperror(char *); /* free result of rpc_sperror() */
 
 #ifdef __cplusplus
 }

--- a/src/auth_unix.c
+++ b/src/auth_unix.c
@@ -207,7 +207,7 @@ out_err:
 	result->ah_error.re_errno = save_errno;
 	t = rpc_sperror(&result->ah_error, __func__);
 	__warnx(TIRPC_DEBUG_FLAG_AUTH, "%s", t);
-	mem_free(t, 0);
+	free_sperror(t);
 	return result;
 }
 

--- a/src/clnt_perror.c
+++ b/src/clnt_perror.c
@@ -172,6 +172,18 @@ rpc_sperror(const struct rpc_err *e, const char *s)
 	return (strstart);
 }
 
+/*
+ * Free a string returned by rpc_sperror(). Callers must not free() it
+ * directly or pass any other size to mem_free() - RPC_SPERROR_BUFLEN is
+ * an internal implementation detail of rpc_sperror().
+ */
+void
+free_sperror(char *err)
+{
+	if (err != NULL)
+		mem_free(err, RPC_SPERROR_BUFLEN);
+}
+
 void
 rpc_perror(const struct rpc_err *e, const char *s)
 {
@@ -182,7 +194,7 @@ rpc_perror(const struct rpc_err *e, const char *s)
 
 	t = rpc_sperror(e, s);
 	(void)fprintf(stderr, "%s\n", t);
-	mem_free(t, RPC_SPERROR_BUFLEN);
+	free_sperror(t);
 }
 
 static const char *const rpc_errlist[] = {

--- a/src/libntirpc.map.in.cmake
+++ b/src/libntirpc.map.in.cmake
@@ -81,6 +81,7 @@ NTIRPC_${NTIRPC_VERSION_BASE} {
     endrpcent;
 
     # f*
+    free_sperror;
     freenetconfigent;
 
     # g*

--- a/src/rpc_generic.c
+++ b/src/rpc_generic.c
@@ -589,7 +589,7 @@ rpc_nullproc(CLIENT *clnt)
 		char *t = rpc_sperror(&cc->cc_error, __func__);
 
 		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s", t);
-		mem_free(t, RPC_SPERROR_BUFLEN);
+		free_sperror(t);
 		clnt_req_release(cc);
 		return (NULL);
 	}

--- a/src/rpcb_clnt.c
+++ b/src/rpcb_clnt.c
@@ -296,7 +296,7 @@ static CLIENT *getclnthandle(const char *host, const struct netconfig *nconf,
 
 		t = rpc_sperror(&client->cl_error, __func__);
 		__warnx(TIRPC_DEBUG_FLAG_CLNT_RPCB, "%s", t);
-		mem_free(t, RPC_SPERROR_BUFLEN);
+		free_sperror(t);
 
 		addr_to_delete.len = addr->len;
 		addr_to_delete.buf = (char *)mem_zalloc(addr->len);
@@ -413,7 +413,7 @@ static CLIENT *getclnthandle(const char *host, const struct netconfig *nconf,
 
 		t = rpc_sperror(&client->cl_error, __func__);
 		__warnx(TIRPC_DEBUG_FLAG_CLNT_RPCB, "%s", t);
-		mem_free(t, RPC_SPERROR_BUFLEN);
+		free_sperror(t);
 	}
 	if (res)
 		freeaddrinfo(res);
@@ -489,7 +489,7 @@ rpcb_set(rpcprog_t program, rpcvers_t version, const struct netconfig *nconf,
 		char *t = rpc_sperror(&cc->cc_error, __func__);
 
 		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s", t);
-		mem_free(t, RPC_SPERROR_BUFLEN);
+		free_sperror(t);
 	}
 
 	clnt_req_release(cc);
@@ -546,7 +546,7 @@ rpcb_unset(rpcprog_t program, rpcvers_t version,
 		char *t = rpc_sperror(&cc->cc_error, __func__);
 
 		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s", t);
-		mem_free(t, RPC_SPERROR_BUFLEN);
+		free_sperror(t);
 	}
 
 	clnt_req_release(cc);
@@ -844,7 +844,7 @@ __rpcb_findaddr_timed(rpcprog_t program, rpcvers_t version,
 	t = rpc_sperror(&client->cl_error, __func__);
 
 	__warnx(TIRPC_DEBUG_FLAG_CLNT_RPCB, "%s", t);
-	mem_free(t, RPC_SPERROR_BUFLEN);
+	free_sperror(t);
 
  done:
 	if (ua)
@@ -970,7 +970,7 @@ rpcb_getmaps(const struct netconfig *nconf, const char *host)
  error:
 	t = rpc_sperror(&cc->cc_error, __func__);
 	__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s", t);
-	mem_free(t, RPC_SPERROR_BUFLEN);
+	free_sperror(t);
 
  done:
 	clnt_req_release(cc);
@@ -1159,7 +1159,7 @@ boolrpcb_gettime(const char *host, time_t *timep)
 		char *t = rpc_sperror(&cc->cc_error, __func__);
 
 		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s", t);
-		mem_free(t, RPC_SPERROR_BUFLEN);
+		free_sperror(t);
 	}
 
 	clnt_req_release(cc);
@@ -1209,7 +1209,7 @@ char *rpcb_taddr2uaddr(struct netconfig *nconf, struct netbuf *taddr)
 		char *t = rpc_sperror(&cc->cc_error, __func__);
 
 		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s", t);
-		mem_free(t, RPC_SPERROR_BUFLEN);
+		free_sperror(t);
 	}
 
 	clnt_req_release(cc);
@@ -1259,7 +1259,7 @@ struct netbuf *rpcb_uaddr2taddr(struct netconfig *nconf, char *uaddr)
 		char *t = rpc_sperror(&cc->cc_error, __func__);
 
 		__warnx(TIRPC_DEBUG_FLAG_ERROR, "%s", t);
-		mem_free(t, RPC_SPERROR_BUFLEN);
+		free_sperror(t);
 		mem_free(taddr, sizeof(*taddr));
 		taddr = NULL;
 	}
@@ -1322,7 +1322,7 @@ static CLIENT *local_rpcb(const char *tag)
 	t = rpc_sperror(&client->cl_error, tag);
 
 	__warnx(TIRPC_DEBUG_FLAG_CLNT_RPCB, "%s", t);
-	mem_free(t, RPC_SPERROR_BUFLEN);
+	free_sperror(t);
 
 	/* Save client for error return */
 


### PR DESCRIPTION
Add free_sperror() as the supported way to release strings returned by rpc_sperror(), export it from libntirpc, and update libntirpc and Ganesha call sites to use it instead of mem_free(..., RPC_SPERROR_BUFLEN) or gsh_free(..., MEM_COMP_LIBNTIRPC).