### PR TITLE
NFS Ganesha Crash - pthread_mutex_lock on NULL in svc_rqst_expire_insert()

### DIFF
--- a/src/clnt_generic.c
+++ b/src/clnt_generic.c
@@ -502,7 +502,13 @@ clnt_req_callback(struct clnt_req *cc)
 	if (cc->cc_clnt->rdma_clnt) {
 		rdma_clnt_req_expire_insert(cc);
 	} else {
-		svc_rqst_expire_insert(cc);
+		struct cx_data *cx = CX_DATA(cc->cc_clnt);
+
+		/* Shared-session VC clients have ev_p; standalone callback
+		 * sockets (v4.0) do not and use CLNT_CALL_WAIT instead.
+		 */
+		if (cx->cx_rec->ev_p)
+			svc_rqst_expire_insert(cc);
 	}
 
 	return CLNT_CALL_ONCE(cc);


### PR DESCRIPTION
Ganesha Ref PR -  https://review.gerrithub.io/c/ffilz/nfs-ganesha/+/1244768

  PROBLEM                                                 | FIX
1 Inline grant from LOCKU worker             | `state_block_schedule()` in `grant_blocked_locks()`
2 `CLNT_CALL_BACK` without `ev_p`     | v4.0: `CLNT_CALL_WAIT`; libntirpc: guard `ev_p`
3 `CLNT_CALL_WAIT` / destroy on v4.1 shared xprt  |  v4.1: keep `CLNT_CALL_BACK`; don't destroy shared client on failure
4 Retry storm when channel down       | Skip v4.0 grant when `cb_chan_down`; downgrade noisy CRIT logs