### PR TITLE
Fix NULL ev_p Crash During Blocked Lock Grant

### DIFF
--- a/src/clnt_generic.c
+++ b/src/clnt_generic.c
@@ -502,7 +502,16 @@ clnt_req_callback(struct clnt_req *cc)
 	if (cc->cc_clnt->rdma_clnt) {
 		rdma_clnt_req_expire_insert(cc);
 	} else {
-		svc_rqst_expire_insert(cc);
+		if (!svc_rqst_expire_insert(cc)) {
+			/* Transport's event channel is gone (ev_p NULL):
+			 * the xprt was destroyed before we could register
+			 * the call timeout.  Report the connection as lost
+			 * so the caller can clean up the blocked lock entry
+			 * and try the next waiter.
+			 */
+			cc->cc_error.re_status = RPC_TIMEDOUT;
+			return RPC_TIMEDOUT;
+		}
 	}
 
 	return CLNT_CALL_ONCE(cc);

--- a/src/clnt_internal.h
+++ b/src/clnt_internal.h
@@ -62,8 +62,8 @@ clnt_data_destroy(struct cx_data *cx)
 }
 
 /* in svc_rqst.c */
-void svc_rqst_expire_insert(struct clnt_req *);
-void svc_rqst_expire_remove(struct clnt_req *);
+bool svc_rqst_expire_insert(struct clnt_req *);
+bool svc_rqst_expire_remove(struct clnt_req *);
 void svc_rqst_expire_task(struct work_pool_entry *);
 int svc_rqst_expire_cmpf(const struct opr_rbtree_node *lhs,
 			 const struct opr_rbtree_node *rhs);

--- a/src/svc_rqst.c
+++ b/src/svc_rqst.c
@@ -330,12 +330,20 @@ svc_rqst_expire_ms(struct timespec *to)
 	return timespec_ms(&ts);
 }
 
-void
+bool
 svc_rqst_expire_insert(struct clnt_req *cc)
 {
 	struct cx_data *cx = CX_DATA(cc->cc_clnt);
 	struct svc_rqst_rec *sr_rec = cx->cx_rec->ev_p;
 	struct opr_rbtree_node *nv;
+
+	if (!sr_rec) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			"%s: xprt fd %d has no event channel (ev_p NULL),"
+			" transport already destroyed",
+			__func__, cx->cx_rec->xprt.xp_fd);
+		return false;
+	}
 
 	cc->cc_expire_ms = svc_rqst_expire_ms(&cc->cc_timeout);
 
@@ -355,13 +363,22 @@ svc_rqst_expire_insert(struct clnt_req *cc)
 		__func__, sr_rec->sv[0],
 		sr_rec);
 	ev_sig(sr_rec->sv[0], 0);	/* send wakeup */
+	return true;
 }
 
-void
+bool
 svc_rqst_expire_remove(struct clnt_req *cc)
 {
 	struct cx_data *cx = CX_DATA(cc->cc_clnt);
 	struct svc_rqst_rec *sr_rec = cx->cx_rec->ev_p;
+
+	if (!sr_rec) {
+		__warnx(TIRPC_DEBUG_FLAG_ERROR,
+			"%s: xprt fd %d has no event channel (ev_p NULL),"
+			" transport already destroyed",
+			__func__, cx->cx_rec->xprt.xp_fd);
+		return false;
+	}
 
 	mutex_lock(&sr_rec->ev_lock);
 	opr_rbtree_remove(&sr_rec->call_expires, &cc->cc_rqst);
@@ -372,6 +389,7 @@ svc_rqst_expire_remove(struct clnt_req *cc)
 		__func__, sr_rec->sv[0],
 		sr_rec);
 	ev_sig(sr_rec->sv[0], 0);	/* send wakeup */
+	return true;
 }
 
 void


### PR DESCRIPTION
Bug: Ganesha crashes with a NULL dereference in `svc_rqst_expire_insert` when granting a blocked NFSv4 lock to a client that disconnected before the grant was attempted.

Depend On Ganesha PR :
https://review.gerrithub.io/c/ffilz/nfs-ganesha/+/1245847?tab=comments

Guards the narrow race window not covered by Ganesha (transport torn down concurrently with an in-flight RPC).

Added a NULL check for 'ev_p' in both function
svc_rqst_expire_insert() & svc_rqst_expire_remove().