### PR TITLE
libntirpc: honor start and datalen in xdrmem_fillbufs

### DIFF
--- a/src/xdr_mem.c
+++ b/src/xdr_mem.c
@@ -283,7 +283,12 @@ xdrmem_fillbufs(XDR *xdrs, u_int start, xdr_vio *vector, u_int datalen)
 	vector[0] = xdrs->x_v;
 	vector[0].vio_type = VIO_DATA;
 
-	vector[0].vio_length = vector[0].vio_tail - vector[0].vio_head;
+	/* Return the requested range, relative to vio_head, as xdr_ioq does. */
+	if (xdrs->x_v.vio_head != NULL) {
+		vector[0].vio_head = xdrs->x_v.vio_head + start;
+		vector[0].vio_tail = vector[0].vio_head + datalen;
+	}
+	vector[0].vio_length = datalen;
 	return true;
 }
 

--- a/src/xdr_mem.c
+++ b/src/xdr_mem.c
@@ -231,10 +231,36 @@ xdrmem_noop(void)
 	return (false);
 }
 
+/*
+ * Does [start, start + datalen) lie within the used part of the buffer?
+ *
+ * Compared using lengths rather than by forming vio_head + start + datalen:
+ * that pointer may be outside the object, which is undefined, and where
+ * pointers are 32 bits it can wrap far enough to satisfy a naive comparison.
+ * datalen routinely arrives straight off the wire, so the check has to hold
+ * for hostile values.
+ */
+static inline bool
+xdrmem_range_valid(XDR *xdrs, u_int start, u_int datalen)
+{
+	size_t used;
+
+	if (xdrs->x_v.vio_head == NULL || xdrs->x_v.vio_tail == NULL) {
+		/* xdrmem_ncreate() accepts a NULL buffer; only an empty
+		 * range can be served from one.
+		 */
+		return start == 0 && datalen == 0;
+	}
+
+	used = (size_t)(xdrs->x_v.vio_tail - xdrs->x_v.vio_head);
+
+	return start <= used && datalen <= used - start;
+}
+
 static int
 xdrmem_iovcount(XDR *xdrs, u_int start, u_int datalen)
 {
-	if ((xdrs->x_v.vio_head + start + datalen) > xdrs->x_v.vio_tail) {
+	if (!xdrmem_range_valid(xdrs, start, datalen)) {
 		/* start and datalen reference outside the size of the data
 		 * in the buffer.
 		 */
@@ -247,7 +273,7 @@ xdrmem_iovcount(XDR *xdrs, u_int start, u_int datalen)
 static bool
 xdrmem_fillbufs(XDR *xdrs, u_int start, xdr_vio *vector, u_int datalen)
 {
-	if ((xdrs->x_v.vio_head + start + datalen) > xdrs->x_v.vio_tail) {
+	if (!xdrmem_range_valid(xdrs, start, datalen)) {
 		/* start and datalen reference outside the size of the data
 		 * in the buffer.
 		 */
@@ -256,6 +282,7 @@ xdrmem_fillbufs(XDR *xdrs, u_int start, xdr_vio *vector, u_int datalen)
 
 	vector[0] = xdrs->x_v;
 	vector[0].vio_type = VIO_DATA;
+
 	vector[0].vio_length = vector[0].vio_tail - vector[0].vio_head;
 	return true;
 }


### PR DESCRIPTION
`xdrmem_fillbufs()` range-checks `start` and `datalen` and then ignores both. It copies `xdrs->x_v` verbatim into `vector[0]` and sets `vio_length` to the whole used region, so a caller always receives everything from `vio_head` onwards no matter which range it asked for.

Callers use `vio_head` as the data pointer and `vio_length` as the length, so any request for a payload at a non-zero offset silently receives the wrong bytes.

### Why this is the wrong behaviour, independent of any caller

`xdr_ioq_fillbufs()` (src/xdr_ioq.c) is the only other implementation of this operation, and it is used by both the plain IOQ and RDMA stream types. It advances `vio_head` by `start` and truncates `vio_tail`/`vio_length` to `datalen`. xdrmem was simply not honouring the same contract. This patch makes the two agree.

All six in-tree callers (`svc_ioq.c:195`, `authgss_prot.c:366,794,828,944`, and nfs-ganesha's `xdr_io_data_decode()`) consume `vio_head`/`vio_length` as a requested slice, so none depended on the old whole-buffer behaviour.

### Observed symptom

nfs-ganesha's FSAL_PROXY_V3 decodes replies from an xdrmem stream. Decoding a `READ3res` left the iovec in `xdr_io_data_decode()` pointing at the start of the RPC reply, so the FSAL copied the RPC and NFS reply headers followed by the beginning of the payload, truncated to the requested count — reads returned the correct length and the wrong contents.

### The first commit

`xdrmem_iovcount()` and `xdrmem_fillbufs()` both validated the caller's range with

```c
xdrs->x_v.vio_head + start + datalen > xdrs->x_v.vio_tail
```

Forming that address is undefined exactly when the range is out of bounds, which is the case the test exists to catch. Where pointers are 32 bits it can also wrap — `start = 4` with `datalen = UINT_MAX` lands three bytes below `vio_head` and passes.

That predicate predates this series, but the second commit makes a bypass materially worse: it assigns `datalen` straight into `vio_length`, where previously `vio_length` was derived from the buffer and therefore bounded regardless. `datalen` routinely arrives as an XDR length off the wire. So the check is corrected first, by comparing lengths rather than addresses in a helper shared by both functions, including the NULL buffer that `xdrmem_ncreate()` accepts.

### Testing

Built and exercised through nfs-ganesha V15.2 with FSAL_PROXY_V3 against a NetApp ONTAP NFSv3 export, compared against a direct kernel NFSv3 mount of the same export:

- directory listings identical (143/143 files, and 533/533 over the full tree)
- full-tree content identical — 196 MB, matching md5
- six large files of 343 KB to 16.8 MB byte-identical; the largest spans several hundred `READ3` calls at increasing offsets, which is what actually exercises `start`
- no XDR decode errors, no crashes

### Note

I could not find a unit-test harness covering the XDR stream backends, so this series adds no test. Coverage worth having, if you can point me at where it would belong: non-zero `start`, partial length, exact-end, zero length, a rejected overflowing range, and `vio_base`/`vio_wrap` left unmodified.
