### PR TITLE
libntirpc: forward caller site through mem_free and clnt_req_release

### DIFF
--- a/ntirpc/rpc/clnt.h
+++ b/ntirpc/rpc/clnt.h
@@ -81,7 +81,8 @@
 				 ((s) == RPC_CANTDECODEARGS))
 
 struct clnt_req;
-typedef void (*clnt_req_freer)(struct clnt_req *, size_t);
+typedef void (*clnt_req_freer)(struct clnt_req *, size_t,  const char *, int,
+			       const char *);
 
 /*
  * Client rpc handle.

--- a/ntirpc/rpc/types.h
+++ b/ntirpc/rpc/types.h
@@ -167,7 +167,8 @@ typedef void *(*mem_2_size_t) (size_t, size_t,
 	     const char *file, int line, const char *function);
 typedef void *(*mem_p_size_t) (void *, size_t,
 	     const char *file, int line, const char *function);
-typedef void (*mem_free_size_t) (void *, size_t);
+typedef void (*mem_free_size_t) (void *, size_t,
+	     const char *file, int line, const char *function);
 typedef void (*mem_format_t) (const char *fmt, ...);
 typedef void (*mem_char_t) (const char *);
 
@@ -210,11 +211,8 @@ extern tirpc_pkg_params __ntirpc_pkg_params;
 #define mem_zalloc(size) __ntirpc_pkg_params.calloc_(1, (size), \
 			__FILE__, __LINE__, __func__)
 
-static inline void
-mem_free(void *p, size_t n)
-{
-	__ntirpc_pkg_params.free_size_(p, n);
-}
+#define mem_free(p, n) __ntirpc_pkg_params.free_size_((p), (n), \
+			__FILE__, __LINE__, __func__)
 
 /*
  * Uses allocator with indirections, if any.

--- a/src/clnt_generic.c
+++ b/src/clnt_generic.c
@@ -784,7 +784,7 @@ clnt_req_release(struct clnt_req *cc)
 	clnt_req_fini(cc);
 	CLNT_RELEASE(cc->cc_clnt, CLNT_RELEASE_FLAG_NONE);
 
-	(*cc->cc_free_cb)(cc, cc->cc_size);
+	(*cc->cc_free_cb)(cc, cc->cc_size, __FILE__, __LINE__, __func__);
 	return (refs);
 }
 

--- a/src/rpc_generic.c
+++ b/src/rpc_generic.c
@@ -78,7 +78,8 @@ tirpc_thread_name(const char *p)
 }
 
 static void
-tirpc_free(void *p, size_t unused)
+tirpc_free(void *p, size_t unused, const char *file, int line,
+	   const char *function)
 {
 	free(p);
 }


### PR DESCRIPTION
Extend mem_free_size_t and clnt_req_freer with file, line, and function arguments so memory statistics and mem_comp audit can attribute frees to the real libntirpc call site instead of types.h.

Replace the inline mem_free() with a macro that passes __FILE__, __LINE__, and __func__ into the Ganesha hook.  Have clnt_req_release() pass its own caller context into cc_free_cb, and update tirpc_free() to match the new signature.