### PR TITLE
libntirpcmonitoring: restrict exports with a version script

### DIFF
--- a/src/monitoring/CMakeLists.txt
+++ b/src/monitoring/CMakeLists.txt
@@ -6,9 +6,15 @@ SET(ntirpcmonitoring_SRCS
   monitoring.cc
 )
 
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/libntirpcmonitoring.map.in.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/libntirpcmonitoring.map"
+)
+
 add_library(ntirpcmonitoring SHARED ${ntirpcmonitoring_SRCS})
 add_sanitizers(ntirpcmonitoring)
 set_target_properties(ntirpcmonitoring PROPERTIES
+  LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/libntirpcmonitoring.map"
   VERSION ${NTIRPC_VERSION}
   SOVERSION "${NTIRPC_MAJOR_VERSION}${NTIRPC_MINOR_VERSION}"
   )

--- a/src/monitoring/libntirpcmonitoring.map.in.cmake
+++ b/src/monitoring/libntirpcmonitoring.map.in.cmake
@@ -1,0 +1,18 @@
+NTIRPC_MONITORING_${NTIRPC_VERSION_BASE} {
+  global:
+    # monitoring__*
+    monitoring__register_counter;
+    monitoring__register_gauge;
+    monitoring__register_histogram;
+    monitoring__counter_inc;
+    monitoring__gauge_inc;
+    monitoring__gauge_dec;
+    monitoring__gauge_set;
+    monitoring__histogram_observe;
+    monitoring__buckets_exp2;
+    monitoring__buckets_exp2_compact;
+    monitoring__get_registry_handle;
+
+  local:
+    *;
+};


### PR DESCRIPTION
This avoids leaking prometheus-cpp-lite symbols into the shared library.

---

I noticed build failures in Ubuntu due to missing symbols when compared to Debian (since LTO is not enabled there). [Example build failure](https://launchpadlibrarian.net/868463784/buildlog_ubuntu-stonking-amd64.ntirpc_7.2-2_BUILDING.txt.gz).

This patch fixes this issue by exporting only the `monitoring__` functions, avoiding prometheus-cpp-lite symbols.

I'm not 100% sure that this is correct, but it seems like it is. Sorry for the noise if this is completely wrong, I feel a bit out of depth here.